### PR TITLE
CI vm_replication integration test uses a single remote cluster

### DIFF
--- a/tests/integration/targets/vm_replication/tasks/main.yml
+++ b/tests/integration/targets/vm_replication/tasks/main.yml
@@ -52,12 +52,13 @@
           - cluster_connection_info is succeeded
           # To test switching replication to a different cluster,
           # at least two remote clusters are needed.
-          - cluster_connection_info.record | length > 1
+          # At the moment, we do not test reconfiguring replication to a second cluster.
+          - cluster_connection_info.record | length > 0
 
     - name: Store remote cluster name (TEMP connection UUID)
       ansible.builtin.set_fact:
         remote_cluster_0_name: "{{ cluster_connection_info.record.0.remoteClusterInfo.clusterName}}"
-        remote_cluster_1_name: "{{ cluster_connection_info.record.1.remoteClusterInfo.clusterName }}"
+        # remote_cluster_1_name: "{{ cluster_connection_info.record.1.remoteClusterInfo.clusterName }}"
 
 # ----------------------------------Job-------------------------------------------------------------------------------------
     - name: Create replication


### PR DESCRIPTION
The second one was not really used, no need for it to be confiugred on test cluster.

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>