### PR TITLE
Fix changing boot devices order for HyperCore v9.2

### DIFF
--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -601,7 +601,7 @@ class VM(PayloadMapper):
         vm.do_shutdown_steps(module, rest_client)
         task_tag = rest_client.update_record(
             "{0}/{1}".format("/rest/v1/VirDomain", vm.uuid),
-            dict(bootDevices=boot_order, uuid=vm.uuid),
+            dict(bootDevices=boot_order),
             module.check_mode,
         )
         TaskTag.wait_task(rest_client, task_tag)

--- a/tests/unit/plugins/module_utils/test_vm.py
+++ b/tests/unit/plugins/module_utils/test_vm.py
@@ -808,7 +808,6 @@ class TestVM:
             "/rest/v1/VirDomain/7542f2gg-5f9a-51ff-8a91-8ceahgf47ghg",
             dict(
                 bootDevices=["device1-id", "device2-id"],
-                uuid="7542f2gg-5f9a-51ff-8a91-8ceahgf47ghg",
             ),
             False,
         )


### PR DESCRIPTION
The VM uuid is already in PATCH URL path, it is not needed in PATCH data/payload.
v9.1 did not complain, v9.2 does complain.

Fix by @ddemlow

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>