### PR TITLE
Replace '=' with '__' (double underscore) in tags recognized by inventory plugin

### DIFF
--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -16,7 +16,7 @@ description:
   - Builds an inventory containing VMs on Scale Computing HyperCore.
   - Inventory uses tags to group VMs and to add variables to inventory.
   - VM can be added to multiple groups.
-  - Available tags - ansible_group__, ansible_user__, ansible_port__, ansible_ssh_private_key_file__.
+  - Available tags - ansible_host__, ansible_group__, ansible_user__, ansible_port__, ansible_ssh_private_key_file__.
   - Does not support caching.
 version_added: 0.0.1
 seealso: []

--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -16,7 +16,7 @@ description:
   - Builds an inventory containing VMs on Scale Computing HyperCore.
   - Inventory uses tags to group VMs and to add variables to inventory.
   - VM can be added to multiple groups.
-  - Available tags - ansible_group=, ansible_user=, ansible_port=, ansible_ssh_private_key_file=.
+  - Available tags - ansible_group__, ansible_user__, ansible_port__, ansible_ssh_private_key_file__.
   - Does not support caching.
 version_added: 0.0.1
 seealso: []
@@ -260,17 +260,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     include = False
             for tag in tags:
                 if (
-                    tag.startswith("ansible_group=")
-                    and tag[len("ansible_group=") :] not in groups
+                    tag.startswith("ansible_group__")
+                    and tag[len("ansible_group__") :] not in groups
                 ):
-                    groups.append(tag[len("ansible_group=") :])
-                elif tag.startswith("ansible_user="):
-                    ansible_user = tag[len("ansible_user=") :]
-                elif tag.startswith("ansible_port="):
-                    ansible_port = int(tag[len("ansible_port=") :])
+                    groups.append(tag[len("ansible_group__") :])
+                elif tag.startswith("ansible_user__"):
+                    ansible_user = tag[len("ansible_user__") :]
+                elif tag.startswith("ansible_port__"):
+                    ansible_port = int(tag[len("ansible_port__") :])
                 elif tag.startswith("ansible_ssh_private_key_file"):
                     ansible_ssh_private_key_file = tag[
-                        len("ansible_ssh_private_key_file=") :
+                        len("ansible_ssh_private_key_file__") :
                     ]
             if include:
                 # Group

--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -286,8 +286,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         ansible_host = nic["ipv4Addresses"][0]
                         break
                 for tag in tags:
-                    if tag.startswith("ansible_host="):
-                        ansible_host = tag[len("ansible_host=") :]
+                    if tag.startswith("ansible_host__"):
+                        ansible_host = tag[len("ansible_host__") :]
                 # User
                 inventory = self.add_user(inventory, ansible_user, vm["name"])
                 # Port

--- a/tests/integration/targets/inventory/prepare.yml
+++ b/tests/integration/targets/inventory/prepare.yml
@@ -22,19 +22,19 @@
 #            vlan: 0
 #            connected: true
       - name: ci-inventory-vm1
-        tags: Xlab,ci-inventory,ansible_disable,ansible_host=10.0.0.1,ansible_user__first,ansible_port__33
+        tags: Xlab,ci-inventory,ansible_disable,ansible_host__10.0.0.1,ansible_user__first,ansible_port__33
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm2
-        tags: Xlab,ci-inventory,ansible_disable,ansible_enable,ansible_host=10.0.0.2
+        tags: Xlab,ci-inventory,ansible_disable,ansible_enable,ansible_host__10.0.0.2
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm3
-        tags: Xlab,ci-inventory,ansible_enable,ansible_host=10.0.0.3,ansible_ssh_private_key_file__that_file.txt
+        tags: Xlab,ci-inventory,ansible_enable,ansible_host__10.0.0.3,ansible_ssh_private_key_file__that_file.txt
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm4
-        tags: Xlab,ci-inventory,ansible_enable,ansible_group__grp0,ansible_host=10.0.0.4
+        tags: Xlab,ci-inventory,ansible_enable,ansible_group__grp0,ansible_host__10.0.0.4
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm5

--- a/tests/integration/targets/inventory/prepare.yml
+++ b/tests/integration/targets/inventory/prepare.yml
@@ -22,7 +22,7 @@
 #            vlan: 0
 #            connected: true
       - name: ci-inventory-vm1
-        tags: Xlab,ci-inventory,ansible_disable,ansible_host=10.0.0.1,ansible_user=first,ansible_port=33
+        tags: Xlab,ci-inventory,ansible_disable,ansible_host=10.0.0.1,ansible_user__first,ansible_port__33
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm2
@@ -30,19 +30,19 @@
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm3
-        tags: Xlab,ci-inventory,ansible_enable,ansible_host=10.0.0.3,ansible_ssh_private_key_file=that_file.txt
+        tags: Xlab,ci-inventory,ansible_enable,ansible_host=10.0.0.3,ansible_ssh_private_key_file__that_file.txt
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm4
-        tags: Xlab,ci-inventory,ansible_enable,ansible_group=grp0,ansible_host=10.0.0.4
+        tags: Xlab,ci-inventory,ansible_enable,ansible_group__grp0,ansible_host=10.0.0.4
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm5
-        tags: Xlab,ci-inventory,ansible_enable,ansible_group=grp1,ansible_ssh_private_key_file=this_file.txt
+        tags: Xlab,ci-inventory,ansible_enable,ansible_group__grp1,ansible_ssh_private_key_file__this_file.txt
         mem: 512100100
         numVCPU: 1
       - name: ci-inventory-vm6
-        tags: Xlab,ci-inventory,ansible_enable,ansible_group=grp0,ansible_group=grp1,ansible_user=second
+        tags: Xlab,ci-inventory,ansible_enable,ansible_group__grp0,ansible_group__grp1,ansible_user__second
         mem: 512100100
         numVCPU: 1
 


### PR DESCRIPTION
The HyperCore web UI does not allow tag with '=', so we must not use it.