### PR TITLE
Add example playbooks for vm_info and vm_replication_info modules

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,9 +15,9 @@ The examples are run from localhost (`ansible-playbook -i localhost,` part),
 and playbooks contain `connection: local`.
 This allows to use environ variables from local shell environment.
 
-If ansible will execute an example via SSH connection (e.g. without `connection: local`),
-then you need to add to examples environment section with `SC_HOST` and other environment variables.
-In [iso_info.yml](iso_info.yml) is this included as an example.
+If ansible executes an example via SSH connection (e.g. without `connection: local`),
+then you need to add to example environment section with `SC_HOST` and other environment variables.
+For example please see file [iso_info.yml](iso_info.yml).
 
 ## Modules iso, iso_info
 
@@ -30,6 +30,20 @@ ansible-playbook -i localhost, examples/iso.yml
 
 # Remove old TinyCore-current.iso if present, to force re-upload
 ansible-playbook -i localhost, -e iso_remove_old_image=True examples/iso.yml
+```
+
+## Module vm__info
+
+```shell
+# Show info about specific VM
+ansible-playbook -i localhost, -e vm_name=demo-vm examples/vm_info.yml
+```
+
+## Module vm_replication_info
+
+```shell
+# Show info about specific VM replication settings
+ansible-playbook -i localhost, -e vm_name=demo-vm examples/vm_replication_info.yml
 ```
 
 ## Module api

--- a/examples/vm_info.yml
+++ b/examples/vm_info.yml
@@ -1,0 +1,16 @@
+- name: Show replication settings for a specific VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: demo-vm
+
+  tasks:
+  - name: Get info about VM {{ vm_name }}
+    scale_computing.hypercore.vm_info:
+      vm_name: "{{ vm_name }}"
+    register: vm_info_result
+
+  - name: Show the info about {{ vm_name }} VM
+    debug:
+      var: vm_info_result

--- a/examples/vm_info.yml
+++ b/examples/vm_info.yml
@@ -6,11 +6,11 @@
     vm_name: demo-vm
 
   tasks:
-  - name: Get info about VM {{ vm_name }}
-    scale_computing.hypercore.vm_info:
-      vm_name: "{{ vm_name }}"
-    register: vm_info_result
+    - name: Get info about VM {{ vm_name }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name }}"
+      register: vm_info_result
 
-  - name: Show the info about {{ vm_name }} VM
-    debug:
-      var: vm_info_result
+    - name: Show the info about {{ vm_name }} VM
+      debug:
+        var: vm_info_result

--- a/examples/vm_replication_info.yml
+++ b/examples/vm_replication_info.yml
@@ -6,11 +6,11 @@
     vm_name: demo-vm
 
   tasks:
-  - name: Get replication info for VM {{ vm_name }}
-    scale_computing.hypercore.vm_replication_info:
-      vm_name: "{{ vm_name }}"
-    register: replication_info_result
+    - name: Get replication info for VM {{ vm_name }}
+      scale_computing.hypercore.vm_replication_info:
+        vm_name: "{{ vm_name }}"
+      register: replication_info_result
 
-  - name: Show the replication info status of {{ vm_name }} VM
-    debug:
-      var: replication_info_result
+    - name: Show the replication info status of {{ vm_name }} VM
+      debug:
+        var: replication_info_result

--- a/examples/vm_replication_info.yml
+++ b/examples/vm_replication_info.yml
@@ -1,0 +1,16 @@
+- name: Show replication settings for a specific VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: demo-vm
+
+  tasks:
+  - name: Get replication info for VM {{ vm_name }}
+    scale_computing.hypercore.vm_replication_info:
+      vm_name: "{{ vm_name }}"
+    register: replication_info_result
+
+  - name: Show the replication info status of {{ vm_name }} VM
+    debug:
+      var: replication_info_result


### PR DESCRIPTION
Nothing special in those two playbooks, they are just ready-to-run example playbooks.

@ddemlow Are such examples something that you would find useful when you craft your own playbooks? The `examples/` were added with intention that endusers could run then immediately (ok, after installing ansible and `export SC_HOST=...`.