### PR TITLE
ansible-lint should not check github workflows

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,3 +5,4 @@ exclude_paths:
   - sample_*.yml
   - tests
   - examples/cloud-init-user-data-example.yml
+  - .github/workflows


### PR DESCRIPTION
The "on:" keyword contains a list of triggers, but ansible-lint thinks it is boolean and want it to be true/false.

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>