### PR TITLE
Fix vm_replication_info for unreplicated vm

### DIFF
--- a/plugins/modules/vm_replication_info.py
+++ b/plugins/modules/vm_replication_info.py
@@ -73,11 +73,14 @@ def run(module, rest_client):
         virtual_machine_obj_list = VM.get_or_fail(
             query={"name": module.params["vm_name"]}, rest_client=rest_client
         )
-        replication = Replication.get(
+        replication_list = Replication.get(
             query={"sourceDomainUUID": virtual_machine_obj_list[0].uuid},
             rest_client=rest_client,
-        )[0]
-        records = [replication.to_ansible()]
+        )
+        if not replication_list:
+            # No replication found for specified VM
+            return False, []
+        records = [replication_list[0].to_ansible()]
     return False, records
 
 

--- a/tests/integration/targets/vm_replication_info/tasks/main.yml
+++ b/tests/integration/targets/vm_replication_info/tasks/main.yml
@@ -87,7 +87,22 @@
         that:
           - cluster_connection_info is succeeded
           - cluster_connection_info.record | length > 0
-  
+
+# -------------------------------------------------------------------------
+# Test vm_replication_info for VM without replication
+    - name: Get replication info for one VM
+      scale_computing.hypercore.vm_replication_info:
+        vm_name: XLAB-vm_replication_info_CI_test
+      register: replication_info
+    - ansible.builtin.assert:
+        that:
+          - replication_info is succeeded
+          - replication_info is not changed
+          - replication_info.records | length == 1
+          - replication_info.records[0].vm_name == 'XLAB-vm_replication_info_CI_test'
+          - replication_info.records[0].state == 'enabled'
+          - replication_info.records[0].remote_cluster == "{{ cluster_connection_info.record.0.remoteClusterInfo.clusterName }}"
+
 # -------------------------------------------------------------------------
     - name: Create replication
       scale_computing.hypercore.api:
@@ -158,18 +173,3 @@
           - replication_info_all.records[1].state in ['enabled', 'disabled']
           - replication_info_all.records[1].remote_cluster
 
-    - name: Delete XLAB-vm_replication_info_CI_test
-      scale_computing.hypercore.vm: *delete-XLAB-vm_nic_CI_test
-      register: output
-    - ansible.builtin.assert:
-        that:
-          - output is succeeded
-          - output is changed
-
-    - name: Delete XLAB-vm2_replication_info_CI_test
-      scale_computing.hypercore.vm: *delete-XLAB-vm2_nic_CI_test
-      register: output
-    - ansible.builtin.assert:
-        that:
-          - output is succeeded
-          - output is changed

--- a/tests/integration/targets/vm_replication_info/tasks/main.yml
+++ b/tests/integration/targets/vm_replication_info/tasks/main.yml
@@ -184,3 +184,18 @@
           - replication_info_all.records[1].state in ['enabled', 'disabled']
           - replication_info_all.records[1].remote_cluster
 
+    - name: Delete XLAB-vm_replication_info_CI_test
+      scale_computing.hypercore.vm: *delete-XLAB-vm_nic_CI_test
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is succeeded
+          - output is changed
+
+    - name: Delete XLAB-vm2_replication_info_CI_test
+      scale_computing.hypercore.vm: *delete-XLAB-vm2_nic_CI_test
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is succeeded
+          - output is changed

--- a/tests/integration/targets/vm_replication_info/tasks/main.yml
+++ b/tests/integration/targets/vm_replication_info/tasks/main.yml
@@ -6,6 +6,18 @@
 
   block:
 # -------------------------------------------------------------------------
+# Test vm_replication_info for not present VM
+    - name: Get replication info for one VM
+      scale_computing.hypercore.vm_replication_info:
+        vm_name: XLAB-vm_replication_info_CI_test-bf238ai6d2
+      register: replication_info
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - replication_info is failed
+          - replication_info is not changed
+
+# -------------------------------------------------------------------------
 # Create 1st VM
     - name: Delete XLAB-vm_replication_info_CI_test
       scale_computing.hypercore.vm: &delete-XLAB-vm_nic_CI_test
@@ -90,6 +102,8 @@
 
 # -------------------------------------------------------------------------
 # Test vm_replication_info for VM without replication
+# Module fails if VM with given name is not present,
+# and does not fail if only replication is not configured.
     - name: Get replication info for one VM
       scale_computing.hypercore.vm_replication_info:
         vm_name: XLAB-vm_replication_info_CI_test
@@ -98,10 +112,7 @@
         that:
           - replication_info is succeeded
           - replication_info is not changed
-          - replication_info.records | length == 1
-          - replication_info.records[0].vm_name == 'XLAB-vm_replication_info_CI_test'
-          - replication_info.records[0].state == 'enabled'
-          - replication_info.records[0].remote_cluster == "{{ cluster_connection_info.record.0.remoteClusterInfo.clusterName }}"
+          - replication_info.records | length == 0
 
 # -------------------------------------------------------------------------
     - name: Create replication


### PR DESCRIPTION
How the module should behave:
- if VM is not present, is should fail - CI test added for this case
- if VM is present, and replication is not configured, the module should:
  - succeed
  - `records` should be an empty list

This way, `records` list does not contain element with `vm_name` equal to VM module is reporting replication info about.
This is consistent with behavior when module is called with ommited `vm_name` param - unreplicated VMs are just not included into the returned `records`. 

Fixes #24 