### PR TITLE
Bugfix: we do not crash if machineType is empty

### DIFF
--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -61,6 +61,7 @@ FROM_ANSIBLE_TO_HYPERCORE_MACHINE_TYPE = {
     "UEFI": "scale-8.10",
     "BIOS": "scale-7.2",
     "vTPM+UEFI": "scale-uefi-tpm-9.2",
+    "": "",
 }
 
 FROM_HYPERCORE_TO_ANSIBLE_MACHINE_TYPE = {


### PR DESCRIPTION
For some instances API returns VirDomain with empty machineType. Ansible should work with instances like that - at least read part should not have any problems.