### PR TITLE
Fix CachedRestClient - filterd data was cached as if it is unfiltered

### DIFF
--- a/plugins/module_utils/rest_client.py
+++ b/plugins/module_utils/rest_client.py
@@ -116,13 +116,13 @@ class CachedRestClient(RestClient):
         self.cache = dict()
 
     def list_records(self, endpoint, query=None, timeout=None):
-        records = self.cache.get(endpoint)
-        if records:
-            return utils.filter_results(records, query)
+        if endpoint in self.cache:
+            records = self.cache[endpoint]
+        else:
+            try:
+                records = self.client.get(path=endpoint, timeout=timeout).json
+            except TimeoutError as e:
+                raise errors.ScaleComputingError(f"Request timed out: {e}")
+            self.cache[endpoint] = records
 
-        try:
-            records = self.client.get(path=endpoint, timeout=timeout).json
-        except TimeoutError as e:
-            raise errors.ScaleComputingError(f"Request timed out: {e}")
-        self.cache[endpoint] = records
         return utils.filter_results(records, query)

--- a/plugins/module_utils/rest_client.py
+++ b/plugins/module_utils/rest_client.py
@@ -120,8 +120,9 @@ class CachedRestClient(RestClient):
         if records:
             return utils.filter_results(records, query)
 
-        records = super().list_records(endpoint, query, timeout)
-        # BUG - here we store filtered result!
-        # Call this twice with different query.
+        try:
+            records = self.client.get(path=endpoint, timeout=timeout).json
+        except TimeoutError as e:
+            raise errors.ScaleComputingError(f"Request timed out: {e}")
         self.cache[endpoint] = records
-        return records
+        return utils.filter_results(records, query)

--- a/plugins/module_utils/rest_client.py
+++ b/plugins/module_utils/rest_client.py
@@ -121,5 +121,7 @@ class CachedRestClient(RestClient):
             return utils.filter_results(records, query)
 
         records = super().list_records(endpoint, query, timeout)
+        # BUG - here we store filtered result!
+        # Call this twice with different query.
         self.cache[endpoint] = records
         return records

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -31,15 +31,14 @@ def mock_list_records():
     pass
 
 class TestCachedRestClient:
-    # @pytest.mark.parametrize(
-    #     "swap_query0_query1",
-    #     [
-    #         (None, {}),
-    #         ([], {}),
-    #         ([("a", "aVal"), ("b", "bVal")], {"a": "aVal", "b": "bVal"}),
-    #     ],
-    # )
-    def test_list_records(self, mocker):
+    @pytest.mark.parametrize(
+        "swap_query_order",
+        [
+            (False),
+            (True),
+        ],
+    )
+    def test_list_records(self, mocker, swap_query_order):
         # records = self.client.get(path=endpoint, timeout=timeout).json
         endpoint = "url1"
         data = '[{"name": "vm0"}, {"name": "vm1"}]'
@@ -50,6 +49,11 @@ class TestCachedRestClient:
         # this query should return only subset
         query1 = {"name": "vm1"}
         expected_data1 = '[{"name": "vm1"}]'
+
+        if swap_query_order:
+            # First will be executed query with filtering
+            query1, query0 = query0, query1
+            expected_data1, expected_data0 = expected_data0, expected_data1
 
         client_obj = client.Client("https://thehost", "user", "pass")
         cached_client = rest_client.CachedRestClient(client=client_obj)

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -7,15 +7,10 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import io
 import json
 import sys
 
 import pytest
-
-from ansible.module_utils.common.text.converters import to_text
-from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
-from ansible.module_utils.six.moves.urllib.parse import urlparse, parse_qs
 
 from ansible_collections.scale_computing.hypercore.plugins.module_utils import (
     client,
@@ -26,9 +21,6 @@ pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"
 )
 
-
-def mock_list_records():
-    pass
 
 class TestCachedRestClient:
     @pytest.mark.parametrize(
@@ -57,7 +49,7 @@ class TestCachedRestClient:
         client_obj = client.Client("https://thehost", "user", "pass")
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
-        client_mock.return_value = client.Response(200, data, '')
+        client_mock.return_value = client.Response(200, data, "")
 
         # on first call, we get something back
         records = cached_client.list_records(endpoint, query0)
@@ -125,7 +117,7 @@ class TestCachedRestClient:
         client_obj = client.Client("https://thehost", "user", "pass")
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
-        client_mock.return_value = client.Response(200, data, '')
+        client_mock.return_value = client.Response(200, data, "")
 
         # first call
         records = cached_client.list_records(endpoint, None)

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -39,7 +39,6 @@ class TestCachedRestClient:
         ],
     )
     def test_list_records(self, mocker, swap_query_order):
-        # records = self.client.get(path=endpoint, timeout=timeout).json
         endpoint = "url1"
         data = '[{"name": "vm0"}, {"name": "vm1"}]'
         #
@@ -79,3 +78,41 @@ class TestCachedRestClient:
         records = cached_client.list_records(endpoint, query1)
         assert records == json.loads(expected_data1)
         assert client_mock.call_count == 1
+
+    def test_list_records_different_endpoint(self, mocker):
+        # Check calling with different endpoint does return different data
+        endpoint0 = "vms"
+        endpoint1 = "disks"
+        data0 = '[{"name": "vm0"}]'
+        data1 = '[{"disk_type": "ide"}]'
+
+        def mockup_client_get(path, timeout):
+            if path == endpoint0:
+                return client.Response(200, data0, "")
+            else:
+                return client.Response(200, data1, "")
+
+        client_obj = client.Client("https://thehost", "user", "pass")
+        cached_client = rest_client.CachedRestClient(client=client_obj)
+        client_mock = mocker.patch.object(cached_client.client, "get")
+        client_mock.side_effect = mockup_client_get
+
+        # on first call, we get something back
+        records = cached_client.list_records(endpoint0, None)
+        assert records == json.loads(data0)
+        assert client_mock.call_count == 1
+
+        # on second call, we get something else back
+        records = cached_client.list_records(endpoint1, None)
+        assert records == json.loads(data1)
+        # and one extra HTTP request was needed
+        assert client_mock.call_count == 2
+
+        # try both endpoints once more
+        records = cached_client.list_records(endpoint0, None)
+        assert records == json.loads(data0)
+        assert client_mock.call_count == 2
+        #
+        records = cached_client.list_records(endpoint1, None)
+        assert records == json.loads(data1)
+        assert client_mock.call_count == 2

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -116,3 +116,23 @@ class TestCachedRestClient:
         records = cached_client.list_records(endpoint1, None)
         assert records == json.loads(data1)
         assert client_mock.call_count == 2
+
+    def test_list_records_empty_response(self, mocker):
+        # API might return "[]" as responses
+        endpoint = "vms"
+        data = "[]"
+
+        client_obj = client.Client("https://thehost", "user", "pass")
+        cached_client = rest_client.CachedRestClient(client=client_obj)
+        client_mock = mocker.patch.object(cached_client.client, "get")
+        client_mock.return_value = client.Response(200, data, '')
+
+        # first call
+        records = cached_client.list_records(endpoint, None)
+        assert records == []
+        assert client_mock.call_count == 1
+
+        # second call - should be cached too
+        records = cached_client.list_records(endpoint, None)
+        assert records == []
+        assert client_mock.call_count == 1

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import io
+import json
+import sys
+
+import pytest
+
+from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+from ansible.module_utils.six.moves.urllib.parse import urlparse, parse_qs
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils import (
+    client,
+    rest_client,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+def mock_list_records():
+    pass
+
+class TestCachedRestClient:
+    # @pytest.mark.parametrize(
+    #     "swap_query0_query1",
+    #     [
+    #         (None, {}),
+    #         ([], {}),
+    #         ([("a", "aVal"), ("b", "bVal")], {"a": "aVal", "b": "bVal"}),
+    #     ],
+    # )
+    def test_list_records(self, mocker):
+        # records = self.client.get(path=endpoint, timeout=timeout).json
+        endpoint = "url1"
+        data = '[{"name": "vm0"}, {"name": "vm1"}]'
+        #
+        # enpty query - we get all data
+        query0 = None
+        expected_data0 = data
+        # this query should return only subset
+        query1 = {"name": "vm1"}
+        expected_data1 = '[{"name": "vm1"}]'
+
+        client_obj = client.Client("https://thehost", "user", "pass")
+        cached_client = rest_client.CachedRestClient(client=client_obj)
+        client_mock = mocker.patch.object(cached_client.client, "get")
+        client_mock.return_value = client.Response(200, data, '')
+
+        # on first call, we get something back
+        records = cached_client.list_records(endpoint, query0)
+        assert records == json.loads(expected_data0)
+        assert client_mock.call_count == 1
+
+        # call_count is still 1
+        records = cached_client.list_records(endpoint, query0)
+        assert records == json.loads(expected_data0)
+        assert client_mock.call_count == 1
+
+        # now filter
+        records = cached_client.list_records(endpoint, query1)
+        assert records == json.loads(expected_data1)
+        assert client_mock.call_count == 1
+
+        # now filter - again
+        records = cached_client.list_records(endpoint, query1)
+        assert records == json.loads(expected_data1)
+        assert client_mock.call_count == 1


### PR DESCRIPTION
If CachedRestClient was first called with non-emtpy query, then filtered data was stored into cache.
If next call would have different filter, it would get a wrong response.

Also added some tests for this class. 