### PR TITLE
41 cloud init disk logic fix

### DIFF
--- a/plugins/module_utils/disk.py
+++ b/plugins/module_utils/disk.py
@@ -189,9 +189,14 @@ class Disk(PayloadMapper):
             virDomainUUID=vm.uuid,
         )
 
-    def needs_reboot(self, desired_disk):
+    def needs_reboot(self, action: str, desired_disk=None) -> bool:
+        # action is "create", "update", "delete".
         # Only a few actions over disks require reboot.
         # Delete and change type.
-        if self.type != desired_disk.type:
+        if desired_disk and action == "update" and self.type != desired_disk.type:
+            return True
+        if (
+            action == "delete" and self.type == "ide_cdrom"
+        ):  # ide_cdrom can never be deleted when VM is running.
             return True
         return False

--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -969,7 +969,7 @@ class ManageVMDisks:
     @staticmethod
     def _update_block_device(module, rest_client, desired_disk, existing_disk, vm):
         payload = desired_disk.post_and_patch_payload(vm)
-        if existing_disk.needs_reboot(desired_disk):
+        if existing_disk.needs_reboot("update", desired_disk):
             vm.do_shutdown_steps(module, rest_client)
         task_tag = rest_client.update_record(
             "{0}/{1}".format("/rest/v1/VirDomainBlockDevice", existing_disk.uuid),
@@ -996,6 +996,8 @@ class ManageVMDisks:
                 ):
                     to_delete = False
             if to_delete:
+                if existing_disk.needs_reboot("delete"):
+                    vm.do_shutdown_steps(module, rest_client)
                 task_tag = rest_client.delete_record(
                     "{0}/{1}".format(
                         "/rest/v1/VirDomainBlockDevice", existing_disk.uuid

--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -986,6 +986,8 @@ class ManageVMDisks:
         for updated_ansible_disk in updated_ansible_disks:
             existing_disk = Disk.from_ansible(updated_ansible_disk)
             to_delete = True
+            if existing_disk.name and "cloud-init" in existing_disk.name:
+                continue
             for ansible_desired_disk in module.params[disk_key]:
                 desired_disk = Disk.from_ansible(ansible_desired_disk)
                 if (

--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -458,7 +458,7 @@ class VM(PayloadMapper):
         dom = filter_dict(payload, *VM_PAYLOAD_KEYS)
         cloud_init_payload = VM.create_cloud_init_payload(ansible_dict)
         if cloud_init_payload is not None:
-            dom["CloudIinitData"] = cloud_init_payload
+            dom["cloudInitData"] = cloud_init_payload
         options = dict(attachGuestToolsISO=payload["attachGuestToolsISO"])
         return dict(dom=dom, options=options)
 

--- a/plugins/modules/vm_disk.py
+++ b/plugins/modules/vm_disk.py
@@ -277,6 +277,8 @@ def ensure_absent(module, rest_client):
                     module, rest_client, iso, uuid, attach=False
                 )
         # Remove the disk
+        if existing_disk.needs_reboot("delete"):
+            vm_before.do_shutdown_steps(module, rest_client)
         task_tag = rest_client.delete_record(
             "{0}/{1}".format("/rest/v1/VirDomainBlockDevice", uuid),
             module.check_mode,

--- a/tests/integration/targets/vm/tasks/01_main.yml
+++ b/tests/integration/targets/vm/tasks/01_main.yml
@@ -32,7 +32,7 @@
         state: present
       register: result
 
-    - name: Create and start the VM with disks, nics and boot devices set. Attach ISO onto the VM. Add cloud init data
+    - name: Create and start the VM with disks, nics and boot devices set. Attach ISO onto the VM.
       scale_computing.hypercore.vm: &create-vm
         vm_name: vm-integration-test-vm
         description: Demo VM
@@ -62,16 +62,6 @@
             disk_slot: 0
           - type: nic
             nic_vlan: 1
-        cloud_init:
-          user_data:
-            is_this: "yes"
-            valid:
-              - "yaml"
-              - "expression?"
-          meta_data:
-            this_data:
-              - "is"
-              - "very meta"
         machine_type: BIOS
       register: vm_created
     - ansible.builtin.assert:

--- a/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
+++ b/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
@@ -1,13 +1,14 @@
 # ----------------------------------Cleanup--------------------------------------------------------------------------------
-- name: Delete XLAB-vm
+- name: Delete XLAB-vm (START)
   scale_computing.hypercore.vm: &delete-XLAB-vm
     vm_name: "{{ item }}"
     state: absent
   loop:
     - XLAB-cloud-init-integration
+    - XLAB-cloud-init-integration-2
 
 # ----------------------------------Job-------------------------------------------------------------------------------------
-- name: Create and start the cloud_init VM
+- name: Create the XLAB-cloud-init-integration
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
@@ -75,8 +76,76 @@
       - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
+- name: Create and start the XLAB-cloud-init-integration-2
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration-2
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: start
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created_2
+- ansible.builtin.assert:
+    that:
+      - vm_created_2 is changed
+      - vm_created_2 is succeeded
+      - vm_created_2.record.0.description == "Demo VM"
+      - vm_created_2.record.0.memory == 536870912
+      - vm_created_2.record.0.tags == ["Xlab"]
+      - vm_created_2.record.0.vcpu == 2
+      - vm_created_2.record.0.vm_name == "XLAB-cloud-init-integration-2"
+      - vm_created_2.record.0.disks | length == 3     # Cloud init creates an IDE_CDROM disk, on first available slot.
+      - vm_created_2.record.0.nics | length == 2
+      - vm_created_2.record.0.nics.0.vlan == 1
+      - vm_created_2.record.0.nics.0.type == "RTL8139"
+      - vm_created_2.record.0.nics.1.vlan == 2
+      - vm_created_2.record.0.nics.1.type == "virtio"
+      - vm_created_2.record.0.disks.2.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.2.disk_slot == 1
+      - vm_created_2.record.0.disks.1.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.0.type == "virtio_disk"
+      - vm_created_2.record.0.disks.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices | length == 2
+      - vm_created_2.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created_2.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created_2.record.0.boot_devices.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices.1.vlan == 1
+      - vm_created_2.record.0.power_state == "started"
+      - vm_created_2.record.0.machine_type == "BIOS"
+
 # ----------------------------------Idempotence check------------------------------------------------------------------------
-- name: Create and start the cloud_init VM (Idempotence)
+- name: Create the XLAB-cloud-init-integration (Idempotence)
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
@@ -144,8 +213,76 @@
       - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
+- name: Create and start the XLAB-cloud-init-integration-2 (Idempotence)
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration-2
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: start
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created_2
+- ansible.builtin.assert:
+    that:
+      - vm_created_2 is not changed
+      - vm_created_2 is succeeded
+      - vm_created_2.record.0.description == "Demo VM"
+      - vm_created_2.record.0.memory == 536870912
+      - vm_created_2.record.0.tags == ["Xlab"]
+      - vm_created_2.record.0.vcpu == 2
+      - vm_created_2.record.0.vm_name == "XLAB-cloud-init-integration-2"
+      - vm_created_2.record.0.disks | length == 3     # Cloud init creates an IDE_CDROM disk, on first available slot.
+      - vm_created_2.record.0.nics | length == 2
+      - vm_created_2.record.0.nics.0.vlan == 1
+      - vm_created_2.record.0.nics.0.type == "RTL8139"
+      - vm_created_2.record.0.nics.1.vlan == 2
+      - vm_created_2.record.0.nics.1.type == "virtio"
+      - vm_created_2.record.0.disks.2.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.2.disk_slot == 1
+      - vm_created_2.record.0.disks.1.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.0.type == "virtio_disk"
+      - vm_created_2.record.0.disks.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices | length == 2
+      - vm_created_2.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created_2.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created_2.record.0.boot_devices.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices.1.vlan == 1
+      - vm_created_2.record.0.power_state == "started"
+      - vm_created_2.record.0.machine_type == "BIOS"
+
 # ----------------------------------Job-------------------------------------------------------------------------------------
-- name: Detach cloud_init ISO from IDE_CDROM
+- name: Detach cloud_init ISO from IDE_CDROM XLAB-cloud-init-integration
   scale_computing.hypercore.api:
     action: post
     endpoint: /rest/v1/VirDomainBlockDevice/{{ vm_created.record.0.disks.2.uuid }}
@@ -176,7 +313,7 @@
       - result.record.0.blockDevs.0.type == "VIRTIO_DISK"
       - result.record.0.blockDevs.0.slot == 0
 
-- name: Remove unused detached cloud init disk
+- name: Remove unused detached cloud init disk XLAB-cloud-init-integration
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
@@ -242,7 +379,8 @@
       - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
-- name: Remove unused detached cloud init disk (Idempotence)
+# ----------------------------------Idempotence check------------------------------------------------------------------------
+- name: Remove unused detached cloud init disk XLAB-cloud-init-integration (Idempotence)
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
@@ -307,3 +445,176 @@
       - vm_created.record.0.boot_devices.1.vlan == 1
       - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
+
+# ----------------------------------Job-------------------------------------------------------------------------------------
+- name: Detach cloud_init ISO from IDE_CDROM XLAB-cloud-init-integration-2
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/VirDomainBlockDevice/{{ vm_created_2.record.0.disks.2.uuid }}
+    data:
+      path: ""
+      name: ""
+      type: IDE_CDROM
+      capacity: 0
+  register: iso_detached
+- ansible.builtin.assert:
+    that:
+      - iso_detached is changed
+      - iso_detached is succeeded
+
+- name: Get XLAB-cloud-init-integration-2 info
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/VirDomain/{{vm_created_2.record.0.uuid}}
+  register: result
+- ansible.builtin.assert:
+    that:
+      - result.record | length == 1
+      - result.record.0.blockDevs | length == 3
+      - result.record.0.blockDevs.2.type == "IDE_CDROM"
+      - result.record.0.blockDevs.2.slot == 1
+      - result.record.0.blockDevs.1.type == "IDE_CDROM"
+      - result.record.0.blockDevs.1.slot == 0
+      - result.record.0.blockDevs.0.type == "VIRTIO_DISK"
+      - result.record.0.blockDevs.0.slot == 0
+
+- name: Remove unused detached cloud init disk XLAB-cloud-init-integration-2
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration-2
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: start
+    force_reboot: true
+    shutdown_timeout: 10
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created_2
+- ansible.builtin.assert:
+    that:
+      - vm_created_2 is changed
+      - vm_created_2 is succeeded
+      - vm_created_2.record.0.description == "Demo VM"
+      - vm_created_2.record.0.memory == 536870912
+      - vm_created_2.record.0.tags == ["Xlab"]
+      - vm_created_2.record.0.vcpu == 2
+      - vm_created_2.record.0.vm_name == "XLAB-cloud-init-integration-2"
+      - vm_created_2.record.0.disks | length == 2     # Cloud init disk was removed, since ISO was detached.
+      - vm_created_2.record.0.nics | length == 2
+      - vm_created_2.record.0.nics.0.vlan == 1
+      - vm_created_2.record.0.nics.0.type == "RTL8139"
+      - vm_created_2.record.0.nics.1.vlan == 2
+      - vm_created_2.record.0.nics.1.type == "virtio"
+      - vm_created_2.record.0.disks.1.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.0.type == "virtio_disk"
+      - vm_created_2.record.0.disks.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices | length == 2
+      - vm_created_2.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created_2.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created_2.record.0.boot_devices.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices.1.vlan == 1
+      - vm_created_2.record.0.machine_type == "BIOS"
+
+# ----------------------------------Idempotence check------------------------------------------------------------------------
+- name: Remove unused detached cloud init disk XLAB-cloud-init-integration-2 (Idempotence)
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration-2
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: start
+    shutdown_timeout: 10
+    force_reboot: true
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created_2
+- ansible.builtin.assert:
+    that:
+      - vm_created_2 is not changed
+      - vm_created_2 is succeeded
+      - vm_created_2.record.0.description == "Demo VM"
+      - vm_created_2.record.0.memory == 536870912
+      - vm_created_2.record.0.tags == ["Xlab"]
+      - vm_created_2.record.0.vcpu == 2
+      - vm_created_2.record.0.vm_name == "XLAB-cloud-init-integration-2"
+      - vm_created_2.record.0.disks | length == 2     # Cloud init disk was removed, since ISO was detached.
+      - vm_created_2.record.0.nics | length == 2
+      - vm_created_2.record.0.nics.0.vlan == 1
+      - vm_created_2.record.0.nics.0.type == "RTL8139"
+      - vm_created_2.record.0.nics.1.vlan == 2
+      - vm_created_2.record.0.nics.1.type == "virtio"
+      - vm_created_2.record.0.disks.1.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.0.type == "virtio_disk"
+      - vm_created_2.record.0.disks.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices | length == 2
+      - vm_created_2.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created_2.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created_2.record.0.boot_devices.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices.1.vlan == 1
+      - vm_created_2.record.0.machine_type == "BIOS"
+
+- name: Delete XLAB-vm (END)
+  scale_computing.hypercore.vm: *delete-XLAB-vm
+  loop:
+    - XLAB-cloud-init-integration
+    - XLAB-cloud-init-integration-2

--- a/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
+++ b/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
@@ -64,8 +64,11 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.2.type == "ide_cdrom"
       - vm_created.record.0.disks.2.disk_slot == 1
+      # VM with "uuid": "e640e784-606f-4b96-9de2-31970e0a13e8" has ISO with "iso_name": "cloud-init-e640e784.iso"
+      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.1.iso_name == ""
       - vm_created.record.0.disks.0.type == "virtio_disk"
       - vm_created.record.0.disks.0.disk_slot == 0
       - vm_created.record.0.boot_devices | length == 2
@@ -132,8 +135,10 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.2.type == "ide_cdrom"
       - vm_created_2.record.0.disks.2.disk_slot == 1
+      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.1.iso_name == ""
       - vm_created_2.record.0.disks.0.type == "virtio_disk"
       - vm_created_2.record.0.disks.0.disk_slot == 0
       - vm_created_2.record.0.boot_devices | length == 2
@@ -165,8 +170,10 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.2.type == "ide_cdrom"    # This stays, module logic should recognize this is cloud_init IDE from the disk name.
       - vm_created.record.0.disks.2.disk_slot == 1
+      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.1.iso_name == ""
       - vm_created.record.0.disks.0.type == "virtio_disk"
       - vm_created.record.0.disks.0.disk_slot == 0
       - vm_created.record.0.boot_devices | length == 2
@@ -223,8 +230,10 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.2.type == "ide_cdrom"
       - vm_created.record.0.disks.2.disk_slot == 1
+      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.1.iso_name == ""
       - vm_created.record.0.disks.0.type == "virtio_disk"
       - vm_created.record.0.disks.0.disk_slot == 0
       - vm_created.record.0.boot_devices | length == 2
@@ -255,8 +264,10 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.2.type == "ide_cdrom"
       - vm_created_2.record.0.disks.2.disk_slot == 1
+      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.1.iso_name == ""
       - vm_created_2.record.0.disks.0.type == "virtio_disk"
       - vm_created_2.record.0.disks.0.disk_slot == 0
       - vm_created_2.record.0.boot_devices | length == 2
@@ -313,8 +324,10 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.2.type == "ide_cdrom"
       - vm_created_2.record.0.disks.2.disk_slot == 1
+      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.1.iso_name == ""
       - vm_created_2.record.0.disks.0.type == "virtio_disk"
       - vm_created_2.record.0.disks.0.disk_slot == 0
       - vm_created_2.record.0.boot_devices | length == 2
@@ -352,8 +365,10 @@
       - result.record.0.blockDevs | length == 3
       - result.record.0.blockDevs.2.type == "IDE_CDROM"
       - result.record.0.blockDevs.2.slot == 1
+      - result.record.0.blockDevs.2.name == ""
       - result.record.0.blockDevs.1.type == "IDE_CDROM"
       - result.record.0.blockDevs.1.slot == 0
+      - result.record.0.blockDevs.1.name == ""
       - result.record.0.blockDevs.0.type == "VIRTIO_DISK"
       - result.record.0.blockDevs.0.slot == 0
 
@@ -403,6 +418,7 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.1.iso_name == ""
       - vm_created.record.0.disks.0.type == "virtio_disk"
       - vm_created.record.0.disks.0.disk_slot == 0
       - vm_created.record.0.boot_devices | length == 2
@@ -434,6 +450,7 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.1.iso_name == ""
       - vm_created.record.0.disks.0.type == "virtio_disk"
       - vm_created.record.0.disks.0.disk_slot == 0
       - vm_created.record.0.boot_devices | length == 2
@@ -473,6 +490,7 @@
       - result.record.0.blockDevs.2.slot == 1
       - result.record.0.blockDevs.1.type == "IDE_CDROM"
       - result.record.0.blockDevs.1.slot == 0
+      - result.record.0.blockDevs.1.name == ""
       - result.record.0.blockDevs.0.type == "VIRTIO_DISK"
       - result.record.0.blockDevs.0.slot == 0
 
@@ -524,6 +542,7 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.1.iso_name == ""
       - vm_created_2.record.0.disks.0.type == "virtio_disk"
       - vm_created_2.record.0.disks.0.disk_slot == 0
       - vm_created_2.record.0.boot_devices | length == 2
@@ -554,6 +573,7 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.1.iso_name == ""
       - vm_created_2.record.0.disks.0.type == "virtio_disk"
       - vm_created_2.record.0.disks.0.disk_slot == 0
       - vm_created_2.record.0.boot_devices | length == 2
@@ -563,6 +583,80 @@
       - vm_created_2.record.0.boot_devices.1.vlan == 1
       - vm_created_2.record.0.machine_type == "BIOS"
 
+
+# ----------------------------------Job-------------------------------------------------------------------------------------
+# Using scale_computing.hypercore.vm with cloud-init data, on existing VM with no cloud-init ISO,
+# will not create new ISO.
+- name: Create the XLAB-cloud-init-integration (Idempotence, cloud-init data present, but ISO manually removed)
+  scale_computing.hypercore.vm: *cloud-init-integration
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created is not changed
+      - vm_created is succeeded
+      - vm_created.record.0.description == "Demo VM"
+      - vm_created.record.0.memory == 536870912
+      - vm_created.record.0.tags == ["Xlab"]
+      - vm_created.record.0.vcpu == 2
+      - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
+      - vm_created.record.0.disks | length == 2
+      - vm_created.record.0.nics | length == 2
+      - vm_created.record.0.nics.0.vlan == 1
+      - vm_created.record.0.nics.0.type == "RTL8139"
+      - vm_created.record.0.nics.1.vlan == 2
+      - vm_created.record.0.nics.1.type == "virtio"
+#      - vm_created.record.0.disks.2.type == "ide_cdrom"    # This stays, module logic should recognize this is cloud_init IDE from the disk name.
+#      - vm_created.record.0.disks.2.disk_slot == 1
+#      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created.record.0.disks.1.type == "ide_cdrom"
+      - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.1.iso_name == ""
+      - vm_created.record.0.disks.0.type == "virtio_disk"
+      - vm_created.record.0.disks.0.disk_slot == 0
+      - vm_created.record.0.boot_devices | length == 2
+      - vm_created.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created.record.0.boot_devices.0.disk_slot == 0
+      - vm_created.record.0.boot_devices.1.vlan == 1
+      - vm_created.record.0.power_state == "stopped"
+      - vm_created.record.0.machine_type == "BIOS"
+
+- name: Create and start the XLAB-cloud-init-integration-2 (Idempotence, cloud-init data present, but ISO manually removed)
+  scale_computing.hypercore.vm: *cloud-init-integration-2
+  register: vm_created_2
+- ansible.builtin.assert:
+    that:
+      - vm_created_2 is not changed
+      - vm_created_2 is succeeded
+      - vm_created_2.record.0.description == "Demo VM"
+      - vm_created_2.record.0.memory == 536870912
+      - vm_created_2.record.0.tags == ["Xlab"]
+      - vm_created_2.record.0.vcpu == 2
+      - vm_created_2.record.0.vm_name == "XLAB-cloud-init-integration-2"
+      - vm_created_2.record.0.disks | length == 2
+      - vm_created_2.record.0.nics | length == 2
+      - vm_created_2.record.0.nics.0.vlan == 1
+      - vm_created_2.record.0.nics.0.type == "RTL8139"
+      - vm_created_2.record.0.nics.1.vlan == 2
+      - vm_created_2.record.0.nics.1.type == "virtio"
+#      - vm_created_2.record.0.disks.2.type == "ide_cdrom"
+#      - vm_created_2.record.0.disks.2.disk_slot == 1
+#      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created_2.record.0.disks.1.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.1.iso_name == ""
+      - vm_created_2.record.0.disks.0.type == "virtio_disk"
+      - vm_created_2.record.0.disks.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices | length == 2
+      - vm_created_2.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created_2.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created_2.record.0.boot_devices.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices.1.vlan == 1
+      - vm_created_2.record.0.power_state == "started"
+      - vm_created_2.record.0.machine_type == "BIOS"
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Cleanup
 - name: Delete XLAB-vm (END)
   scale_computing.hypercore.vm: *delete-XLAB-vm
   loop:

--- a/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
+++ b/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
@@ -9,7 +9,7 @@
 
 # ----------------------------------Job-------------------------------------------------------------------------------------
 - name: Create the XLAB-cloud-init-integration
-  scale_computing.hypercore.vm:
+  scale_computing.hypercore.vm: &cloud-init-integration
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
     state: present
@@ -77,7 +77,7 @@
       - vm_created.record.0.machine_type == "BIOS"
 
 - name: Create and start the XLAB-cloud-init-integration-2
-  scale_computing.hypercore.vm:
+  scale_computing.hypercore.vm: &cloud-init-integration-2
     vm_name: XLAB-cloud-init-integration-2
     description: Demo VM
     state: present
@@ -146,43 +146,7 @@
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Create the XLAB-cloud-init-integration (Idempotence)
-  scale_computing.hypercore.vm:
-    vm_name: XLAB-cloud-init-integration
-    description: Demo VM
-    state: present
-    tags:
-      - Xlab
-    memory: "{{ '512 MB' | human_to_bytes }}"
-    vcpu: 2
-    attach_guest_tools_iso: true
-    power_state: stop
-    disks:
-      - type: virtio_disk
-        disk_slot: 0
-        size: "{{ '10.1 GB' | human_to_bytes }}"
-      - type: ide_cdrom
-        disk_slot: 0
-    nics:
-      - vlan: 1
-        type: RTL8139
-      - vlan: 2
-        type: virtio
-    boot_devices:
-      - type: virtio_disk
-        disk_slot: 0
-      - type: nic
-        nic_vlan: 1
-    cloud_init:         # This should be ignored by the API on the second run, no more disks should be created.
-      user_data:
-        is_this: "yes"
-        valid:
-          - "yaml"
-          - "expression?"
-      meta_data:
-        this_data:
-          - "is"
-          - "very meta"
-    machine_type: BIOS
+  scale_computing.hypercore.vm: *cloud-init-integration
   register: vm_created
 - ansible.builtin.assert:
     that:
@@ -213,7 +177,97 @@
       - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
+- name: Create the XLAB-cloud-init-integration without cloud init (Idempotence) # Test without cloud init parameter to se if changes happen.
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: stop
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created is not changed
+      - vm_created is succeeded
+      - vm_created.record.0.description == "Demo VM"
+      - vm_created.record.0.memory == 536870912
+      - vm_created.record.0.tags == ["Xlab"]
+      - vm_created.record.0.vcpu == 2
+      - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
+      - vm_created.record.0.disks | length == 3     # Cloud init creates an IDE_CDROM disk, on first available slot.
+      - vm_created.record.0.nics | length == 2
+      - vm_created.record.0.nics.0.vlan == 1
+      - vm_created.record.0.nics.0.type == "RTL8139"
+      - vm_created.record.0.nics.1.vlan == 2
+      - vm_created.record.0.nics.1.type == "virtio"
+      - vm_created.record.0.disks.2.type == "ide_cdrom"
+      - vm_created.record.0.disks.2.disk_slot == 1
+      - vm_created.record.0.disks.1.type == "ide_cdrom"
+      - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.0.type == "virtio_disk"
+      - vm_created.record.0.disks.0.disk_slot == 0
+      - vm_created.record.0.boot_devices | length == 2
+      - vm_created.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created.record.0.boot_devices.0.disk_slot == 0
+      - vm_created.record.0.boot_devices.1.vlan == 1
+      - vm_created.record.0.power_state == "stopped"
+      - vm_created.record.0.machine_type == "BIOS"
+
 - name: Create and start the XLAB-cloud-init-integration-2 (Idempotence)
+  scale_computing.hypercore.vm: *cloud-init-integration-2
+  register: vm_created_2
+- ansible.builtin.assert:
+    that:
+      - vm_created_2 is not changed
+      - vm_created_2 is succeeded
+      - vm_created_2.record.0.description == "Demo VM"
+      - vm_created_2.record.0.memory == 536870912
+      - vm_created_2.record.0.tags == ["Xlab"]
+      - vm_created_2.record.0.vcpu == 2
+      - vm_created_2.record.0.vm_name == "XLAB-cloud-init-integration-2"
+      - vm_created_2.record.0.disks | length == 3     # Cloud init creates an IDE_CDROM disk, on first available slot.
+      - vm_created_2.record.0.nics | length == 2
+      - vm_created_2.record.0.nics.0.vlan == 1
+      - vm_created_2.record.0.nics.0.type == "RTL8139"
+      - vm_created_2.record.0.nics.1.vlan == 2
+      - vm_created_2.record.0.nics.1.type == "virtio"
+      - vm_created_2.record.0.disks.2.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.2.disk_slot == 1
+      - vm_created_2.record.0.disks.1.type == "ide_cdrom"
+      - vm_created_2.record.0.disks.1.disk_slot == 0
+      - vm_created_2.record.0.disks.0.type == "virtio_disk"
+      - vm_created_2.record.0.disks.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices | length == 2
+      - vm_created_2.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created_2.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created_2.record.0.boot_devices.0.disk_slot == 0
+      - vm_created_2.record.0.boot_devices.1.vlan == 1
+      - vm_created_2.record.0.power_state == "started"
+      - vm_created_2.record.0.machine_type == "BIOS"
+
+- name: Create and start the XLAB-cloud-init-integration-2 without cloud init (Idempotence) # Test without cloud init parameter to se if changes happen.
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration-2
     description: Demo VM
@@ -240,16 +294,6 @@
         disk_slot: 0
       - type: nic
         nic_vlan: 1
-    cloud_init:
-      user_data:
-        is_this: "yes"
-        valid:
-          - "yaml"
-          - "expression?"
-      meta_data:
-        this_data:
-          - "is"
-          - "very meta"
     machine_type: BIOS
   register: vm_created_2
 - ansible.builtin.assert:
@@ -314,7 +358,7 @@
       - result.record.0.blockDevs.0.slot == 0
 
 - name: Remove unused detached cloud init disk XLAB-cloud-init-integration
-  scale_computing.hypercore.vm:
+  scale_computing.hypercore.vm: &cloud-init-integration-remove
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
     state: present
@@ -340,16 +384,6 @@
         disk_slot: 0
       - type: nic
         nic_vlan: 1
-    cloud_init:
-      user_data:
-        is_this: "yes"
-        valid:
-          - "yaml"
-          - "expression?"
-      meta_data:
-        this_data:
-          - "is"
-          - "very meta"
     machine_type: BIOS
   register: vm_created
 - ansible.builtin.assert:
@@ -381,43 +415,7 @@
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Remove unused detached cloud init disk XLAB-cloud-init-integration (Idempotence)
-  scale_computing.hypercore.vm:
-    vm_name: XLAB-cloud-init-integration
-    description: Demo VM
-    state: present
-    tags:
-      - Xlab
-    memory: "{{ '512 MB' | human_to_bytes }}"
-    vcpu: 2
-    attach_guest_tools_iso: true
-    power_state: stop
-    disks:
-      - type: virtio_disk
-        disk_slot: 0
-        size: "{{ '10.1 GB' | human_to_bytes }}"
-      - type: ide_cdrom
-        disk_slot: 0
-    nics:
-      - vlan: 1
-        type: RTL8139
-      - vlan: 2
-        type: virtio
-    boot_devices:
-      - type: virtio_disk
-        disk_slot: 0
-      - type: nic
-        nic_vlan: 1
-    cloud_init:
-      user_data:
-        is_this: "yes"
-        valid:
-          - "yaml"
-          - "expression?"
-      meta_data:
-        this_data:
-          - "is"
-          - "very meta"
-    machine_type: BIOS
+  scale_computing.hypercore.vm: *cloud-init-integration-remove
   register: vm_created
 - ansible.builtin.assert:
     that:
@@ -479,7 +477,7 @@
       - result.record.0.blockDevs.0.slot == 0
 
 - name: Remove unused detached cloud init disk XLAB-cloud-init-integration-2
-  scale_computing.hypercore.vm:
+  scale_computing.hypercore.vm: &cloud-init-integration-remove-2
     vm_name: XLAB-cloud-init-integration-2
     description: Demo VM
     state: present
@@ -507,16 +505,6 @@
         disk_slot: 0
       - type: nic
         nic_vlan: 1
-    cloud_init:
-      user_data:
-        is_this: "yes"
-        valid:
-          - "yaml"
-          - "expression?"
-      meta_data:
-        this_data:
-          - "is"
-          - "very meta"
     machine_type: BIOS
   register: vm_created_2
 - ansible.builtin.assert:
@@ -547,45 +535,7 @@
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Remove unused detached cloud init disk XLAB-cloud-init-integration-2 (Idempotence)
-  scale_computing.hypercore.vm:
-    vm_name: XLAB-cloud-init-integration-2
-    description: Demo VM
-    state: present
-    tags:
-      - Xlab
-    memory: "{{ '512 MB' | human_to_bytes }}"
-    vcpu: 2
-    attach_guest_tools_iso: true
-    power_state: start
-    shutdown_timeout: 10
-    force_reboot: true
-    disks:
-      - type: virtio_disk
-        disk_slot: 0
-        size: "{{ '10.1 GB' | human_to_bytes }}"
-      - type: ide_cdrom
-        disk_slot: 0
-    nics:
-      - vlan: 1
-        type: RTL8139
-      - vlan: 2
-        type: virtio
-    boot_devices:
-      - type: virtio_disk
-        disk_slot: 0
-      - type: nic
-        nic_vlan: 1
-    cloud_init:
-      user_data:
-        is_this: "yes"
-        valid:
-          - "yaml"
-          - "expression?"
-      meta_data:
-        this_data:
-          - "is"
-          - "very meta"
-    machine_type: BIOS
+  scale_computing.hypercore.vm: *cloud-init-integration-remove-2
   register: vm_created_2
 - ansible.builtin.assert:
     that:

--- a/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
+++ b/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
@@ -6,25 +6,6 @@
   loop:
     - XLAB-cloud-init-integration
 
-- name: Create project directory /tmp (if it doesn't exist already)
-  file: state=directory path=/tmp
-
-- name: Download ISO image from http://tinycorelinux.net/13.x/x86/release/TinyCore-current.iso and save it into /tmp/TinyCore-vm-integration.iso
-  get_url: url=http://tinycorelinux.net/13.x/x86/release/TinyCore-current.iso dest=/tmp/TinyCore-vm-integration.iso
-
-- name: Delete the ISO image (if it may exist)
-  scale_computing.hypercore.iso: &delete-iso
-    name: "TinyCore-vm-integration.iso"
-    state: absent
-  register: result
-
-- name: Upload ISO image TinyCore-vm-integration.iso to HyperCore API
-  scale_computing.hypercore.iso:
-    name: "TinyCore-vm-integration.iso"
-    source: "/tmp/TinyCore-vm-integration.iso"
-    state: present
-  register: result
-
 # ----------------------------------Job-------------------------------------------------------------------------------------
 - name: Create and start the cloud_init VM
   scale_computing.hypercore.vm:
@@ -43,7 +24,6 @@
         size: "{{ '10.1 GB' | human_to_bytes }}"
       - type: ide_cdrom
         disk_slot: 0
-        iso_name: TinyCore-vm-integration.iso
     nics:
       - vlan: 1
         type: RTL8139
@@ -92,7 +72,7 @@
       - vm_created.record.0.boot_devices.1.type == "RTL8139"
       - vm_created.record.0.boot_devices.0.disk_slot == 0
       - vm_created.record.0.boot_devices.1.vlan == 1
-      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
@@ -113,7 +93,6 @@
         size: "{{ '10.1 GB' | human_to_bytes }}"
       - type: ide_cdrom
         disk_slot: 0
-        iso_name: TinyCore-vm-integration.iso
     nics:
       - vlan: 1
         type: RTL8139
@@ -151,7 +130,7 @@
       - vm_created.record.0.nics.0.type == "RTL8139"
       - vm_created.record.0.nics.1.vlan == 2
       - vm_created.record.0.nics.1.type == "virtio"
-      - vm_created.record.0.disks.2.type == "ide_cdrom"         # This stays, module logic should recognize this is cloud_init IDE from the disk name.
+      - vm_created.record.0.disks.2.type == "ide_cdrom"    # This stays, module logic should recognize this is cloud_init IDE from the disk name.
       - vm_created.record.0.disks.2.disk_slot == 1
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
@@ -162,24 +141,42 @@
       - vm_created.record.0.boot_devices.1.type == "RTL8139"
       - vm_created.record.0.boot_devices.0.disk_slot == 0
       - vm_created.record.0.boot_devices.1.vlan == 1
-      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
 # ----------------------------------Job-------------------------------------------------------------------------------------
 - name: Detach cloud_init ISO from IDE_CDROM
-  scale_computing.hypercore.vm:
-    vm_name: XLAB-cloud-init-integration
-    state: absent
-    items:
-      - type: ide_cdrom
-        disk_slot: 1
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/VirDomainBlockDevice/{{ vm_created.record.0.disks.2.uuid }}
+    data:
+      path: ""
+      name: ""
+      type: IDE_CDROM
+      capacity: 0
   register: iso_detached
 - ansible.builtin.assert:
     that:
       - iso_detached is changed
       - iso_detached is succeeded
 
-- name: Remove IDE_CDROM with detached cloud_init ISO
+- name: Get XLAB-cloud-init-integration info
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/VirDomain/{{vm_created.record.0.uuid}}
+  register: result
+- ansible.builtin.assert:
+    that:
+      - result.record | length == 1
+      - result.record.0.blockDevs | length == 3
+      - result.record.0.blockDevs.2.type == "IDE_CDROM"
+      - result.record.0.blockDevs.2.slot == 1
+      - result.record.0.blockDevs.1.type == "IDE_CDROM"
+      - result.record.0.blockDevs.1.slot == 0
+      - result.record.0.blockDevs.0.type == "VIRTIO_DISK"
+      - result.record.0.blockDevs.0.slot == 0
+
+- name: Remove unused detached cloud init disk
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
@@ -196,7 +193,6 @@
         size: "{{ '10.1 GB' | human_to_bytes }}"
       - type: ide_cdrom
         disk_slot: 0
-        iso_name: TinyCore-vm-integration.iso
     nics:
       - vlan: 1
         type: RTL8139
@@ -228,7 +224,7 @@
       - vm_created.record.0.tags == ["Xlab"]
       - vm_created.record.0.vcpu == 2
       - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
-      - vm_created.record.0.disks | length == 2
+      - vm_created.record.0.disks | length == 2     # Cloud init disk was removed, since ISO was detached.
       - vm_created.record.0.nics | length == 2
       - vm_created.record.0.nics.0.vlan == 1
       - vm_created.record.0.nics.0.type == "RTL8139"
@@ -243,11 +239,10 @@
       - vm_created.record.0.boot_devices.1.type == "RTL8139"
       - vm_created.record.0.boot_devices.0.disk_slot == 0
       - vm_created.record.0.boot_devices.1.vlan == 1
-      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"
 
-# ----------------------------------Idempotence check------------------------------------------------------------------------
-- name: Remove IDE_CDROM with detached cloud_init ISO (Idempotence)
+- name: Remove unused detached cloud init disk (Idempotence)
   scale_computing.hypercore.vm:
     vm_name: XLAB-cloud-init-integration
     description: Demo VM
@@ -264,7 +259,6 @@
         size: "{{ '10.1 GB' | human_to_bytes }}"
       - type: ide_cdrom
         disk_slot: 0
-        iso_name: TinyCore-vm-integration.iso
     nics:
       - vlan: 1
         type: RTL8139
@@ -296,7 +290,7 @@
       - vm_created.record.0.tags == ["Xlab"]
       - vm_created.record.0.vcpu == 2
       - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
-      - vm_created.record.0.disks | length == 2
+      - vm_created.record.0.disks | length == 2     # Cloud init disk was removed, since ISO was detached.
       - vm_created.record.0.nics | length == 2
       - vm_created.record.0.nics.0.vlan == 1
       - vm_created.record.0.nics.0.type == "RTL8139"
@@ -311,5 +305,5 @@
       - vm_created.record.0.boot_devices.1.type == "RTL8139"
       - vm_created.record.0.boot_devices.0.disk_slot == 0
       - vm_created.record.0.boot_devices.1.vlan == 1
-      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.power_state == "stopped"
       - vm_created.record.0.machine_type == "BIOS"

--- a/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
+++ b/tests/integration/targets/vm_git_issues/tasks/issue_41_cloud_init_disks.yml
@@ -1,0 +1,315 @@
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete XLAB-vm
+  scale_computing.hypercore.vm: &delete-XLAB-vm
+    vm_name: "{{ item }}"
+    state: absent
+  loop:
+    - XLAB-cloud-init-integration
+
+- name: Create project directory /tmp (if it doesn't exist already)
+  file: state=directory path=/tmp
+
+- name: Download ISO image from http://tinycorelinux.net/13.x/x86/release/TinyCore-current.iso and save it into /tmp/TinyCore-vm-integration.iso
+  get_url: url=http://tinycorelinux.net/13.x/x86/release/TinyCore-current.iso dest=/tmp/TinyCore-vm-integration.iso
+
+- name: Delete the ISO image (if it may exist)
+  scale_computing.hypercore.iso: &delete-iso
+    name: "TinyCore-vm-integration.iso"
+    state: absent
+  register: result
+
+- name: Upload ISO image TinyCore-vm-integration.iso to HyperCore API
+  scale_computing.hypercore.iso:
+    name: "TinyCore-vm-integration.iso"
+    source: "/tmp/TinyCore-vm-integration.iso"
+    state: present
+  register: result
+
+# ----------------------------------Job-------------------------------------------------------------------------------------
+- name: Create and start the cloud_init VM
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: stop
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: TinyCore-vm-integration.iso
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created is changed
+      - vm_created is succeeded
+      - vm_created.record.0.description == "Demo VM"
+      - vm_created.record.0.memory == 536870912
+      - vm_created.record.0.tags == ["Xlab"]
+      - vm_created.record.0.vcpu == 2
+      - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
+      - vm_created.record.0.disks | length == 3     # Cloud init creates an IDE_CDROM disk, on first available slot.
+      - vm_created.record.0.nics | length == 2
+      - vm_created.record.0.nics.0.vlan == 1
+      - vm_created.record.0.nics.0.type == "RTL8139"
+      - vm_created.record.0.nics.1.vlan == 2
+      - vm_created.record.0.nics.1.type == "virtio"
+      - vm_created.record.0.disks.2.type == "ide_cdrom"
+      - vm_created.record.0.disks.2.disk_slot == 1
+      - vm_created.record.0.disks.1.type == "ide_cdrom"
+      - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.0.type == "virtio_disk"
+      - vm_created.record.0.disks.0.disk_slot == 0
+      - vm_created.record.0.boot_devices | length == 2
+      - vm_created.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created.record.0.boot_devices.0.disk_slot == 0
+      - vm_created.record.0.boot_devices.1.vlan == 1
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.machine_type == "BIOS"
+
+# ----------------------------------Idempotence check------------------------------------------------------------------------
+- name: Create and start the cloud_init VM (Idempotence)
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: stop
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: TinyCore-vm-integration.iso
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:         # This should be ignored by the API on the second run, no more disks should be created.
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created is not changed
+      - vm_created is succeeded
+      - vm_created.record.0.description == "Demo VM"
+      - vm_created.record.0.memory == 536870912
+      - vm_created.record.0.tags == ["Xlab"]
+      - vm_created.record.0.vcpu == 2
+      - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
+      - vm_created.record.0.disks | length == 3
+      - vm_created.record.0.nics | length == 2
+      - vm_created.record.0.nics.0.vlan == 1
+      - vm_created.record.0.nics.0.type == "RTL8139"
+      - vm_created.record.0.nics.1.vlan == 2
+      - vm_created.record.0.nics.1.type == "virtio"
+      - vm_created.record.0.disks.2.type == "ide_cdrom"         # This stays, module logic should recognize this is cloud_init IDE from the disk name.
+      - vm_created.record.0.disks.2.disk_slot == 1
+      - vm_created.record.0.disks.1.type == "ide_cdrom"
+      - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.0.type == "virtio_disk"
+      - vm_created.record.0.disks.0.disk_slot == 0
+      - vm_created.record.0.boot_devices | length == 2
+      - vm_created.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created.record.0.boot_devices.0.disk_slot == 0
+      - vm_created.record.0.boot_devices.1.vlan == 1
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.machine_type == "BIOS"
+
+# ----------------------------------Job-------------------------------------------------------------------------------------
+- name: Detach cloud_init ISO from IDE_CDROM
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration
+    state: absent
+    items:
+      - type: ide_cdrom
+        disk_slot: 1
+  register: iso_detached
+- ansible.builtin.assert:
+    that:
+      - iso_detached is changed
+      - iso_detached is succeeded
+
+- name: Remove IDE_CDROM with detached cloud_init ISO
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: stop
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: TinyCore-vm-integration.iso
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created is changed
+      - vm_created is succeeded
+      - vm_created.record.0.description == "Demo VM"
+      - vm_created.record.0.memory == 536870912
+      - vm_created.record.0.tags == ["Xlab"]
+      - vm_created.record.0.vcpu == 2
+      - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
+      - vm_created.record.0.disks | length == 2
+      - vm_created.record.0.nics | length == 2
+      - vm_created.record.0.nics.0.vlan == 1
+      - vm_created.record.0.nics.0.type == "RTL8139"
+      - vm_created.record.0.nics.1.vlan == 2
+      - vm_created.record.0.nics.1.type == "virtio"
+      - vm_created.record.0.disks.1.type == "ide_cdrom"
+      - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.0.type == "virtio_disk"
+      - vm_created.record.0.disks.0.disk_slot == 0
+      - vm_created.record.0.boot_devices | length == 2
+      - vm_created.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created.record.0.boot_devices.0.disk_slot == 0
+      - vm_created.record.0.boot_devices.1.vlan == 1
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.machine_type == "BIOS"
+
+# ----------------------------------Idempotence check------------------------------------------------------------------------
+- name: Remove IDE_CDROM with detached cloud_init ISO (Idempotence)
+  scale_computing.hypercore.vm:
+    vm_name: XLAB-cloud-init-integration
+    description: Demo VM
+    state: present
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: true
+    power_state: stop
+    disks:
+      - type: virtio_disk
+        disk_slot: 0
+        size: "{{ '10.1 GB' | human_to_bytes }}"
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: TinyCore-vm-integration.iso
+    nics:
+      - vlan: 1
+        type: RTL8139
+      - vlan: 2
+        type: virtio
+    boot_devices:
+      - type: virtio_disk
+        disk_slot: 0
+      - type: nic
+        nic_vlan: 1
+    cloud_init:
+      user_data:
+        is_this: "yes"
+        valid:
+          - "yaml"
+          - "expression?"
+      meta_data:
+        this_data:
+          - "is"
+          - "very meta"
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created is not changed
+      - vm_created is succeeded
+      - vm_created.record.0.description == "Demo VM"
+      - vm_created.record.0.memory == 536870912
+      - vm_created.record.0.tags == ["Xlab"]
+      - vm_created.record.0.vcpu == 2
+      - vm_created.record.0.vm_name == "XLAB-cloud-init-integration"
+      - vm_created.record.0.disks | length == 2
+      - vm_created.record.0.nics | length == 2
+      - vm_created.record.0.nics.0.vlan == 1
+      - vm_created.record.0.nics.0.type == "RTL8139"
+      - vm_created.record.0.nics.1.vlan == 2
+      - vm_created.record.0.nics.1.type == "virtio"
+      - vm_created.record.0.disks.1.type == "ide_cdrom"
+      - vm_created.record.0.disks.1.disk_slot == 0
+      - vm_created.record.0.disks.0.type == "virtio_disk"
+      - vm_created.record.0.disks.0.disk_slot == 0
+      - vm_created.record.0.boot_devices | length == 2
+      - vm_created.record.0.boot_devices.0.type == "virtio_disk"
+      - vm_created.record.0.boot_devices.1.type == "RTL8139"
+      - vm_created.record.0.boot_devices.0.disk_slot == 0
+      - vm_created.record.0.boot_devices.1.vlan == 1
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.machine_type == "BIOS"

--- a/tests/integration/targets/vm_git_issues/tasks/main.yml
+++ b/tests/integration/targets/vm_git_issues/tasks/main.yml
@@ -11,4 +11,5 @@
     - include_tasks: issue_11_empty_ide_cdrom.yml
     - include_tasks: issue_12_machine_types.yml
     - include_tasks: issue_3_enlarging_disk_is_triggering_restart.yml
+    - include_tasks: issue_41_cloud_init_disks.yml
 # TODO: add more tasks here when more issues are fixed.

--- a/tests/unit/plugins/module_utils/test_vm.py
+++ b/tests/unit/plugins/module_utils/test_vm.py
@@ -656,7 +656,7 @@ class TestVM:
             "dom": {
                 "blockDevs": [],
                 "bootDevices": [],
-                "CloudIinitData": {
+                "cloudInitData": {
                     "metaData": "Y2xvdWRfaW5pdC1tZXRhLWRhdGE=",
                     "userData": "Y2xvdWRfaW5pdC11c2VyLWRhdGE=",
                 },


### PR DESCRIPTION
Allows for cloud init to create IDE_CDROM without deleting it as long as cloud-init ISO is still attached.
Removes cloud init CDROM when ISO is detached.