### PR TITLE
Update main.yml - set mem on name: Create XLAB-vm_clone-CI_test-running

### DIFF
--- a/tests/integration/targets/vm_clone/tasks/main.yml
+++ b/tests/integration/targets/vm_clone/tasks/main.yml
@@ -91,7 +91,7 @@
           dom:
             name: XLAB-vm_clone-CI_test-running
             tags: Xlab,CI,test,vm_clone,running
-            mem: 512100100
+            mem: 511705088
             numVCPU: 2
             blockDevs:
               - type: VIRTIO_DISK


### PR DESCRIPTION
made mem == 511705088 change to name: Create XLAB-vm_clone-CI_test-running  (which was the one not starting on 9.2.8 hypercore)