### PR TITLE
Refactor smb_cleanup.sh

### DIFF
--- a/tests/integration/cleanup/smb_cleanup.sh
+++ b/tests/integration/cleanup/smb_cleanup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -e  # exit on error
+set -u  # exit on undefined variable
+# set -x  # verbose
 
 # Delete function.
 # Deletes files that are at least one day old.
@@ -8,29 +11,41 @@ delete_files () {
     username=$3
     password=$4
     folder=$5 # Folder where files are located.
-    files=($(smbclient //$server$share -U $username%$password -D $folder -c ls | awk '{print $1}'))
-    dates=($(smbclient //$server$share -U $username%$password -D $folder -c ls -l | awk '{print $5":"$6":"$8}'))
-    length=${#files[@]}-1
+    # files=($(smbclient //$server$share -U $username%$password -D $folder -c ls | awk '{print $1}'))
+    # dates=($(smbclient //$server$share -U $username%$password -D $folder -c ls -l | awk '{print $5":"$6":"$8}'))
+    # length=${#files[@]}-1
 
+    list_dir=$(smbclient "//$server$share" -U "$username%$password" -D "$folder" -c l)
+    # for each file we have a line is like "  Cuba                                N     2416  Mon Apr 27 10:52:07 2020"
     # Output list of all files inside given directory, easier to debug.
-    echo "Folder:" $folder
-    smbclient //$server$share -U $username%$password -D $folder << SMBCLIENTCOMMANDS
-    ls
-SMBCLIENTCOMMANDS
+    echo "Folder: $folder"
+    echo "list_dir=$list_dir"
+    # remove first 2 and last 2 lines of smbclient output - they are not files
+    files="$(echo "$list_dir" | head --lines=-2 | tail --lines=+3)"
+    echo "files=$files"
 
     today_date=$(date +'%b:%-d:%Y')
-    echo "Todays date:" $today_date
+    echo "Todays date: $today_date"
 
-    for (( j=0; j<length; j++ ));
+    while IFS= read -r line
     do
-        # Delete files that are at least one day old, in order to not crash other integration tests.
-        if [ ${files[j]} != '.' ] && [ ${files[j]} != '..' ] && [ ${files[j]} != '.deleted' ] && [ ${dates[j]} != $today_date ] 
-        then
-            echo "Attempting to delete:" ${files[j]} "with timestamp:" ${dates[j]}
-            smbclient //$server$share -U $username%$password -D $folder -c 'deltree '${files[j]}''
-        fi
-    done
- }
+      # echo line=$line
+      if [ "$line" == "" ]
+      then
+        # directory is empty
+        continue
+      fi
+      filename="$(echo "$line" | awk '{print $1}')"
+      file_date=$(echo "$line" | awk '{print $5":"$6":"$8}')
+      if [ $file_date == $today_date ]
+      then
+        echo "Keeping file $filename, timestamp is $file_date"
+        continue
+      fi
+      echo "Removing file $filename, timestamp is $file_date"
+      smbclient "//$server$share" -U "$username%$password" -D "$folder" -c "deltree $filename"
+    done <<< "$files"
+}
 
 # Main function
 main () {
@@ -39,15 +54,15 @@ main () {
     # $3 username
     # $4 password
     # username is provided as domain;username
-    IFS=';' read -ra username <<< $3
+    IFS=';' read -ra username <<< "$3"
 
     folder='integration-test-vm-export'
-    delete_files $1 $2 ${username[1]} $4 $folder
+    delete_files "$1" "$2" "${username[1]}" "$4" "$folder"
 
     folder='integration-test-vm-import'
-    delete_files $1 $2 ${username[1]} $4 $folder
+    delete_files "$1" "$2" "${username[1]}" "$4" "$folder"
 
     exit 0
 }
 
-main $1 $2 $3 $4
+main "$1" "$2" "$3" "$4"

--- a/tests/integration/cleanup/smb_cleanup.sh
+++ b/tests/integration/cleanup/smb_cleanup.sh
@@ -11,9 +11,6 @@ delete_files () {
     username=$3
     password=$4
     folder=$5 # Folder where files are located.
-    # files=($(smbclient //$server$share -U $username%$password -D $folder -c ls | awk '{print $1}'))
-    # dates=($(smbclient //$server$share -U $username%$password -D $folder -c ls -l | awk '{print $5":"$6":"$8}'))
-    # length=${#files[@]}-1
 
     list_dir=$(smbclient "//$server$share" -U "$username%$password" -D "$folder" -c l)
     # for each file we have a line is like "  Cuba                                N     2416  Mon Apr 27 10:52:07 2020"
@@ -37,7 +34,7 @@ delete_files () {
       fi
       filename="$(echo "$line" | awk '{print $1}')"
       file_date=$(echo "$line" | awk '{print $5":"$6":"$8}')
-      if [ $file_date == $today_date ]
+      if [ "$file_date" == "$today_date" ]
       then
         echo "Keeping file $filename, timestamp is $file_date"
         continue


### PR DESCRIPTION
I'm trying to use ansible-community/ansible-test-gh-action@release/v1 action instead of manually craft `ansible-test ...` command.

One thing it complained about was smb_cleanup.sh, it failed shellcheck test. I modify script a bit (I'm not good at bash arrays, and had problem understanding how script works), and then fixed remaining complains about escaping and quoting.

I tested a script on samba server. Two old files (`cp -a /usr/share/zoneinfo/{Cuba,Libya} /srv/integration-test-vm-export/`) were added, those needs to be deleted. One new file was created, this one needs to stay (`touch /srv/integration-test-vm-export/zaklad`). Output is

```
tests/integration/cleanup/smb_cleanup.sh 10.5.11.179 /users "fakedomain;example1" badpass; echo ret=$?
Folder: integration-test-vm-export
list_dir=  .                                   D        0  Tue Jan 31 13:13:43 2023
  ..                                  D        0  Tue Jan 31 12:47:34 2023
  zaklad                              N        0  Tue Jan 31 13:13:05 2023
  Cuba                                N     2416  Mon Apr 27 12:52:07 2020
  Libya                               N      625  Mon Apr 27 12:52:07 2020

		16517120 blocks of size 1024. 14580632 blocks available
files=  zaklad                              N        0  Tue Jan 31 13:13:05 2023
  Cuba                                N     2416  Mon Apr 27 12:52:07 2020
  Libya
```
