### PR TITLE
Add virtual_disk_info module

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -91,6 +91,7 @@ jobs:
     runs-on: [self-hosted2]
     container: python:3.10-slim-buster
     env:
+      DEBIAN_FRONTEND: noninteractive
       ANSIBLE_COLLECTIONS_PATH: /work-dir
       # vm_import|vm_export - they need SMB server
       # dns_config|time_server - NTP cannot be reconfigured if DNS is invalid
@@ -105,7 +106,7 @@ jobs:
       - run: apt update
       - run: apt install -y git make
       - run: pip install ansible-core==2.13.1
-      - run: apt install -y genisoimage
+      - run: apt install -y genisoimage qemu-utils
       - run: apt install -y jq
       - run: mkdir -p $WORKDIR
       - run: cp -a ./  $WORKDIR
@@ -130,6 +131,8 @@ jobs:
       - units-test
     runs-on: [self-hosted2]
     container: python:3.10-slim-buster
+    env:
+      DEBIAN_FRONTEND: noninteractive
     strategy:
       fail-fast: false
       matrix:
@@ -141,7 +144,7 @@ jobs:
       - run: pip3 install -r sanity.requirements -r test.requirements -r docs.requirements
       - run: apt update
       - run: apt install -y git make
-      - run: apt install -y genisoimage
+      - run: apt install -y genisoimage qemu-utils
       - run: pip install ansible-core==2.13.1
       - run: mkdir -p $WORKDIR
       - run: cp -a ./  $WORKDIR
@@ -165,6 +168,8 @@ jobs:
       - units-test
     runs-on: [self-hosted2]
     container: python:3.10-slim-buster
+    env:
+      DEBIAN_FRONTEND: noninteractive
     strategy:
       fail-fast: false
       matrix:
@@ -175,7 +180,7 @@ jobs:
       - run: pip3 install -r sanity.requirements -r test.requirements -r docs.requirements
       - run: apt update
       - run: apt install -y git make
-      - run: apt install -y genisoimage
+      - run: apt install -y genisoimage qemu-utils
       - run: pip install ansible-core==2.13.1
       - run: mkdir -p $WORKDIR
       - run: cp -a ./  $WORKDIR
@@ -197,6 +202,8 @@ jobs:
       - integ-part1
     runs-on: [self-hosted2]
     container: python:3.10-slim-buster
+    env:
+      DEBIAN_FRONTEND: noninteractive
     strategy:
       fail-fast: false
       matrix:
@@ -207,7 +214,7 @@ jobs:
       - run: pip3 install -r sanity.requirements -r test.requirements -r docs.requirements
       - run: apt update
       - run: apt install -y git make
-      - run: apt install -y genisoimage
+      - run: apt install -y genisoimage qemu-utils
       - run: pip install ansible-core==2.13.1
       - run: mkdir -p $WORKDIR
       - run: cp -a ./  $WORKDIR

--- a/changelogs/fragments/virtual_disk_info_module.yml
+++ b/changelogs/fragments/virtual_disk_info_module.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - Added virtual_disk_info module. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/84)

--- a/plugins/module_utils/hypercore_version.py
+++ b/plugins/module_utils/hypercore_version.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
+__metaclass__ = type
+
+import operator
+import re
+from functools import total_ordering
+from typing import List
+from .rest_client import RestClient
+
+
+class HyperCoreVersion:
+    """
+    Check if HyperCore version does support required feature.
+    Examples include:
+    - VirtualDisk endpoint
+    - PATCH for cluster name
+    """
+
+    def __init__(self, rest_client: RestClient):
+        self._rest_client = rest_client
+        self._version = ""
+
+    @property
+    def version(self) -> str:
+        if not self._version:
+            record = self._rest_client.get_record("/rest/v1/Cluster")
+            if (
+                record is None
+                or "icosVersion" not in record
+                or not isinstance(record["icosVersion"], str)
+            ):
+                raise AssertionError(
+                    "HyperCore version not found in REST API response."
+                )
+            self._version = record["icosVersion"]
+        return self._version
+
+    def verify(self, spec: str) -> bool:
+        # Use spec ">=9.1.9 <9.2.0 || >=9.2.10" to detect a feature
+        # added in 9.2.10 and backported to 9.1.9.
+        version = self.version
+        version = ".".join(version.split(".")[:3])
+        return VersionSpec(spec).match(Version(version))
+
+
+@total_ordering
+class Version:
+    def __init__(self, version: str):
+        self.version = version.strip()
+        if not re.match(r"^[.0-9]*$", self.version):
+            raise AssertionError()
+        # work only with semver-like versions - "a.b.c"
+        if self.version.count(".") != 2:
+            raise AssertionError()
+
+    @property
+    def parts(self) -> List[int]:
+        parts_str = self.version.split(".")
+        parts = [int(pp) for pp in parts_str]
+        return parts
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        my_parts = self.parts
+        other_parts = other.parts
+        for my_part, other_part in zip(my_parts, other_parts):
+            if my_part < other_part:
+                return True
+            elif my_part > other_part:
+                return False
+        return False
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self.parts == other.parts
+
+
+class VersionSpecBase:
+    def __init__(self, spec: str):
+        raise NotImplementedError()
+
+    def match(self, version: Version) -> bool:
+        raise NotImplementedError()
+
+
+class VersionSpecSimple(VersionSpecBase):
+    def __init__(self, spec: str):
+        """
+        :param spec:
+        Must be "operator + version". NO space between!.
+        operator: <, <=, >, >=, ==.
+        """
+        self.spec = spec.strip()
+        if " " in self.spec:
+            raise AssertionError()
+        re_match = re.search(r"[^<>=]", self.spec)
+        if re_match is None:
+            raise AssertionError()
+        version_ind = re_match.start()
+        operator_str = self.spec[:version_ind]
+        version = self.spec[version_ind:]
+        self._version = Version(version)
+        operator_map = {
+            "<": operator.lt,
+            "<=": operator.le,
+            ">": operator.gt,
+            ">=": operator.ge,
+            "==": operator.eq,
+        }
+        self._operator = operator_map[operator_str]
+
+    def match(self, version: Version) -> bool:
+        return bool(self._operator(version, self._version))
+
+
+class VersionSpec(VersionSpecBase):
+    def __init__(self, spec: str):
+        self.spec = spec.strip()
+        self._childs: List[VersionSpecBase]
+        if "||" in self.spec:
+            self._operator = any
+            subspecs_str = self.spec.split("||")
+            self._childs = [VersionSpec(subspec.strip()) for subspec in subspecs_str]
+        else:
+            self._operator = all
+            subspecs_str = self.spec.split()
+            self._childs = [VersionSpecSimple(subspec) for subspec in subspecs_str]
+
+    def match(self, version: Version) -> bool:
+        results = [child.match(version) for child in self._childs]
+        return self._operator(results)

--- a/plugins/module_utils/typed_classes.py
+++ b/plugins/module_utils/typed_classes.py
@@ -120,3 +120,17 @@ class TypedEmailAlertFromAnsible(TypedDict):
     resend_delay: Union[int, None]
     silent_period: Union[int, None]
     latest_task_tag: Union[TypedTaskTag, None]
+
+
+class TypedVirtualDiskToAnsible(TypedDict):
+    name: Union[str, None]
+    uuid: Union[str, None]
+    block_size: Union[int, None]
+    size: Union[int, None]
+    # allocated_size: int
+    replication_factor: Union[int, None]
+
+
+class TypedVirtualDiskFromAnsible(TypedDict):
+    name: Union[str, None]
+    # uuid: str

--- a/plugins/module_utils/virtual_disk.py
+++ b/plugins/module_utils/virtual_disk.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+
+__metaclass__ = type
+
+from ..module_utils.typed_classes import (
+    TypedVirtualDiskFromAnsible,
+    TypedVirtualDiskToAnsible,
+)
+from typing import Union, Dict, List, Any
+
+from .rest_client import RestClient
+from ..module_utils.utils import PayloadMapper
+
+
+class VirtualDisk(PayloadMapper):
+    def __init__(
+        self,
+        name: Union[str, None] = None,
+        uuid: Union[str, None] = None,
+        block_size: Union[int, None] = None,
+        size: Union[int, None] = None,
+        # allocated_size: int = None,
+        replication_factor: Union[int, None] = None,
+    ):
+        self.name = name
+        self.uuid = uuid
+        self.block_size = block_size
+        self.size = size
+        # self.allocated_size = allocated_size
+        self.replication_factor = replication_factor
+
+    @classmethod
+    def from_ansible(cls, ansible_data: TypedVirtualDiskFromAnsible) -> VirtualDisk:
+        return cls(
+            name=ansible_data["name"],
+        )
+
+    @classmethod
+    def from_hypercore(cls, hypercore_data: Dict[Any, Any]) -> VirtualDisk:
+        return cls(
+            name=hypercore_data["name"],
+            uuid=hypercore_data["uuid"],
+            block_size=hypercore_data["blockSize"],
+            size=hypercore_data["capacityBytes"],
+            # allocated_size=hypercore_data["totalAllocationBytes"],
+            replication_factor=hypercore_data["replicationFactor"],
+        )
+
+    def to_hypercore(self) -> Dict[Any, Any]:
+        raise NotImplementedError()
+        # return dict(
+        #     searchDomains=self.search_domains,
+        #     serverIPs=self.server_ips,
+        # )
+
+    def to_ansible(self) -> TypedVirtualDiskToAnsible:
+        return dict(
+            name=self.name,
+            uuid=self.uuid,
+            block_size=self.block_size,
+            size=self.size,
+            # allocated_size=self.allocated_size,
+            replication_factor=self.replication_factor,
+        )
+
+    # This method is here for testing purposes!
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, VirtualDisk):
+            return NotImplemented
+        return all(
+            (
+                self.uuid == other.uuid,
+                self.name == other.name,
+                self.block_size == other.block_size,
+                self.size == other.size,
+                # self.allocated_size == other.allocated_size,
+                self.replication_factor == other.replication_factor,
+            )
+        )
+
+    # @classmethod
+    # def get_by_uuid(cls, ansible_dict, rest_client, must_exist=False):
+    #     query = get_query(ansible_dict, "uuid", ansible_hypercore_map=dict(uuid="uuid"))
+    #     hypercore_dict = rest_client.get_record(
+    #         "/rest/v1/VirtualDisk", query, must_exist=must_exist
+    #     )
+    #     virtual_disk = VirtualDisk.from_hypercore(hypercore_dict)
+    #     return virtual_disk
+
+    @classmethod
+    def get_state(
+        cls, rest_client: RestClient, query: Dict[Any, Any]
+    ) -> List[TypedVirtualDiskToAnsible]:
+        state = [
+            VirtualDisk.from_hypercore(hypercore_data=hypercore_dict).to_ansible()
+            for hypercore_dict in rest_client.list_records(
+                "/rest/v1/VirtualDisk", query
+            )
+        ]
+        return state

--- a/plugins/modules/virtual_disk_info.py
+++ b/plugins/modules/virtual_disk_info.py
@@ -67,6 +67,12 @@ from ..module_utils.rest_client import RestClient, CachedRestClient
 from ..module_utils.utils import get_query
 from ..module_utils.virtual_disk import VirtualDisk
 
+from ..module_utils.hypercore_version import (
+    HyperCoreVersion,
+)
+
+HYPERCORE_VERSION_REQUIREMENTS = ">=9.2.10"
+
 
 def run(
     module: AnsibleModule, rest_client: RestClient
@@ -90,6 +96,10 @@ def main() -> None:
     try:
         client = Client.get_client(module.params["cluster_instance"])
         rest_client = CachedRestClient(client)
+        hcversion = HyperCoreVersion(rest_client)
+        if not hcversion.verify(HYPERCORE_VERSION_REQUIREMENTS):
+            msg = f"HyperCore server version={hcversion.version} does not match required version {HYPERCORE_VERSION_REQUIREMENTS}"
+            module.fail_json(msg=msg)
         records = run(module, rest_client)
         module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:

--- a/plugins/modules/virtual_disk_info.py
+++ b/plugins/modules/virtual_disk_info.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: virtual_disk_info
+
+author:
+  - Justin Cinkelj (@justinc1)
+short_description: List DNS configuration on HyperCore API
+description:
+  - Use this module to list virtual disk on a HyperCore server.
+version_added: 1.2.0
+extends_documentation_fragment:
+  - scale_computing.hypercore.cluster_instance
+seealso:
+  - module: scale_computing.hypercore.virtual_disk
+options:
+  name:
+    type: str
+    description:
+      - Virtual disk name.
+      - If specified, the virtual disk with that specific name will get returned.
+      - Otherwise, all virtual disks are going to get listed.
+"""
+
+
+EXAMPLES = r"""
+- name: List all virtual disks
+  scale_computing.hypercore.virtual_disk_info:
+
+- name: List a single virtual disk
+  scale_computing.hypercore.virtual_disk_info:
+    name: demo-virtual-disk
+"""
+
+RETURN = r"""
+records:
+  description:
+    - A list of virtual_disk records.
+  returned: success
+  type: list
+  sample:
+    name: demo-virtual-disk
+    block_size: 1048576
+    size: 1073741824
+    replication_factor: 2
+    uuid: 7983b298-c37a-4c99-8dfe-b2952e81b092
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from typing import List
+
+from ..module_utils.typed_classes import (
+    TypedVirtualDiskToAnsible,
+)
+from ..module_utils import errors, arguments
+from ..module_utils.client import Client
+from ..module_utils.rest_client import RestClient, CachedRestClient
+from ..module_utils.utils import get_query
+from ..module_utils.virtual_disk import VirtualDisk
+
+
+def run(
+    module: AnsibleModule, rest_client: RestClient
+) -> List[TypedVirtualDiskToAnsible]:
+    query = get_query(module.params, "name", ansible_hypercore_map=dict(name="name"))
+    return VirtualDisk.get_state(rest_client, query)
+
+
+def main() -> None:
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("cluster_instance"),
+            name=dict(
+                type="str",
+                required=False,
+            ),
+        ),
+    )
+
+    try:
+        client = Client.get_client(module.params["cluster_instance"])
+        rest_client = CachedRestClient(client)
+        records = run(module, rest_client)
+        module.exit_json(changed=False, records=records)
+    except errors.ScaleComputingError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/virtual_disk_info/tasks/main.yml
+++ b/tests/integration/targets/virtual_disk_info/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_username }}"
+    SC_PASSWORD: "{{ sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+  vars:
+    image_filename: "ci-test-virtual-disk-1.qcow2"
+
+  block:
+    # --------------------------------------------------------------------
+    # Prepare one disk with known content
+    - name: List all virtual disks using API module
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/VirtualDisk
+      register: api_virtual_disk_result
+
+    - name: Upload new virtual disk with name {{ image_filename }} if it is missing
+      when: image_filename not in api_virtual_disk_result.record | map(attribute='name')
+      block:
+        - name: Create image
+          ansible.builtin.command: qemu-img create /tmp/{{ image_filename }}.uncompressed 1G
+        - name: Compress image
+          ansible.builtin.command: qemu-img convert -c -O qcow2 /tmp/{{ image_filename }}.uncompressed /tmp/{{ image_filename }}
+
+        - name: Get the Virtual Disk size
+          ansible.builtin.stat:
+            path: /tmp/{{ image_filename }}
+          register: disk_file_info
+
+        - name: Upload Virtual Disk {{ image_filename }} to HyperCore
+          scale_computing.hypercore.api:
+            action: put
+            endpoint: /rest/v1/VirtualDisk/upload
+            data:
+              filename: "{{ image_filename }}"
+              filesize: "{{ disk_file_info.stat.size }}"
+            source: /tmp/{{ image_filename }}
+          register: upload_result
+
+    # --------------------------------------------------------------------
+    # Test
+    - name: List all virtual disks
+      scale_computing.hypercore.virtual_disk_info:
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is succeeded
+          - result is not changed
+          - result.records | length >= 1
+          - result.records.0.keys() | sort == ['block_size', 'name', 'replication_factor', 'size', 'uuid']
+
+    - name: List a single virtual disk
+      scale_computing.hypercore.virtual_disk_info:
+        name: "{{ image_filename }}"
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is succeeded
+          - result is not changed
+          - result.records | length == 1
+          - result.records.0.block_size == 1048576
+          - result.records.0.size == 1073741824
+          - result.records.0.name == "{{ image_filename }}"
+          - result.records.0.replication_factor == 2
+          - result.records.0.uuid | length == 36
+
+    - name: List a non-existent virtual disk
+      scale_computing.hypercore.virtual_disk_info:
+        name: "{{ image_filename }}-no-such-disk-2897gfabv9o7i6w4e"
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - result is succeeded
+          - result is not changed
+          - result.records | length == 0
+
+    # --------------------------------------------------------------------
+    # Cleanup - not needed

--- a/tests/unit/plugins/module_utils/test_hypercore_version.py
+++ b/tests/unit/plugins/module_utils/test_hypercore_version.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2022, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.hypercore_version import (
+    HyperCoreVersion,
+    Version,
+    VersionSpecSimple,
+    VersionSpec,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="requires python3.8 or higher"
+)
+
+
+class TestHyperCoreVersion:
+    def test_simple(self):
+        hcversion = HyperCoreVersion(None)
+        hcversion._version = "9.1.10.2345"
+        assert hcversion.verify(">1.2.3") is True
+
+        assert hcversion.verify("==9.1.10") is True
+        assert hcversion.verify(">=9.1.10") is True
+        assert hcversion.verify(">9.1.10") is False
+
+        assert hcversion.verify("<9.2.0") is True
+        assert hcversion.verify(">9.2.0") is False
+        assert hcversion.verify(">=9.2.0") is False
+        assert hcversion.verify(">=9.2.0") is False
+
+        assert hcversion.verify("<9.2.10") is True
+        assert hcversion.verify(">9.2.10") is False
+        assert hcversion.verify(">=9.2.10") is False
+        assert hcversion.verify(">=9.2.10") is False
+
+    @pytest.mark.parametrize(
+        ("version", "expected_result"),
+        [
+            ["8.9.10.2345", False],
+            ["9.0.10.2345", False],
+            ["9.1.8.2345", False],
+            ["9.1.9.2345", True],
+            ["9.1.10.2345", True],
+            ["9.2.9.2345", False],
+            ["9.2.10.2345", True],
+            ["9.2.11.2345", True],
+        ],
+    )
+    def test_compound(self, version, expected_result):
+        # needed feature was added in 9.2.10 and backported to 9.1.9.
+        hcversion = HyperCoreVersion(None)
+        hcversion._version = version
+        assert hcversion.verify(">=9.1.9 <9.2.0 || >=9.2.10") is expected_result
+
+
+class TestVersion:
+    def test_parts(self):
+        version_str = "8.9.10"
+        version = Version(version_str)
+        assert [8, 9, 10] == version.parts
+
+    @pytest.mark.parametrize(
+        ("v1", "v2", "expected_result"),
+        [
+            # change 1st part
+            ["8.9.10", "7.9.10", False],
+            ["8.9.10", "8.9.10", False],
+            ["8.9.10", "9.9.10", True],
+            # change 2nd part
+            ["8.9.10", "8.8.10", False],
+            ["8.9.10", "8.9.10", False],
+            ["8.9.10", "8.10.10", True],
+            # change 3rd part
+            ["8.9.10", "8.9.9", False],
+            ["8.9.10", "8.9.10", False],
+            ["8.9.10", "8.9.11", True],
+        ],
+    )
+    def test_lt(self, v1, v2, expected_result):
+        assert expected_result == (Version(v1) < Version(v2))
+
+
+class TestVersionSpecSimple:
+    @pytest.mark.parametrize(
+        ("version_str", "spec_str", "expected_result"),
+        [
+            # lt
+            ["9.5.2", "<9.0.10", False],
+            ["9.5.2", "<9.4.10", False],
+            ["9.5.2", "<9.5.1", False],
+            ["9.5.2", "<9.5.2", False],
+            ["9.5.2", "<9.5.3", True],
+            ["9.5.2", "<9.6.0", True],
+            ["9.5.2", "<10.6.0", True],
+            # le
+            ["9.5.2", "<=9.0.10", False],
+            ["9.5.2", "<=9.4.10", False],
+            ["9.5.2", "<=9.5.1", False],
+            ["9.5.2", "<=9.5.2", True],
+            ["9.5.2", "<=9.5.3", True],
+            ["9.5.2", "<=9.6.0", True],
+            ["9.5.2", "<=10.6.0", True],
+            # gt
+            ["9.5.2", ">9.0.10", True],
+            ["9.5.2", ">9.4.10", True],
+            ["9.5.2", ">9.5.1", True],
+            ["9.5.2", ">9.5.2", False],
+            ["9.5.2", ">9.5.3", False],
+            ["9.5.2", ">9.6.0", False],
+            ["9.5.2", ">10.6.0", False],
+            # ge
+            ["9.5.2", ">=9.0.10", True],
+            ["9.5.2", ">=9.4.10", True],
+            ["9.5.2", ">=9.5.1", True],
+            ["9.5.2", ">=9.5.2", True],
+            ["9.5.2", ">=9.5.3", False],
+            ["9.5.2", ">=9.6.0", False],
+            ["9.5.2", ">=10.6.0", False],
+            # eq
+            ["9.5.2", "==9.0.10", False],
+            ["9.5.2", "==9.4.10", False],
+            ["9.5.2", "==9.5.1", False],
+            ["9.5.2", "==9.5.2", True],
+            ["9.5.2", "==9.5.3", False],
+            ["9.5.2", "==9.6.0", False],
+            ["9.5.2", "==10.6.0", False],
+        ],
+    )
+    def test_match(self, version_str, spec_str, expected_result):
+        version = Version(version_str)
+        spec = VersionSpecSimple(spec_str)
+        assert spec.match(version) is expected_result
+
+
+class TestVersionSpec:
+    @pytest.mark.parametrize(
+        ("version_str", "spec_str", "expected_result"),
+        [
+            ["9.0.10", ">=9.1.9 <9.2.0 || >=9.2.10", False],
+            ["9.1.0", ">=9.1.9 <9.2.0 || >=9.2.10", False],
+            ["9.1.8", ">=9.1.9 <9.2.0 || >=9.2.10", False],
+            ["9.1.9", ">=9.1.9 <9.2.0 || >=9.2.10", True],
+            ["9.1.10", ">=9.1.9 <9.2.0 || >=9.2.10", True],
+            ["9.2.0", ">=9.1.9 <9.2.0 || >=9.2.10", False],
+            ["9.2.1", ">=9.1.9 <9.2.0 || >=9.2.10", False],
+            ["9.2.9", ">=9.1.9 <9.2.0 || >=9.2.10", False],
+            ["9.2.10", ">=9.1.9 <9.2.0 || >=9.2.10", True],
+            ["9.2.11", ">=9.1.9 <9.2.0 || >=9.2.10", True],
+            ["9.3.0", ">=9.1.9 <9.2.0 || >=9.2.10", True],
+        ],
+    )
+    def test_match(self, version_str, spec_str, expected_result):
+        # no special constraint means it is OK
+        spec = VersionSpec(spec_str)
+        version = Version(version_str)
+        assert spec.match(version) is expected_result

--- a/tests/unit/plugins/module_utils/test_virtual_disk.py
+++ b/tests/unit/plugins/module_utils/test_virtual_disk.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from copy import deepcopy
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.virtual_disk import (
+    VirtualDisk,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires2.7 or higher"
+)
+
+
+class TestVirtualDisk:
+    def setup_method(self):
+        self.virtual_disk = VirtualDisk(
+            name="vdisk-0",
+            uuid="vdisk-uuid",
+            block_size=1048576,
+            size=104857600,
+            replication_factor=2,
+        )
+        self.from_hypercore_dict = dict(
+            blockSize=1048576,
+            capacityBytes=104857600,
+            name="vdisk-0",
+            replicationFactor=2,
+            totalAllocationBytes=10485760,
+            uuid="vdisk-uuid",
+        )
+        # self.to_hypercore_dict = dict(
+        #     name="vdisk-0",
+        #     uuid="vdisk-uuid",
+        #     block_size=1048576,
+        #     size=104857600,
+        #     replication_factor=2,
+        # )
+        self.to_ansible_dict = dict(
+            name="vdisk-0",
+            uuid="vdisk-uuid",
+            block_size=1048576,
+            size=104857600,
+            replication_factor=2,
+        )
+
+    def test_virtual_disk_to_hypercore(self):
+        with pytest.raises(NotImplementedError):
+            self.virtual_disk.to_hypercore()
+
+    def test_virtual_disk_from_hypercore_dict_not_empty(self):
+        virtual_disk_from_hypercore = VirtualDisk.from_hypercore(
+            self.from_hypercore_dict
+        )
+        assert self.virtual_disk == virtual_disk_from_hypercore
+
+    # def test_virtual_disk_from_hypercore_dict_empty(self):
+    #     assert VirtualDisk.from_hypercore({}) is None
+
+    def test_virtual_disk_to_ansible(self):
+        print(self.virtual_disk.to_ansible())
+        assert self.virtual_disk.to_ansible() == self.to_ansible_dict
+
+    def test_virtual_disk_from_ansible(self):
+        virtual_disk_from_ansible = VirtualDisk.from_ansible(self.from_hypercore_dict)
+        assert "vdisk-0" == virtual_disk_from_ansible.name
+        assert virtual_disk_from_ansible.uuid is None
+        assert virtual_disk_from_ansible.block_size is None
+        assert virtual_disk_from_ansible.size is None
+        assert virtual_disk_from_ansible.replication_factor is None
+
+    def test_get_state(self, rest_client):
+        query = dict()
+        rest_client.list_records.return_value = [self.from_hypercore_dict]
+
+        result = VirtualDisk.get_state(rest_client, query)
+        print(result)
+        assert result == [
+            {
+                "name": "vdisk-0",
+                "uuid": "vdisk-uuid",
+                "block_size": 1048576,
+                "size": 104857600,
+                "replication_factor": 2,
+            }
+        ]
+
+    def test_get_state_more_than_one_record(self, rest_client):
+        expected_result = [
+            {
+                "name": "vdisk-0",
+                "uuid": "vdisk-uuid",
+                "block_size": 1048576,
+                "size": 104857600,
+                "replication_factor": 2,
+            },
+            {
+                "name": "vdisk-1",
+                "uuid": "vdisk-uuid-1",
+                "block_size": 1048576,
+                "size": 104857600,
+                "replication_factor": 2,
+            },
+        ]
+        hypercore_dict_0 = deepcopy(self.from_hypercore_dict)
+        hypercore_dict_1 = deepcopy(self.from_hypercore_dict)
+        hypercore_dict_1.update(
+            {
+                "name": "vdisk-1",
+                "uuid": "vdisk-uuid-1",
+            }
+        )
+        query = dict()
+        rest_client.list_records.return_value = [
+            hypercore_dict_0,
+            hypercore_dict_1,
+        ]
+        result = VirtualDisk.get_state(rest_client, query)
+        assert expected_result == result
+
+    def test_get_state_no_record(self, rest_client):
+        query = dict()
+        rest_client.list_records.return_value = []
+
+        result = VirtualDisk.get_state(rest_client, query)
+        assert result == []

--- a/tests/unit/plugins/modules/test_virtual_disk_info.py
+++ b/tests/unit/plugins/modules/test_virtual_disk_info.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.modules import (
+    virtual_disk_info,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestRun:
+    def test_run(self, create_module, rest_client):
+        module = create_module(
+            params=dict(
+                cluster_instance=dict(
+                    host="https://0.0.0.0",
+                    username="admin",
+                    password="admin",
+                ),
+                name="vdisk-0",
+            )
+        )
+        rest_client.list_records.return_value = [
+            dict(
+                blockSize=1048576,
+                capacityBytes=104857600,
+                name="vdisk-0",
+                replicationFactor=2,
+                totalAllocationBytes=10485760,
+                uuid="vdisk-uuid",
+            )
+        ]
+
+        result = virtual_disk_info.run(module, rest_client)
+        rest_client.list_records.assert_called_once_with(
+            "/rest/v1/VirtualDisk",
+            dict(name="vdisk-0"),
+        )
+        assert result == [
+            dict(
+                name="vdisk-0",
+                uuid="vdisk-uuid",
+                block_size=1048576,
+                size=104857600,
+                replication_factor=2,
+            )
+        ]


### PR DESCRIPTION
Module sample output is:
```
  sample:
    name: demo-virtual-disk
    block_size: 1048576
    size: 1073741824
    replication_factor: 2
    uuid: 7983b298-c37a-4c99-8dfe-b2952e81b092
```

`size` gets value from `capacityBytes` in API response. API field `totalAllocationBytes` is ignored, until it gets clear why it is equal to `capacityBytes`.
