### PR TITLE
Delay integration tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   docs:
-    runs-on: [self-hosted]
+    runs-on: [ubuntu-latest]
     container: python:3.10-slim-buster
     steps:
       - name: Checkout
@@ -25,7 +25,7 @@ jobs:
       - run: cd $WORKDIR && ls -al docs/build/html
 
   sanity-test:
-    runs-on: [self-hosted]
+    runs-on: [ubuntu-latest]
     container: python:3.10-slim-buster
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
       - run: cd $WORKDIR && ansible-test sanity
 
   units-test:
-    runs-on: [self-hosted]
+    runs-on: [ubuntu-latest]
     container: python:3.10-slim-buster
     steps:
       - name: Checkout

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -101,6 +101,7 @@ jobs:
   integration-test:
     needs:
       - integration-prepare-env
+      - units-test
     runs-on: [self-hosted]
     container: python:3.10-slim-buster
     env:


### PR DESCRIPTION
Integration tests are run after unit tests pass.

Sanity and unit tests do not need HyperCore server, run them on public runners.