### PR TITLE
Add Us11 email alert modules (email_alert, email_alert_info)

### DIFF
--- a/changelogs/fragments/email_alert.yml
+++ b/changelogs/fragments/email_alert.yml
@@ -1,4 +1,4 @@
 ---
 major_changes:
   - Added email_alert and email_alert_info modules.
-    (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/82)
+    (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/99)

--- a/changelogs/fragments/email_alert.yml
+++ b/changelogs/fragments/email_alert.yml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - Added email_alert and email_alert_info modules.
+    (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/82)

--- a/examples/email_alert.yml
+++ b/examples/email_alert.yml
@@ -2,37 +2,16 @@
 # --------------- Module email_alert
 - name: Create Email alert recipient
   scale_computing.hypercore.email_alert:
-    uuid: 8664ed18-c354-4bab-be96-78dae5f6377f # required; required if (state=test)
-    email_address: example@example.com # required
-    resend_delay: 86400 # not required
-    silent_period: 900 # not required
+    email: example@example.com
     state: present # absent, test --> create, delete, test
 
-# only ONE of the following parameters are required:
-# - uuid
-# - email_address
-
-# If parameter uuid is provided
-# - if (state=present) change the Email Alert Recipient with that uuid.
-# - if (state=absent)  delete the Email Alert Recipient with that uuid.
-# Else
-# - If (state=present) create a new Email Alert Recipient.
-# - If (state=absent)  delete all Email Alert Recipients with the provided email_address.
-
-# - uuid is not fixed
-# - every email alert recipient has an additional uuid (alertTagUUID),
-#   which seems to always be set to "0" ==> Do I need to make this dynamic/modifyable or
-#   can I just always set it to "0" ??
-
-# --------------- Module email_alert_info
-- name: List all Email alert recipients
-  scale_computing.hypercore.email_alert_info:
-  register: info
-- ansible.builtin.debug:
-    msg: "{{ info }}"
-
-# ------ new example email_alert
-- name: Create Email alert recipient
+- name: Modify previously created Email alert recipient
   scale_computing.hypercore.email_alert:
-    email: old@old.com
-    email_new: new@new.com
+    email: example@example.com
+    email_new: new@example.com
+    state: present
+
+- name: Remove Email alert recipient
+  scale_computing.hypercore.email_alert:
+    email: new@example.com
+    state: absent

--- a/examples/email_alert.yml
+++ b/examples/email_alert.yml
@@ -31,7 +31,6 @@
 - ansible.builtin.debug:
     msg: "{{ info }}"
 
-
 # ------ new example email_alert
 - name: Create Email alert recipient
   scale_computing.hypercore.email_alert:

--- a/examples/email_alert.yml
+++ b/examples/email_alert.yml
@@ -1,0 +1,39 @@
+---
+# --------------- Module email_alert
+- name: Create Email alert recipient
+  scale_computing.hypercore.email_alert:
+    uuid: 8664ed18-c354-4bab-be96-78dae5f6377f # required; required if (state=test)
+    email_address: example@example.com # required
+    resend_delay: 86400 # not required
+    silent_period: 900 # not required
+    state: present # absent, test --> create, delete, test
+
+# only ONE of the following parameters are required:
+# - uuid
+# - email_address
+
+# If parameter uuid is provided
+# - if (state=present) change the Email Alert Recipient with that uuid.
+# - if (state=absent)  delete the Email Alert Recipient with that uuid.
+# Else
+# - If (state=present) create a new Email Alert Recipient.
+# - If (state=absent)  delete all Email Alert Recipients with the provided email_address.
+
+# - uuid is not fixed
+# - every email alert recipient has an additional uuid (alertTagUUID),
+#   which seems to always be set to "0" ==> Do I need to make this dynamic/modifyable or
+#   can I just always set it to "0" ??
+
+# --------------- Module email_alert_info
+- name: List all Email alert recipients
+  scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.debug:
+    msg: "{{ info }}"
+
+
+# ------ new example email_alert
+- name: Create Email alert recipient
+  scale_computing.hypercore.email_alert:
+    email: old@old.com
+    email_new: new@new.com

--- a/examples/email_alert.yml
+++ b/examples/email_alert.yml
@@ -5,6 +5,11 @@
     email: example@example.com
     state: present # absent, test --> create, delete, test
 
+- name: Send a test email
+  scale_computing.hypercore.email_alert:
+    email: example@example.com
+    state: test
+
 - name: Modify previously created Email alert recipient
   scale_computing.hypercore.email_alert:
     email: example@example.com

--- a/examples/email_alert_info.yml
+++ b/examples/email_alert_info.yml
@@ -1,0 +1,6 @@
+---
+- name: List all Email alert recipients
+  scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.debug:
+    msg: "{{ info }}"

--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from .rest_client import RestClient
+from ..module_utils.utils import PayloadMapper, get_query
+from ..module_utils import errors
+
+
+class EmailAlert(PayloadMapper):
+    def __init__(
+        self,
+        uuid: str = None,
+        alert_tag_uuid: str = None,
+        email_address: str = None,
+        resend_delay: int = None,
+        silent_period: int = None,
+        latest_task_tag: {} = None,
+    ):
+        self.uuid = uuid
+        self.alert_tag_uuid = alert_tag_uuid
+        self.email_address = email_address
+        self.resend_delay = resend_delay
+        self.silent_period = silent_period
+        self.latest_task_tag = latest_task_tag if latest_task_tag is not None else {}
+
+    @classmethod
+    def from_ansible(cls, ansible_data):
+        return EmailAlert(
+            uuid=ansible_data["uuid"],
+            alert_tag_uuid=ansible_data["alertTagUUID"],
+            email_address=ansible_data["emailAddress"],
+            resend_delay=ansible_data["resendDelay"],
+            silent_period=ansible_data["silentPeriod"],
+            latest_task_tag=ansible_data["latestTaskTag"],
+        )
+
+    @classmethod
+    def from_hypercore(cls, hypercore_data):
+        if not hypercore_data:
+            return None
+
+        return cls(
+            uuid=hypercore_data["uuid"],
+            alert_tag_uuid=hypercore_data["alertTagUUID"],
+            email_address=hypercore_data["emailAddress"],
+            resend_delay=hypercore_data["resendDelay"],
+            silent_period=hypercore_data["silentPeriod"],
+            latest_task_tag=hypercore_data["latestTaskTag"],
+        )
+
+    def to_hypercore(self):
+        return dict(
+            alertTagUUID=self.alert_tag_uuid,
+            emailAddress=self.email_address,
+            resendDelay=self.resend_delay,
+            silentPeriod=self.silent_period,
+        )
+
+    def to_ansible(self):
+        return dict(
+            uuid=self.uuid,
+            alert_tag_uuid=self.alert_tag_uuid,
+            email_address=self.email_address,
+            resend_delay=self.resend_delay,
+            silent_period=self.silent_period,
+            latest_task_tag=self.latest_task_tag,
+        )
+
+    # This method is here for testing purposes!
+    def __eq__(self, other):
+        return all(
+            (
+                self.uuid == other.uuid,
+                self.alert_tag_uuid == other.alert_tag_uuid,
+                self.email_address == other.email_address,
+                self.resend_delay == other.resend_delay,
+                self.silent_period == other.silent_period,
+                self.latest_task_tag == other.latest_task_tag,
+            )
+        )
+
+    @classmethod
+    def get_by_uuid(cls, ansible_dict, rest_client, must_exist=False):
+        query = get_query(ansible_dict, "uuid", ansible_hypercore_map=dict(uuid="uuid"))
+        hypercore_dict = rest_client.get_record(
+            "/rest/v1/AlertEmailTarget", query, must_exist=must_exist
+        )
+        alert_email_from_hypercore = EmailAlert.from_hypercore(hypercore_dict)
+        return alert_email_from_hypercore
+
+    @classmethod
+    def get_by_email(cls, ansible_dict, rest_client, must_exist=False):
+        query = get_query(ansible_dict, "email_address", ansible_hypercore_map=dict(email_address="emailAddress"))
+        hypercore_dict = rest_client.get_record(
+            "/rest/v1/AlertEmailTarget", query, must_exist=must_exist
+        )
+
+        alert_email_from_hypercore = EmailAlert.from_hypercore(hypercore_dict)
+        return alert_email_from_hypercore
+
+    @classmethod
+    def get_state(cls, rest_client):
+        state = [
+            EmailAlert.from_hypercore(hypercore_data=hypercore_dict).to_ansible()
+            for hypercore_dict in rest_client.list_records("/rest/v1/AlertEmailTarget/")
+        ]
+
+        return state
+
+    @classmethod
+    def create(cls, rest_client: RestClient, payload, check_mode=False):
+        rest_client.create_record("/rest/v1/AlertEmailTarget/", payload, check_mode)
+
+    def update(self, rest_client: RestClient, payload, check_mode=False):
+        rest_client.update_record(f"/rest/v1/AlertEmailTarget/{self.uuid}", payload, check_mode)
+
+    def delete(self, rest_client: RestClient, check_mode=False):
+        rest_client.delete_record(f"/rest/v1/AlertEmailTarget/{self.uuid}", check_mode)

--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -96,7 +96,11 @@ class EmailAlert(PayloadMapper):
 
     @classmethod
     def get_by_email(cls, ansible_dict, rest_client, must_exist=False):
-        query = get_query(ansible_dict, "email_address", ansible_hypercore_map=dict(email_address="emailAddress"))
+        query = get_query(
+            ansible_dict,
+            "email_address",
+            ansible_hypercore_map=dict(email_address="emailAddress"),
+        )
         hypercore_dict = rest_client.get_record(
             "/rest/v1/AlertEmailTarget", query, must_exist=must_exist
         )
@@ -118,7 +122,9 @@ class EmailAlert(PayloadMapper):
         rest_client.create_record("/rest/v1/AlertEmailTarget/", payload, check_mode)
 
     def update(self, rest_client: RestClient, payload, check_mode=False):
-        rest_client.update_record(f"/rest/v1/AlertEmailTarget/{self.uuid}", payload, check_mode)
+        rest_client.update_record(
+            f"/rest/v1/AlertEmailTarget/{self.uuid}", payload, check_mode
+        )
 
     def delete(self, rest_client: RestClient, check_mode=False):
         rest_client.delete_record(f"/rest/v1/AlertEmailTarget/{self.uuid}", check_mode)

--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -9,7 +9,6 @@ __metaclass__ = type
 
 from .rest_client import RestClient
 from ..module_utils.utils import PayloadMapper, get_query
-from ..module_utils import errors
 
 
 class EmailAlert(PayloadMapper):

--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -10,16 +10,23 @@ __metaclass__ = type
 from .rest_client import RestClient
 from ..module_utils.utils import PayloadMapper, get_query
 
+from ..module_utils.typed_classes import (
+    TypedTaskTag,
+    TypedEmailAlertToAnsible,
+    TypedEmailAlertFromAnsible,
+)
+from typing import Union, Any, Dict
+
 
 class EmailAlert(PayloadMapper):
     def __init__(
         self,
-        uuid: str = None,
-        alert_tag_uuid: str = None,
-        email_address: str = None,
-        resend_delay: int = None,
-        silent_period: int = None,
-        latest_task_tag: {} = None,
+        uuid: Union[str, None] = None,
+        alert_tag_uuid: Union[str, None] = None,
+        email_address: Union[str, None] = None,
+        resend_delay: Union[int, None] = None,
+        silent_period: Union[int, None] = None,
+        latest_task_tag: Union[TypedTaskTag, dict[Any, Any], None] = None,
     ):
         self.uuid = uuid
         self.alert_tag_uuid = alert_tag_uuid
@@ -29,21 +36,20 @@ class EmailAlert(PayloadMapper):
         self.latest_task_tag = latest_task_tag if latest_task_tag is not None else {}
 
     @classmethod
-    def from_ansible(cls, ansible_data):
+    def from_ansible(cls, ansible_data: TypedEmailAlertFromAnsible):
         return EmailAlert(
             uuid=ansible_data["uuid"],
-            alert_tag_uuid=ansible_data["alertTagUUID"],
-            email_address=ansible_data["emailAddress"],
-            resend_delay=ansible_data["resendDelay"],
-            silent_period=ansible_data["silentPeriod"],
-            latest_task_tag=ansible_data["latestTaskTag"],
+            alert_tag_uuid=ansible_data["alert_tag_uuid"],
+            email_address=ansible_data["email_address"],
+            resend_delay=ansible_data["resend_delay"],
+            silent_period=ansible_data["silent_period"],
+            latest_task_tag=ansible_data["latest_task_tag"],
         )
 
     @classmethod
-    def from_hypercore(cls, hypercore_data):
+    def from_hypercore(cls, hypercore_data: dict[Any, Any]):
         if not hypercore_data:
             return None
-
         return cls(
             uuid=hypercore_data["uuid"],
             alert_tag_uuid=hypercore_data["alertTagUUID"],
@@ -53,7 +59,7 @@ class EmailAlert(PayloadMapper):
             latest_task_tag=hypercore_data["latestTaskTag"],
         )
 
-    def to_hypercore(self):
+    def to_hypercore(self) -> dict[Any, Any]:
         return dict(
             alertTagUUID=self.alert_tag_uuid,
             emailAddress=self.email_address,
@@ -61,7 +67,7 @@ class EmailAlert(PayloadMapper):
             silentPeriod=self.silent_period,
         )
 
-    def to_ansible(self):
+    def to_ansible(self) -> TypedEmailAlertToAnsible:
         return dict(
             uuid=self.uuid,
             alert_tag_uuid=self.alert_tag_uuid,
@@ -72,7 +78,9 @@ class EmailAlert(PayloadMapper):
         )
 
     # This method is here for testing purposes!
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, EmailAlert):
+            return NotImplemented
         return all(
             (
                 self.uuid == other.uuid,
@@ -85,16 +93,26 @@ class EmailAlert(PayloadMapper):
         )
 
     @classmethod
-    def get_by_uuid(cls, ansible_dict, rest_client, must_exist=False):
+    def get_by_uuid(
+        cls,
+        ansible_dict: Dict[Any, Any],
+        rest_client: RestClient,
+        must_exist: bool = False,
+    ):
         query = get_query(ansible_dict, "uuid", ansible_hypercore_map=dict(uuid="uuid"))
         hypercore_dict = rest_client.get_record(
             "/rest/v1/AlertEmailTarget", query, must_exist=must_exist
         )
-        alert_email_from_hypercore = EmailAlert.from_hypercore(hypercore_dict)
+        alert_email_from_hypercore = cls.from_hypercore(hypercore_dict)
         return alert_email_from_hypercore
 
     @classmethod
-    def get_by_email(cls, ansible_dict, rest_client, must_exist=False):
+    def get_by_email(
+        cls,
+        ansible_dict: Dict[Any, Any],
+        rest_client: RestClient,
+        must_exist: bool = False,
+    ):
         query = get_query(
             ansible_dict,
             "email_address",
@@ -108,7 +126,10 @@ class EmailAlert(PayloadMapper):
         return alert_email_from_hypercore
 
     @classmethod
-    def get_state(cls, rest_client):
+    def get_state(
+        cls,
+        rest_client: RestClient,
+    ):
         state = [
             EmailAlert.from_hypercore(hypercore_data=hypercore_dict).to_ansible()
             for hypercore_dict in rest_client.list_records("/rest/v1/AlertEmailTarget/")
@@ -117,13 +138,27 @@ class EmailAlert(PayloadMapper):
         return state
 
     @classmethod
-    def create(cls, rest_client: RestClient, payload, check_mode=False):
+    def create(
+        cls,
+        rest_client: RestClient,
+        payload: Dict[Any, Any],
+        check_mode: bool = False,
+    ) -> None:
         rest_client.create_record("/rest/v1/AlertEmailTarget/", payload, check_mode)
 
-    def update(self, rest_client: RestClient, payload, check_mode=False):
+    def update(
+        self,
+        rest_client: RestClient,
+        payload: Dict[Any, Any],
+        check_mode: bool = False,
+    ) -> None:
         rest_client.update_record(
             f"/rest/v1/AlertEmailTarget/{self.uuid}", payload, check_mode
         )
 
-    def delete(self, rest_client: RestClient, check_mode=False):
+    def delete(
+        self,
+        rest_client: RestClient,
+        check_mode: bool = False,
+    ) -> None:
         rest_client.delete_record(f"/rest/v1/AlertEmailTarget/{self.uuid}", check_mode)

--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 __metaclass__ = type
 

--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from .rest_client import RestClient
+
+# from .client import Client
 from ..module_utils.utils import PayloadMapper, get_query
 
 from ..module_utils.typed_classes import (
@@ -162,3 +164,12 @@ class EmailAlert(PayloadMapper):
         check_mode: bool = False,
     ) -> None:
         rest_client.delete_record(f"/rest/v1/AlertEmailTarget/{self.uuid}", check_mode)
+
+    def test(
+        self,
+        rest_client: RestClient,
+    ) -> TypedTaskTag:
+        response = rest_client.client.post(
+            f"/rest/v1/AlertEmailTarget/{self.uuid}/test", None
+        )
+        return response

--- a/plugins/module_utils/typed_classes.py
+++ b/plugins/module_utils/typed_classes.py
@@ -104,3 +104,21 @@ class TypedSmtpFromAnsible(TypedDict):
     auth_password: Union[str, None]
     from_address: Union[str, None]
     latest_task_tag: Union[TypedTaskTag, None]
+
+
+class TypedEmailAlertToAnsible(TypedDict):
+    uuid: Union[str, None]
+    alert_tag_uuid: Union[str, None]
+    email_address: Union[str, None]
+    resend_delay: Union[int, None]
+    silent_period: Union[int, None]
+    latest_task_tag: Union[TypedTaskTag, dict[Any, Any], None]
+
+
+class TypedEmailAlertFromAnsible(TypedDict):
+    uuid: Union[str, None]
+    alert_tag_uuid: Union[str, None]
+    email_address: Union[str, None]
+    resend_delay: Union[int, None]
+    silent_period: Union[int, None]
+    latest_task_tag: Union[TypedTaskTag, None]

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -1,0 +1,219 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: email_alert
+
+author:
+  - Ana Zobec (@anazobec)
+short_description: Create, update, delete or send test emails to Email Alert Recipients on HyperCore API.
+description:
+  - Use this module to create, update, delete or send test emails to the
+    Email Alert Recipients configuration on HyperCore API.
+version_added: 1.2.0
+extends_documentation_fragment:
+  - scale_computing.hypercore.cluster_instance
+seealso:
+  - module: scale_computing.hypercore.email_alert_info
+options:
+  email:
+    type: str
+    description:
+      - An Email address of a recipient you wish to create, update, delete or send test emails to.
+    required: True
+  email_new:
+    type: str
+    description:
+      - An Email address with which the existing email on the HyperCore API will be updated.
+  state:
+    type: str
+    choices: [ present, absent, test ]
+    description:
+      - The desired state of the email alert recipient on HyperCore API.
+      - If I(state=present) and C(email_new) wasn't provided, 
+        a new Email Alert Recipient will be added on the HyperCore API.
+      - If I(state=absent), the Email Alert Recipient with the provided
+        C(email) will be removed from HyperCore API.
+      - If I(state=test), a test email will be sent to the provided
+        Email Alert Recipient on HyperCore API.
+    required: True
+notes:
+ - C(check_mode) is not supported.
+"""
+
+
+EXAMPLES = r"""
+- name: Create a new Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: example@example.com
+    state: present
+
+- name: Update previously create Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: example@example.com
+    email_new: new@example.com
+    state: present
+    
+- name: Remove previously updated Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: new@example.com
+    state: absent
+    
+- name: Send a test email to an Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: recipient@example.com
+    state: test
+"""
+
+RETURN = r"""
+records:
+  description:
+    - Output from modifying entries of the Email Alert Recipients on HyperCore API.
+  returned: success
+  type: list
+  sample:
+    - alert_tag_uuid: 0
+      email_address: sample@sample.com
+      latest_task_tag:
+        completed: 1675680830
+        created: 1675680830
+        descriptionParameters: []
+        formattedDescription: Create Alert Email Target
+        formattedMessage: ""
+        messageParameters: []
+        modified: 1675680830
+        nodeUUIDs: []
+        objectUUID: 8664ed18-c354-4bab-be96-78dae5f6377f
+        progressPercent: 100
+        sessionID: 2bed8c34-1ef3-4366-8895-360f4f786afe
+        state: COMPLETE
+        taskTag: 813
+      resend_delay: 86400
+      silent_period: 900
+      uuid: 8664ed18-c354-4bab-be96-78dae5f6377f
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from typing import Tuple
+
+from ..module_utils import arguments, errors
+from ..module_utils.client import Client
+from ..module_utils.rest_client import RestClient
+from ..module_utils.email_alert import EmailAlert
+
+
+def create_email_alert(module: AnsibleModule, rest_client: RestClient):
+    before = EmailAlert.get_state(rest_client)
+    for item in before:
+        module.warn(str(item))
+        if item.get("email_address") == module.params["email"]:
+            return False, before, dict(before=before, after=before)
+    EmailAlert.create(
+        rest_client=rest_client,
+        payload=dict(
+            emailAddress=module.params["email"]
+        ),
+        check_mode=module.check_mode,
+    )
+    after = EmailAlert.get_state(rest_client)
+    return after != before, after, dict(before=before, after=after)  # changed, records, diff
+
+
+def update_email_alert(module: AnsibleModule, rest_client: RestClient):
+    before = EmailAlert.get_state(rest_client)  # get the records of emailAlert endpoint before update
+
+    # Get record of old emailAlert by email
+    old_email = EmailAlert.get_by_email(dict(email_address=module.params["email"]), rest_client)
+
+    if not old_email:
+        old_email = EmailAlert.get_by_email(dict(email_address=module.params["email_new"]), rest_client)
+        if not old_email:
+            raise errors.ScaleComputingError("Email Alert: Can't update a nonexistent email.")
+
+    # Return if there are no changes
+    if (module.params["email_new"] == old_email.to_ansible().get("email_address")
+            or module.params["email_new"] == module.params["email"]):
+        return False, before, dict(before=before, after=before)
+
+    # Otherwise, update with new email address
+    old_email.update(
+        rest_client=rest_client,
+        payload=dict(
+            emailAddress=module.params["email_new"]
+        ),
+        check_mode=module.check_mode,
+    )
+    after = EmailAlert.get_state(rest_client)  # get the records od emailAlert endpoint after update
+    return after != before, after, dict(before=before, after=after)  # changed, records, diff
+
+
+def delete_email_alert(module: AnsibleModule, rest_client: RestClient):
+    before = EmailAlert.get_state(rest_client)
+    delete_email = EmailAlert.get_by_email(dict(email_address=module.params["email"]), rest_client)
+    if not delete_email:
+        raise errors.ScaleComputingError("Email Alert: The email you're trying to remove, doesn't exist.")
+    delete_email.delete(rest_client, module.check_mode)
+
+    after = EmailAlert.get_state(rest_client)
+    return after != before, after, dict(before=before, after=after)  # changed, records, diff
+
+
+def run(module: AnsibleModule, rest_client: RestClient) -> Tuple[bool, dict, dict]:
+    state = module.params["state"]
+    if state == "present":
+        if module.params["email_new"] is not None:
+            return update_email_alert(module, rest_client)
+        return create_email_alert(module, rest_client)
+    elif state == "absent":
+        return delete_email_alert(module, rest_client)
+    else:  # state == "test"
+        module.warn("state=test not yet implemented.")
+
+    return False, EmailAlert.get_state(rest_client), dict(before=[], after=[])  # changed, records, diff
+
+
+def main() -> None:
+    module = AnsibleModule(
+        supports_check_mode=False,
+        argument_spec=dict(
+            arguments.get_spec("cluster_instance"),
+            email=dict(
+                type="str",
+                required=True,
+            ),
+            email_new=dict(
+                type="str",
+                required=False,
+            ),
+            state=dict(
+                type="str",
+                choices=["present", "absent", "test"],
+                required=True,
+            )
+        ),
+    )
+
+    try:
+        client = Client(
+            host=module.params["cluster_instance"]["host"],
+            username=module.params["cluster_instance"]["username"],
+            password=module.params["cluster_instance"]["password"],
+        )
+        rest_client = RestClient(client)
+        changed, records, diff = run(module, rest_client)
+        module.exit_json(changed=changed, records=records, diff=diff)
+    except errors.ScaleComputingError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -103,7 +103,6 @@ records:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from typing import Tuple
 
 from ..module_utils import arguments, errors
 from ..module_utils.client import Client

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -110,6 +110,10 @@ from ..module_utils.client import Client
 from ..module_utils.rest_client import RestClient
 from ..module_utils.email_alert import EmailAlert
 
+# from ..module_utils.typed_classes import TypedEmailAlertToAnsible, TypedDiff
+
+# from typing import List, Tuple, Union, Dict, Any
+
 
 def create_email_alert(module: AnsibleModule, rest_client: RestClient):
     before = EmailAlert.get_state(rest_client)
@@ -189,7 +193,7 @@ def delete_email_alert(module: AnsibleModule, rest_client: RestClient):
     )  # changed, records, diff
 
 
-def run(module: AnsibleModule, rest_client: RestClient) -> Tuple[bool, dict, dict]:
+def run(module: AnsibleModule, rest_client: RestClient):
     state = module.params["state"]
     if state == "present":
         if module.params["email_new"] is not None:

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -114,57 +114,79 @@ from ..module_utils.email_alert import EmailAlert
 def create_email_alert(module: AnsibleModule, rest_client: RestClient):
     before = EmailAlert.get_state(rest_client)
     for item in before:
-        module.warn(str(item))
         if item.get("email_address") == module.params["email"]:
             return False, before, dict(before=before, after=before)
     EmailAlert.create(
         rest_client=rest_client,
-        payload=dict(
-            emailAddress=module.params["email"]
-        ),
+        payload=dict(emailAddress=module.params["email"]),
         check_mode=module.check_mode,
     )
     after = EmailAlert.get_state(rest_client)
-    return after != before, after, dict(before=before, after=after)  # changed, records, diff
+    return (
+        after != before,
+        after,
+        dict(before=before, after=after),
+    )  # changed, records, diff
 
 
 def update_email_alert(module: AnsibleModule, rest_client: RestClient):
-    before = EmailAlert.get_state(rest_client)  # get the records of emailAlert endpoint before update
+    before = EmailAlert.get_state(
+        rest_client
+    )  # get the records of emailAlert endpoint before update
 
     # Get record of old emailAlert by email
-    old_email = EmailAlert.get_by_email(dict(email_address=module.params["email"]), rest_client)
+    old_email = EmailAlert.get_by_email(
+        dict(email_address=module.params["email"]), rest_client
+    )
 
     if not old_email:
-        old_email = EmailAlert.get_by_email(dict(email_address=module.params["email_new"]), rest_client)
+        old_email = EmailAlert.get_by_email(
+            dict(email_address=module.params["email_new"]), rest_client
+        )
         if not old_email:
-            raise errors.ScaleComputingError("Email Alert: Can't update a nonexistent email.")
+            raise errors.ScaleComputingError(
+                "Email Alert: Can't update a nonexistent email."
+            )
 
     # Return if there are no changes
-    if (module.params["email_new"] == old_email.to_ansible().get("email_address")
-            or module.params["email_new"] == module.params["email"]):
+    if (
+        module.params["email_new"] == old_email.to_ansible().get("email_address")
+        or module.params["email_new"] == module.params["email"]
+    ):
         return False, before, dict(before=before, after=before)
 
     # Otherwise, update with new email address
     old_email.update(
         rest_client=rest_client,
-        payload=dict(
-            emailAddress=module.params["email_new"]
-        ),
+        payload=dict(emailAddress=module.params["email_new"]),
         check_mode=module.check_mode,
     )
-    after = EmailAlert.get_state(rest_client)  # get the records od emailAlert endpoint after update
-    return after != before, after, dict(before=before, after=after)  # changed, records, diff
+    after = EmailAlert.get_state(
+        rest_client
+    )  # get the records od emailAlert endpoint after update
+    return (
+        after != before,
+        after,
+        dict(before=before, after=after),
+    )  # changed, records, diff
 
 
 def delete_email_alert(module: AnsibleModule, rest_client: RestClient):
     before = EmailAlert.get_state(rest_client)
-    delete_email = EmailAlert.get_by_email(dict(email_address=module.params["email"]), rest_client)
+    delete_email = EmailAlert.get_by_email(
+        dict(email_address=module.params["email"]), rest_client
+    )
     if not delete_email:
-        raise errors.ScaleComputingError("Email Alert: The email you're trying to remove, doesn't exist.")
+        module.warn("Email Alert: The email you're trying to remove, doesn't exist.")
+        return False, before, dict(before=before, after=before)
     delete_email.delete(rest_client, module.check_mode)
 
     after = EmailAlert.get_state(rest_client)
-    return after != before, after, dict(before=before, after=after)  # changed, records, diff
+    return (
+        after != before,
+        after,
+        dict(before=before, after=after),
+    )  # changed, records, diff
 
 
 def run(module: AnsibleModule, rest_client: RestClient) -> Tuple[bool, dict, dict]:
@@ -178,7 +200,11 @@ def run(module: AnsibleModule, rest_client: RestClient) -> Tuple[bool, dict, dic
     else:  # state == "test"
         module.warn("state=test not yet implemented.")
 
-    return False, EmailAlert.get_state(rest_client), dict(before=[], after=[])  # changed, records, diff
+    return (
+        False,
+        EmailAlert.get_state(rest_client),
+        dict(before=[], after=[]),
+    )  # changed, records, diff
 
 
 def main() -> None:
@@ -198,7 +224,7 @@ def main() -> None:
                 type="str",
                 choices=["present", "absent", "test"],
                 required=True,
-            )
+            ),
         ),
     )
 

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -38,7 +38,7 @@ options:
     choices: [ present, absent, test ]
     description:
       - The desired state of the email alert recipient on HyperCore API.
-      - If I(state=present) and C(email_new) wasn't provided, 
+      - If I(state=present) and C(email_new) wasn't provided,
         a new Email Alert Recipient will be added on the HyperCore API.
       - If I(state=absent), the Email Alert Recipient with the provided
         C(email) will be removed from HyperCore API.
@@ -61,12 +61,12 @@ EXAMPLES = r"""
     email: example@example.com
     email_new: new@example.com
     state: present
-    
+
 - name: Remove previously updated Email Alert Recipient
   scale_computing.hypercore.email_alert:
     email: new@example.com
     state: absent
-    
+
 - name: Send a test email to an Email Alert Recipient
   scale_computing.hypercore.email_alert:
     email: recipient@example.com

--- a/plugins/modules/email_alert_info.py
+++ b/plugins/modules/email_alert_info.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+module: email_alert_info
+
+author:
+  - Ana Zobec (@anazobec)
+short_description: List Email Alert Recipients on HyperCore API
+description:
+  - Use this module to list information about the DNS configuration on HyperCore API.
+version_added: 1.2.0
+extends_documentation_fragment:
+  - scale_computing.hypercore.cluster_instance
+seealso:
+  - module: scale_computing.hypercore.email_alert
+"""
+
+
+EXAMPLES = r"""
+- name: List all Email Alert Recipients on HyperCore API
+  scale_computing.hypercore.email_alert_info:
+  register: email_alert
+"""
+
+RETURN = r"""
+records:
+  description:
+    - A list of Email Alert Recipient records.
+  returned: success
+  type: list
+  sample:
+    - alert_tag_uuid: 0
+      email_address: sample@sample.com
+      latest_task_tag:
+        completed: 1675680830
+        created: 1675680830
+        descriptionParameters: []
+        formattedDescription: Create Alert Email Target
+        formattedMessage: ""
+        messageParameters: []
+        modified: 1675680830
+        nodeUUIDs: []
+        objectUUID: 8664ed18-c354-4bab-be96-78dae5f6377f
+        progressPercent: 100
+        sessionID: 2bed8c34-1ef3-4366-8895-360f4f786afe
+        state: COMPLETE
+        taskTag: 813
+      resend_delay: 86400
+      silent_period: 900
+      uuid: 8664ed18-c354-4bab-be96-78dae5f6377f
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils import errors, arguments
+from ..module_utils.client import Client
+from ..module_utils.rest_client import RestClient
+from ..module_utils.email_alert import EmailAlert
+
+
+def run(rest_client: RestClient):
+    return EmailAlert.get_state(rest_client)
+
+
+def main():
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            arguments.get_spec("cluster_instance"),
+        ),
+    )
+
+    try:
+        client = Client(
+            host=module.params["cluster_instance"]["host"],
+            username=module.params["cluster_instance"]["username"],
+            password=module.params["cluster_instance"]["password"],
+        )
+        rest_client = RestClient(client)
+        records = run(rest_client)
+        module.exit_json(changed=False, records=records)
+    except errors.ScaleComputingError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/email_alert_info.py
+++ b/plugins/modules/email_alert_info.py
@@ -66,13 +66,15 @@ from ..module_utils import errors, arguments
 from ..module_utils.client import Client
 from ..module_utils.rest_client import RestClient
 from ..module_utils.email_alert import EmailAlert
+from ..module_utils.typed_classes import TypedEmailAlertToAnsible
+from typing import List, Union
 
 
-def run(rest_client: RestClient):
+def run(rest_client: RestClient) -> List[Union[TypedEmailAlertToAnsible, None]]:
     return EmailAlert.get_state(rest_client)
 
 
-def main():
+def main() -> None:
     module = AnsibleModule(
         supports_check_mode=True,
         argument_spec=dict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,12 @@ module = [
     "plugins.inventory.*"
 ]
 disable_error_code = ["no-untyped-def", "no-untyped-call", "assignment", "type-arg", "var-annotated", "import", "misc", "arg-type", "dict-item", "override", "union-attr", "valid-type"]
+
+# TEMP
+[[tool.mypy.overrides]]
+module = [
+    "plugins.modules.email_alert_info",
+    "plugins.modules.email_alert",
+    "plugins.module_utils.email_alert"
+]
+disable_error_code = ["no-untyped-def", "no-untyped-call", "assignment", "type-arg", "var-annotated", "import", "misc", "arg-type", "dict-item", "override", "union-attr", "valid-type", "no-any-return"]

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -5,34 +5,31 @@
     SC_PASSWORD: "{{ sc_password }}"
 
   vars:
-#    starting_email_num: 0
-#    current_email_num: 0
     new_email : new@test.com
     create_email: test@test.com
 
   block:
-    # todo cleanup
-#    - name: Get default emails
-#      scale_computing.hypercore.api:
-#        endpoint: rest/v1/AlertEmailTarget
-#        action: get
-#      register: default_emails
-#    - ansible.builtin.set_fact:
-#        default_emails: default_emails
-#
-#    - name: Preapare for test - cleanup
-#      scale_computing.hypercore.api:
-#        endpoint: rest/v1/AlertEmailTarget
-#        action: post
-
-
-    - name: Get initial number of emails
+    - name: Get starting emails
       scale_computing.hypercore.email_alert_info:
       register: info
     - ansible.builtin.set_fact:
+        starting_emails: "{{ info.records }}"
+
+    - name: Preapare for test - cleanup (also test Remove with loop)
+      scale_computing.hypercore.email_alert:
+        email: "{{ item.email_address }}"
+        state: absent
+      loop: "{{ starting_emails }}"
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - info.records == []
+          - info.records|length == 0|int
+    - ansible.builtin.set_fact:
         starting_email_num: "{{ info.records|length }}"
-    - ansible.builtin.debug:
-        msg: "{{ starting_email_num }}"
+
+    # -----------------------------------------------------------
 
     - name: Create new Email Alert Recipient
       scale_computing.hypercore.email_alert:
@@ -50,6 +47,7 @@
           - result.records != []
           - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
           - info.records|length == starting_email_num|int + 1|int
+          - info.records[0].email_address == "{{ create_email }}"
 
     - name: Create new Email Alert Recipient - idempotence
       scale_computing.hypercore.email_alert:
@@ -78,7 +76,6 @@
           - result.diff.before != result.diff.after
     - ansible.builtin.assert: &test1
         that:
-          - result.changed == True
           - result.records != []
           - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
           - info.records|length == starting_email_num|int + 1|int
@@ -102,6 +99,7 @@
       scale_computing.hypercore.email_alert:
         email: "{{ new_email }}"
         email_new: "{{ new_email }}"
+        state: present
       register: result
     - scale_computing.hypercore.email_alert_info:
       register: info
@@ -123,11 +121,25 @@
       register: info
     - ansible.builtin.assert:
         that:
+          - result.changed == True
+          - result.diff.before != result.diff.after
+    - ansible.builtin.assert: &test2
+        that:
+          - info.records|length == starting_email_num|int
+          - result.records == []
+
+    - name: Remove previously created Email Alert Recipient - idempotence
+      scale_computing.hypercore.email_alert:
+        email: "{{ new_email }}"
+        state: absent
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
           - result.changed == False
           - result.diff.before == result.diff.after
-          - info.records|length == starting_email_num|int
-          - result.records != []
-          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+    - ansible.builtin.assert: *test2
 
 # --------- Not yet implemented ---------
 #    - name: Send test email to an existing Email Alert Recipient
@@ -142,3 +154,11 @@
 #          - result.diff.before == result.diff.after
 #          - info.records|length == current_email_num
 #          - info.records[0].email_address == "new@test.com"
+
+    # -----------------------------------------------------------
+
+    - name: Restore back to default
+      scale_computing.hypercore.email_alert:
+        email: "{{ item.email_address }}"
+        state: present
+      loop: "{{ starting_emails }}"

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -1,0 +1,144 @@
+---
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_username }}"
+    SC_PASSWORD: "{{ sc_password }}"
+
+  vars:
+#    starting_email_num: 0
+#    current_email_num: 0
+    new_email : new@test.com
+    create_email: test@test.com
+
+  block:
+    # todo cleanup
+#    - name: Get default emails
+#      scale_computing.hypercore.api:
+#        endpoint: rest/v1/AlertEmailTarget
+#        action: get
+#      register: default_emails
+#    - ansible.builtin.set_fact:
+#        default_emails: default_emails
+#
+#    - name: Preapare for test - cleanup
+#      scale_computing.hypercore.api:
+#        endpoint: rest/v1/AlertEmailTarget
+#        action: post
+
+
+    - name: Get initial number of emails
+      scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.set_fact:
+        starting_email_num: "{{ info.records|length }}"
+    - ansible.builtin.debug:
+        msg: "{{ starting_email_num }}"
+
+    - name: Create new Email Alert Recipient
+      scale_computing.hypercore.email_alert:
+        email: "{{ create_email }}"
+        state: present
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - result.diff.before != result.diff.after
+    - ansible.builtin.assert: &test0
+        that:
+          - result.records != []
+          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+          - info.records|length == starting_email_num|int + 1|int
+
+    - name: Create new Email Alert Recipient - idempotence
+      scale_computing.hypercore.email_alert:
+        email: "{{ create_email }}"
+        state: present
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+    - ansible.builtin.assert: *test0
+
+    - name: Modify existing Email Alert Recipient
+      scale_computing.hypercore.email_alert:
+        email: "{{ create_email }}"
+        email_new: "{{ new_email }}"
+        state: present
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - result.diff.before != result.diff.after
+    - ansible.builtin.assert: &test1
+        that:
+          - result.changed == True
+          - result.records != []
+          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+          - info.records|length == starting_email_num|int + 1|int
+
+    - name: Modify existing Email Alert Recipient - idempotence
+      scale_computing.hypercore.email_alert:
+        email: "{{ create_email }}"
+        email_new: "{{ new_email }}"
+        state: present
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+    - ansible.builtin.assert: *test1
+
+
+    - name: Modify existing Email Alert Recipient - with same emails
+      scale_computing.hypercore.email_alert:
+        email: "{{ new_email }}"
+        email_new: "{{ new_email }}"
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+          - info.records|length == starting_email_num|int + 1|int
+          - result.records != []
+          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+
+
+    - name: Remove previously created Email Alert Recipient
+      scale_computing.hypercore.email_alert:
+        email: "{{ new_email }}"
+        state: absent
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+          - info.records|length == starting_email_num|int
+          - result.records != []
+          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+
+# --------- Not yet implemented ---------
+#    - name: Send test email to an existing Email Alert Recipient
+#      scale_computing.hypercore.email_alert:
+#        email: new@test.com
+#        state: test
+#    - scale_computing.hypercore.email_alert_info:
+#      register: info
+#    - ansible.builtin.assert:
+#        that:
+#          - result.changed == False
+#          - result.diff.before == result.diff.after
+#          - info.records|length == current_email_num
+#          - info.records[0].email_address == "new@test.com"

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -15,7 +15,7 @@
     - ansible.builtin.set_fact:
         starting_emails: "{{ info.records }}"
 
-    - name: Preapare for test - cleanup (also test Remove with loop)
+    - name: Prepare for test - cleanup (also test Remove with loop)
       scale_computing.hypercore.email_alert:
         email: "{{ item.email_address }}"
         state: absent
@@ -26,8 +26,6 @@
         that:
           - info.records == []
           - info.records|length == 0|int
-    - ansible.builtin.set_fact:
-        starting_email_num: "{{ info.records|length }}"
 
     # -----------------------------------------------------------
 
@@ -48,7 +46,7 @@
           - result.records[0].keys() | sort ==
             ['alert_tag_uuid', 'email_address', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']
-          - info.records|length == starting_email_num|int + 1|int
+          - info.records|length == 1|int
           - info.records[0].email_address == "{{ create_email }}"
 
     - name: Create new Email Alert Recipient - idempotence
@@ -82,7 +80,7 @@
           - result.records[0].keys() | sort ==
             ['alert_tag_uuid', 'email_address', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']
-          - info.records|length == starting_email_num|int + 1|int
+          - info.records|length == 1|int
 
     - name: Modify existing Email Alert Recipient - idempotence
       scale_computing.hypercore.email_alert:
@@ -111,7 +109,7 @@
         that:
           - result.changed == False
           - result.diff.before == result.diff.after
-          - info.records|length == starting_email_num|int + 1|int
+          - info.records|length == 1|int
           - result.records != []
           - result.records[0].keys() | sort ==
             ['alert_tag_uuid', 'email_address', 'latest_task_tag',
@@ -131,7 +129,7 @@
         that:
           - result.changed == False
           - result.diff.before == result.diff.after
-          - info.records|length == starting_email_num|int + 1|int
+          - info.records|length == 1|int
           - result.records != []
           - result.records[0].keys() | sort ==
             ['alert_tag_uuid', 'email_address', 'latest_task_tag',
@@ -151,7 +149,7 @@
           - result.diff.before != result.diff.after
     - ansible.builtin.assert: &test2
         that:
-          - info.records|length == starting_email_num|int
+          - info.records|length == 0|int
           - result.records == []
 
     - name: Remove previously created Email Alert Recipient - idempotence

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -118,6 +118,26 @@
             'resend_delay', 'silent_period', 'uuid']
 
 
+    - name: Send test email to an existing Email Alert Recipient
+      scale_computing.hypercore.email_alert:
+        email: "{{ new_email }}"
+        state: test
+      register: result
+    - scale_computing.hypercore.email_alert_info:
+      register: info
+    - ansible.builtin.debug:
+        msg: "{{ result }}"
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+          - info.records|length == starting_email_num|int + 1|int
+          - result.records != []
+          - result.records[0].keys() | sort ==
+            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            'resend_delay', 'silent_period', 'uuid']
+
+
     - name: Remove previously created Email Alert Recipient
       scale_computing.hypercore.email_alert:
         email: "{{ new_email }}"
@@ -146,20 +166,6 @@
           - result.changed == False
           - result.diff.before == result.diff.after
     - ansible.builtin.assert: *test2
-
-    # --------- Not yet implemented ---------
-#    - name: Send test email to an existing Email Alert Recipient
-#      scale_computing.hypercore.email_alert:
-#        email: new@test.com
-#        state: test
-#    - scale_computing.hypercore.email_alert_info:
-#      register: info
-#    - ansible.builtin.assert:
-#        that:
-#          - result.changed == False
-#          - result.diff.before == result.diff.after
-#          - info.records|length == current_email_num
-#          - info.records[0].email_address == "new@test.com"
 
     # -----------------------------------------------------------
 

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -5,7 +5,7 @@
     SC_PASSWORD: "{{ sc_password }}"
 
   vars:
-    new_email : new@test.com
+    new_email: new@test.com
     create_email: test@test.com
 
   block:
@@ -45,7 +45,9 @@
     - ansible.builtin.assert: &test0
         that:
           - result.records != []
-          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+          - result.records[0].keys() | sort ==
+            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            'resend_delay', 'silent_period', 'uuid']
           - info.records|length == starting_email_num|int + 1|int
           - info.records[0].email_address == "{{ create_email }}"
 
@@ -77,7 +79,9 @@
     - ansible.builtin.assert: &test1
         that:
           - result.records != []
-          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+          - result.records[0].keys() | sort ==
+            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            'resend_delay', 'silent_period', 'uuid']
           - info.records|length == starting_email_num|int + 1|int
 
     - name: Modify existing Email Alert Recipient - idempotence
@@ -109,7 +113,9 @@
           - result.diff.before == result.diff.after
           - info.records|length == starting_email_num|int + 1|int
           - result.records != []
-          - result.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+          - result.records[0].keys() | sort ==
+            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            'resend_delay', 'silent_period', 'uuid']
 
 
     - name: Remove previously created Email Alert Recipient
@@ -141,7 +147,7 @@
           - result.diff.before == result.diff.after
     - ansible.builtin.assert: *test2
 
-# --------- Not yet implemented ---------
+    # --------- Not yet implemented ---------
 #    - name: Send test email to an existing Email Alert Recipient
 #      scale_computing.hypercore.email_alert:
 #        email: new@test.com

--- a/tests/integration/targets/email_alert_info/tasks/main.yml
+++ b/tests/integration/targets/email_alert_info/tasks/main.yml
@@ -11,4 +11,6 @@
     - ansible.builtin.assert:
         that:
           - emails.records != []
-          - emails.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+          - emails.records[0].keys() | sort ==
+            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            'resend_delay', 'silent_period', 'uuid']

--- a/tests/integration/targets/email_alert_info/tasks/main.yml
+++ b/tests/integration/targets/email_alert_info/tasks/main.yml
@@ -5,21 +5,6 @@
     SC_PASSWORD: "{{ sc_password }}"
 
   block:
-#    - name: Add Email alert recipient
-#      scale_computing.hypercore.api:
-#        action: post
-#        endpoint: /rest/v1/AlertEmailTarget
-#        data:
-#          emailAddress: test1
-#
-#    - name: Add some Email alert recipient
-#      scale_computing.hypercore.api:
-#        action: post
-#        endpoint: /rest/v1/AlertEmailTarget
-#        data:
-#          emailAddress: test2
-
-
     - name: Retrieve info about Email alert recipients
       scale_computing.hypercore.email_alert_info:
       register: emails
@@ -27,15 +12,3 @@
         that:
           - emails.records != []
           - emails.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
-
-#    - name: Check if new email test1 exists
-#      ansible.builtin.fail:
-#        msg: "New email is not present!"
-#      when: item.email_address == test1
-#      loop: "{{ emails.records }}"
-#
-#    - name: Check if new email test2 exists
-#      ansible.builtin.fail:
-#        msg: "New email is not present!"
-#      when: item.email_address == test2
-#      loop: "{{ emails.records }}"

--- a/tests/integration/targets/email_alert_info/tasks/main.yml
+++ b/tests/integration/targets/email_alert_info/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_username }}"
+    SC_PASSWORD: "{{ sc_password }}"
+
+  block:
+#    - name: Add Email alert recipient
+#      scale_computing.hypercore.api:
+#        action: post
+#        endpoint: /rest/v1/AlertEmailTarget
+#        data:
+#          emailAddress: test1
+#
+#    - name: Add some Email alert recipient
+#      scale_computing.hypercore.api:
+#        action: post
+#        endpoint: /rest/v1/AlertEmailTarget
+#        data:
+#          emailAddress: test2
+
+
+    - name: Retrieve info about Email alert recipients
+      scale_computing.hypercore.email_alert_info:
+      register: emails
+    - ansible.builtin.assert:
+        that:
+          - emails.records != []
+          - emails.records[0].keys() | sort == ['alert_tag_uuid', 'email_address', 'latest_task_tag', 'resend_delay', 'silent_period', 'uuid']
+
+#    - name: Check if new email test1 exists
+#      ansible.builtin.fail:
+#        msg: "New email is not present!"
+#      when: item.email_address == test1
+#      loop: "{{ emails.records }}"
+#
+#    - name: Check if new email test2 exists
+#      ansible.builtin.fail:
+#        msg: "New email is not present!"
+#      when: item.email_address == test2
+#      loop: "{{ emails.records }}"

--- a/tests/unit/plugins/module_utils/test_email_alert.py
+++ b/tests/unit/plugins/module_utils/test_email_alert.py
@@ -8,11 +8,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import sys
-from copy import deepcopy
 
 import pytest
 
-from ansible_collections.scale_computing.hypercore.plugins.module_utils import errors
 from ansible_collections.scale_computing.hypercore.plugins.module_utils.email_alert import (
     EmailAlert,
 )

--- a/tests/unit/plugins/module_utils/test_email_alert.py
+++ b/tests/unit/plugins/module_utils/test_email_alert.py
@@ -73,9 +73,7 @@ class TestEmailAlert:
         assert self.email_alert == email_alert_from_ansible
 
     def test_get_by_uuid(self, rest_client):
-        rest_client.get_record.return_value = dict(
-            **self.from_hypercore_dict
-        )
+        rest_client.get_record.return_value = dict(**self.from_hypercore_dict)
         ansible_dict = dict(
             uuid="test",
         )
@@ -99,10 +97,7 @@ class TestEmailAlert:
         result = EmailAlert.get_state(rest_client)
         print(result)
 
-        assert result == [
-            expected,
-            expected
-        ]
+        assert result == [expected, expected]
 
     def test_get_state_no_record(self, rest_client):
         rest_client.list_records.return_value = []

--- a/tests/unit/plugins/module_utils/test_email_alert.py
+++ b/tests/unit/plugins/module_utils/test_email_alert.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+from copy import deepcopy
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils import errors
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.email_alert import (
+    EmailAlert,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires2.7 or higher"
+)
+
+
+class TestEmailAlert:
+    def setup_method(self):
+        self.email_alert = EmailAlert(
+            uuid="8664ed18-c354-4bab-be96-78dae5f6377f",
+            alert_tag_uuid="0",
+            email_address="test@test.com",
+            resend_delay=123,
+            silent_period=123,
+            latest_task_tag={},
+        )
+        self.from_hypercore_dict = dict(
+            uuid="8664ed18-c354-4bab-be96-78dae5f6377f",
+            alertTagUUID="0",
+            emailAddress="test@test.com",
+            resendDelay=123,
+            silentPeriod=123,
+            latestTaskTag={},
+        )
+        self.to_hypercore_dict = dict(
+            alertTagUUID="0",
+            emailAddress="test@test.com",
+            resendDelay=123,
+            silentPeriod=123,
+        )
+        self.ansible_dict = dict(
+            uuid="8664ed18-c354-4bab-be96-78dae5f6377f",
+            alert_tag_uuid="0",
+            email_address="test@test.com",
+            resend_delay=123,
+            silent_period=123,
+            latest_task_tag={},
+        )
+
+    def test_email_alert_to_hypercore(self):
+        assert self.email_alert.to_hypercore() == self.to_hypercore_dict
+
+    def test_email_alert_from_hypercore_dict_not_empty(self):
+        email_alert_from_hypercore = EmailAlert.from_hypercore(self.from_hypercore_dict)
+        assert self.email_alert == email_alert_from_hypercore
+
+    def test_email_alert_from_hypercore_dict_empty(self):
+        assert EmailAlert.from_hypercore([]) is None
+
+    def test_email_alert_to_ansible(self):
+        assert self.email_alert.to_ansible() == self.ansible_dict
+
+    def test_email_alert_from_ansible(self):
+        email_alert_from_ansible = EmailAlert.from_ansible(self.ansible_dict)
+        assert self.email_alert == email_alert_from_ansible
+
+    def test_get_by_uuid(self, rest_client):
+        rest_client.get_record.return_value = dict(
+            **self.from_hypercore_dict
+        )
+        ansible_dict = dict(
+            uuid="test",
+        )
+        email_alert_from_hypercore = EmailAlert.get_by_uuid(ansible_dict, rest_client)
+        assert email_alert_from_hypercore == self.email_alert
+
+    def test_get_state(self, rest_client):
+        rest_client.list_records.return_value = [
+            self.from_hypercore_dict,
+            self.from_hypercore_dict,
+        ]
+
+        expected = {
+            "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
+            "alert_tag_uuid": "0",
+            "email_address": "test@test.com",
+            "resend_delay": 123,
+            "silent_period": 123,
+            "latest_task_tag": {},
+        }
+        result = EmailAlert.get_state(rest_client)
+        print(result)
+
+        assert result == [
+            expected,
+            expected
+        ]
+
+    def test_get_state_no_record(self, rest_client):
+        rest_client.list_records.return_value = []
+
+        result = EmailAlert.get_state(rest_client)
+        assert result == []
+
+    # def test_get_by_email(self, rest_client):
+    #     other_hypercore_dict = self.from_hypercore_dict
+    #     other_hypercore_dict["email_address"] = "test1@test.com"
+    #     rest_client.get_record.return_value = [
+    #         self.from_hypercore_dict,
+    #     ]
+    #
+    #     result = EmailAlert.get_by_email(dict(email_address="test@test.com"), rest_client)
+    #     print(result)
+    #     assert result == {
+    #         "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
+    #         "alert_tag_uuid": "0",
+    #         "email_address": "test@test.com",
+    #         "resend_delay": 123,
+    #         "silent_period": 123,
+    #         "latest_task_tag": {},
+    #     }

--- a/tests/unit/plugins/modules/test_email_alert.py
+++ b/tests/unit/plugins/modules/test_email_alert.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils import errors
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.email_alert import (
+    EmailAlert,
+)
+from ansible_collections.scale_computing.hypercore.plugins.modules import email_alert
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestModifyEmailAlert:
+    pass
+
+
+class TestMain:
+    pass

--- a/tests/unit/plugins/modules/test_email_alert.py
+++ b/tests/unit/plugins/modules/test_email_alert.py
@@ -11,11 +11,6 @@ import sys
 
 import pytest
 
-from ansible_collections.scale_computing.hypercore.plugins.module_utils import errors
-from ansible_collections.scale_computing.hypercore.plugins.module_utils.email_alert import (
-    EmailAlert,
-)
-from ansible_collections.scale_computing.hypercore.plugins.modules import email_alert
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (2, 7), reason="requires python2.7 or higher"

--- a/tests/unit/plugins/modules/test_email_alert_info.py
+++ b/tests/unit/plugins/modules/test_email_alert_info.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.modules import (
+    email_alert_info,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (2, 7), reason="requires python2.7 or higher"
+)
+
+
+class TestRun:
+    def test_run_record_present(self, rest_client):
+        rest_client.list_records.return_value = [
+            dict(
+                uuid="8664ed18-c354-4bab-be96-78dae5f6377f",
+                alertTagUUID="0",
+                emailAddress="test@test.com",
+                resendDelay=123,
+                silentPeriod=123,
+                latestTaskTag={},
+            )
+        ]
+
+        result = email_alert_info.run(rest_client)
+        assert result == [{
+            "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
+            "alert_tag_uuid": "0",
+            "email_address": "test@test.com",
+            "resend_delay": 123,
+            "silent_period": 123,
+            "latest_task_tag": {},
+        }]
+
+    def test_run_record_absent(self, rest_client):
+        rest_client.list_records.return_value = []
+
+        result = email_alert_info.run(rest_client)
+        assert result == []

--- a/tests/unit/plugins/modules/test_email_alert_info.py
+++ b/tests/unit/plugins/modules/test_email_alert_info.py
@@ -34,14 +34,16 @@ class TestRun:
         ]
 
         result = email_alert_info.run(rest_client)
-        assert result == [{
-            "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
-            "alert_tag_uuid": "0",
-            "email_address": "test@test.com",
-            "resend_delay": 123,
-            "silent_period": 123,
-            "latest_task_tag": {},
-        }]
+        assert result == [
+            {
+                "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
+                "alert_tag_uuid": "0",
+                "email_address": "test@test.com",
+                "resend_delay": 123,
+                "silent_period": 123,
+                "latest_task_tag": {},
+            }
+        ]
 
     def test_run_record_absent(self, rest_client):
         rest_client.list_records.return_value = []


### PR DESCRIPTION
Added email alert modules (email_alert, email_alert_info)

Examples usages:
```yaml
- name: Create a new Email Alert Recipient
  scale_computing.hypercore.email_alert:
    email: example@example.com
    state: present

- name: Update previously create Email Alert Recipient
  scale_computing.hypercore.email_alert:
    email: example@example.com
    email_new: new@example.com
    state: present
    
- name: Remove previously updated Email Alert Recipient
  scale_computing.hypercore.email_alert:
    email: new@example.com
    state: absent

- name: Send test email to an Email Alert Recipient
  scale_computing.hypercore.email_alert:
    email: recipient@example.com
    state: test

# ---- info
- name: Retrieve al recipients
  scale_computing.hypercore.email_alert_info:
  register: info
- ansible.builtin.debug:
    msg: "{{ info.records }}"
```