### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,9 +2,17 @@
 name: Ansible test
 on:
   push:
+    paths:
+      - "meta/**"
+      - "plugins/**"
+      - "roles/**"
+      - "tests/**"
+      - "*requirements*"
+      - "*.py"
+      - "*ansible*"
   # pull_request:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 env:
   NAMESPACE: scale_computing
   COLLECTION_NAME: hypercore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+---
+name: Release and Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup python 🐍
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies 👽
+        run: python -m pip install ansible-core yq rst-to-myst
+
+      - name: Verify release 🗒️
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          echo "::warning::TODO: confirm tests pass for this commit"
+          tag_version="${TAG_NAME##*v}"
+          version="$(yq -r .version galaxy.yml)"
+          if [[ ${tag_version} != ${version} ]]; then
+            echo "::error file=galaxy.yml::🔴 Tag version '${tag_version}' does not match galaxy.yml version '${version}'"
+            exit 1
+          fi
+          echo "::notice::🟢 Version number verified: '$version'"
+
+      - name: Build 🛠️
+        run: ansible-galaxy collection build -v --force .
+
+      - name: Prepare release notes 📓
+        env:
+          CHANGELOG_URL: "${{ format('{0}/{1}/blob/{2}/CHANGELOG.rst', github.server_url, github.repository, github.ref_name) }}"
+          REF_NAME: "${{ github.ref_name }}"
+        run: |
+          rst2myst stream --no-sphinx CHANGELOG.rst | csplit - "/^## ${REF_NAME}/" '/^## v.*/'
+          mv xx01 release_notes.md
+          echo "See also: [CHANGELOG](${CHANGELOG_URL}#${REF_NAME//./-})" >>release_notes.md
+
+      - name: Release 🛸
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *.tar.gz
+          body_path: release_notes.md
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish to galaxy 🌌
+        uses: ansible/ansible-publish-action@v1.0.0
+        with:
+          api_key: ${{ secrets.GALAXY_API_KEY }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,3 +85,14 @@ Sample ansible.cfg is there to ensure collection does not need to be installed.
 ```yaml
 ansible-playbook -i localhost, examples/iso_info.yml -v
 ```
+
+## Creating a release
+
+Releases are automatically created when a tag is created with a name matching
+`v*.*.*`. Before tagging a commit, create a release issue and complete all of
+the prerequisites.
+
+- Create a new release issue with the "[New
+  release](https://github.com/ScaleComputing/HyperCoreAnsibleCollection/issues/new/choose)."
+  template
+- Complete each of the items in the release steps checklist

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,13 +18,10 @@ documentation: https://scalecomputing.github.io/HyperCoreAnsibleCollection-docs
 homepage: https://github.com/ScaleComputing/HyperCoreAnsibleCollection
 issues: https://github.com/ScaleComputing/HyperCoreAnsibleCollection/issues
 build_ignore:
-  - .idea
-  - .gitignore
+  - .*
   - tests
   - docs
   # all this should be under hacking/ or similar
-  - .ansible-lint
-  - .flake8
   - ci-infra
   - DEVELOPMENT.md
   - docs.requirements
@@ -34,4 +31,3 @@ build_ignore:
   # files used during local testing/building
   - ansible.cfg
   - examples
-  - .gitlab-ci.yml


### PR DESCRIPTION
Add the release.yml workflow file for automatic releases. Releases are triggered by tagging a commit with a name matching `v*.*.*`.

The workflow follows these steps:
- Verify the release by comparing the tag name with the galaxy.yml version.
- Build the collection tar file to include as a release artifact.
- Generate release notes from CHANGELOG.rst
- Create a [github release](https://github.com/ScaleComputing/HyperCoreAnsibleCollection/releases) using the tag name
- Publish the release to ansible galaxy (**this step will fail until a valid api key is added to the repo secrets**)