### PR TITLE
Fix missing timeout when Client is created

### DIFF
--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -223,11 +223,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             host = os.getenv("SC_HOST")
             username = os.getenv("SC_USERNAME")
             password = os.getenv("SC_PASSWORD")
+            timeout = os.getenv("SC_TIMEOUT")
         except KeyError:
             raise errors.ScaleComputingError(
                 "Missing parameters: sc_host, sc_username, sc_password."
             )
-        client = Client(host, username, password)
+        client = Client(host, username, password, timeout)
         rest_client = RestClient(client)
 
         vms = rest_client.list_records("/rest/v1/VirDomain")

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -51,9 +51,9 @@ class Client:
     def __init__(
         self,
         host: str,
-        username: str = None,
-        password: str = None,
-        timeout: float = None,
+        username: str,
+        password: str,
+        timeout: float,
     ):
         if not (host or "").startswith(("https://", "http://")):
             raise ScaleComputingError(

--- a/plugins/modules/dns_config.py
+++ b/plugins/modules/dns_config.py
@@ -250,11 +250,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         changed, new_state, diff = run(module, rest_client)
         module.exit_json(changed=changed, new_state=new_state, diff=diff)

--- a/plugins/modules/dns_config_info.py
+++ b/plugins/modules/dns_config_info.py
@@ -82,11 +82,7 @@ def main():
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         record = run(rest_client)
         module.exit_json(changed=False, record=record)

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -247,11 +247,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         changed, records, diff = run(module, rest_client)
         module.exit_json(changed=changed, records=records, diff=diff)

--- a/plugins/modules/email_alert_info.py
+++ b/plugins/modules/email_alert_info.py
@@ -83,11 +83,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         records = run(rest_client)
         module.exit_json(changed=False, records=records)

--- a/plugins/modules/smtp.py
+++ b/plugins/modules/smtp.py
@@ -323,11 +323,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         changed, record, diff = run(module, rest_client)
         module.exit_json(changed=changed, record=record, diff=diff)

--- a/plugins/modules/smtp_info.py
+++ b/plugins/modules/smtp_info.py
@@ -90,11 +90,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         record = run(rest_client)
         module.exit_json(changed=False, record=record)

--- a/plugins/modules/time_server.py
+++ b/plugins/modules/time_server.py
@@ -142,11 +142,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         changed, record, diff = run(module, rest_client)
         module.exit_json(changed=changed, record=record, diff=diff)

--- a/plugins/modules/time_server_info.py
+++ b/plugins/modules/time_server_info.py
@@ -95,11 +95,7 @@ def main():
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         record = run(rest_client)
         module.exit_json(changed=False, record=record)

--- a/plugins/modules/time_zone.py
+++ b/plugins/modules/time_zone.py
@@ -575,11 +575,7 @@ def main() -> None:
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         changed, record, diff = run(module, rest_client)
         module.exit_json(changed=changed, record=record, diff=diff)

--- a/plugins/modules/time_zone_info.py
+++ b/plugins/modules/time_zone_info.py
@@ -79,11 +79,7 @@ def main():
     )
 
     try:
-        client = Client(
-            host=module.params["cluster_instance"]["host"],
-            username=module.params["cluster_instance"]["username"],
-            password=module.params["cluster_instance"]["password"],
-        )
+        client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         record = run(rest_client)
         module.exit_json(changed=False, record=record)

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -46,7 +46,7 @@ class TestCachedRestClient:
             query1, query0 = query0, query1
             expected_data1, expected_data0 = expected_data0, expected_data1
 
-        client_obj = client.Client("https://thehost", "user", "pass")
+        client_obj = client.Client("https://thehost", "user", "pass", None)
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
         client_mock.return_value = client.Response(200, data, "")
@@ -84,7 +84,7 @@ class TestCachedRestClient:
             else:
                 return client.Response(200, data1, "")
 
-        client_obj = client.Client("https://thehost", "user", "pass")
+        client_obj = client.Client("https://thehost", "user", "pass", None)
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
         client_mock.side_effect = mockup_client_get
@@ -114,7 +114,7 @@ class TestCachedRestClient:
         endpoint = "vms"
         data = "[]"
 
-        client_obj = client.Client("https://thehost", "user", "pass")
+        client_obj = client.Client("https://thehost", "user", "pass", None)
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
         client_mock.return_value = client.Response(200, data, "")


### PR DESCRIPTION
But default value None for timeout is the root problem. To easy to miss you need to set timeout.

Removed all default parameter values for Client.Client(). Normal modules should use Client.get_client() anyway, and now no-one will want to use Client.Client()

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>