### PR TITLE
Time zone on empty cluster

### DIFF
--- a/plugins/module_utils/time_zone.py
+++ b/plugins/module_utils/time_zone.py
@@ -73,7 +73,7 @@ class TimeZone(PayloadMapper):
         )
 
     @classmethod
-    def get_by_uuid(cls, ansible_dict, rest_client, must_exist=True):
+    def get_by_uuid(cls, ansible_dict, rest_client, must_exist=False):
         query = get_query(ansible_dict, "uuid", ansible_hypercore_map=dict(uuid="uuid"))
         hypercore_dict = rest_client.get_record(
             "/rest/v1/TimeZone", query, must_exist=must_exist

--- a/tests/integration/targets/time_zone/tasks/02_time_zone.yml
+++ b/tests/integration/targets/time_zone/tasks/02_time_zone.yml
@@ -4,27 +4,25 @@
     SC_USERNAME: "{{ sc_username }}"
     SC_PASSWORD: "{{ sc_password }}"
 
+  vars:
+    time_zone_a: "Europe/Ljubljana"
+    time_zone_b: "Europe/Zagreb"
+    actual_uuid: "timezone_guid"
+
   block:
-    - name: Get default configs
-      scale_computing.hypercore.api:
-        action: get
-        endpoint: /rest/v1/TimeZone/timezone_guid
-      register: time_zone
-    - ansible.builtin.set_fact:
-        actual_zone: "{{ time_zone.record.0.timeZone }}"  # US/Eastern
-        actual_uuid: "{{ time_zone.record.0.uuid }}"
+#    - name: Set initial state
+#      scale_computing.hypercore.api:
+#        action: post
+#        endpoint: /rest/v1/TimeZone/timezone_guid
+#        data:
+#          timeZone: "Europe/Zagreb"
 
-    # ------------------------------------------------
-    - name: Set initial state
-      scale_computing.hypercore.api:
-        action: post
-        endpoint: /rest/v1/TimeZone/timezone_guid
-        data:
-          timeZone: "Europe/Zagreb"
+    - name: Remove all TimeZone objects
+      include_tasks: helper_api_time_zone_delete_all.yml
 
-    - name: Change time zone
+    - name: Create TimeZone object
       scale_computing.hypercore.time_zone:
-        zone: Europe/Ljubljana
+        zone: "{{ time_zone_b }}"
       register: result
     - scale_computing.hypercore.time_zone_info:
       register: info
@@ -32,12 +30,12 @@
         that:
           - result.changed == True
           - result.diff.before != result.diff.after
-          - info.record.time_zone == "Europe/Ljubljana"
+          - info.record.time_zone == time_zone_b
           - info.record.uuid == actual_uuid
 
-    - name: Update with time zone from previous task
+    - name: Create TimeZone object - idempotence
       scale_computing.hypercore.time_zone:
-        zone: Europe/Ljubljana
+        zone: "{{ time_zone_b }}"
       register: result
     - scale_computing.hypercore.time_zone_info:
       register: info
@@ -45,14 +43,31 @@
         that:
           - result.changed == False
           - result.diff.before == result.diff.after
-          - info.record.time_zone == "Europe/Ljubljana"
+          - info.record.time_zone == time_zone_b
           - info.record.uuid == actual_uuid
 
-    # ------------------------------------------------
+    - name: Change time zone
+      scale_computing.hypercore.time_zone:
+        zone: "{{ time_zone_a }}"
+      register: result
+    - scale_computing.hypercore.time_zone_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - result.diff.before != result.diff.after
+          - info.record.time_zone == time_zone_a
+          - info.record.uuid == actual_uuid
 
-    - name: Restore back to default
-      scale_computing.hypercore.api:
-        action: post
-        endpoint: /rest/v1/TimeZone/timezone_guid
-        data:
-          timeZone: "{{ actual_zone }}"
+    - name: Change time zone - idempotence
+      scale_computing.hypercore.time_zone:
+        zone: "{{ time_zone_a }}"
+      register: result
+    - scale_computing.hypercore.time_zone_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+          - info.record.time_zone == time_zone_a
+          - info.record.uuid == actual_uuid

--- a/tests/integration/targets/time_zone/tasks/helper_api_time_zone_create_one.yml
+++ b/tests/integration/targets/time_zone/tasks/helper_api_time_zone_create_one.yml
@@ -1,0 +1,21 @@
+---
+# Create TimeZone config.
+# Assumes all TimeZone were deleted before.
+
+# Create/POST, not update/PATCH!
+- name: Create a desired TimeZone config
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/TimeZone
+    data:
+      timeZone: "{{ time_zone_config.zone }}"
+# TODO wait on TaskTag
+
+- name: Get current TimeZone
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/TimeZone
+  register: time_zone_config_result
+- name: Show current TimeZone
+  ansible.builtin.debug:
+    var: time_zone_config_result

--- a/tests/integration/targets/time_zone/tasks/helper_api_time_zone_delete_all.yml
+++ b/tests/integration/targets/time_zone/tasks/helper_api_time_zone_delete_all.yml
@@ -1,0 +1,18 @@
+---
+# Remove TimeZone config.
+
+- name: Get current TimeZone
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/TimeZone
+  register: time_zone_config_result
+- name: Show current TimeZone
+  ansible.builtin.debug:
+    var: time_zone_config_result
+
+- name: Remove all existing TimeZone configs
+  scale_computing.hypercore.api:
+    action: delete
+    endpoint: /rest/v1/TimeZone/{{ item.uuid }}
+  with_items: "{{ time_zone_config_result.record }}"
+# TODO wait on TaskTag

--- a/tests/integration/targets/time_zone/tasks/helper_api_time_zone_reset.yml
+++ b/tests/integration/targets/time_zone/tasks/helper_api_time_zone_reset.yml
@@ -1,0 +1,14 @@
+---
+# Reset time zone configuration when testing is finished.
+# Configure using raw API module.
+# Should work even when all other modules are broken.
+
+- name: Show desired time_zone_config
+  ansible.builtin.debug:
+    var: time_zone_config
+
+- name: Delete all TimeZone objects
+  include_tasks: helper_api_time_zone_delete_all.yml
+
+- name: Create one TimeZone object
+  include_tasks: helper_api_time_zone_create_one.yml

--- a/tests/integration/targets/time_zone/tasks/main.yml
+++ b/tests/integration/targets/time_zone/tasks/main.yml
@@ -8,3 +8,7 @@
   block:
     - include_tasks: 01_time_zone_info.yml
     - include_tasks: 02_time_zone.yml
+  always:
+    - include_tasks: helper_api_time_zone_reset.yml
+      vars:
+        time_zone_config: "{{ sc_config[sc_host].time_zone }}"


### PR DESCRIPTION
Fixed time_zone module not working on an empty cluster in which case it now creates one instead of printing out a warning message.