### PR TITLE
Time server on empty cluster

### DIFF
--- a/plugins/module_utils/time_server.py
+++ b/plugins/module_utils/time_server.py
@@ -65,7 +65,7 @@ class TimeServer(PayloadMapper):
         )
 
     @classmethod
-    def get_by_uuid(cls, ansible_dict, rest_client, must_exist=True):
+    def get_by_uuid(cls, ansible_dict, rest_client, must_exist=False):
         query = get_query(ansible_dict, "uuid", ansible_hypercore_map=dict(uuid="uuid"))
         hypercore_dict = rest_client.get_record(
             "/rest/v1/TimeSource", query, must_exist=must_exist

--- a/plugins/modules/time_server.py
+++ b/plugins/modules/time_server.py
@@ -84,25 +84,20 @@ def modify_time_server(
     # GET method to get the Time Server by UUID
     time_server = TimeServer.get_by_uuid(module.params, rest_client)
 
-    # Get new time_server source host
-    new_time_server_source = module.params["source"]
-
-    # If Time Server doesn't exist, create one
+    # If Time Server doesn't exist, raise an exception (error)
     if not time_server:
-        create_task_tag = rest_client.create_record(
-            endpoint="/rest/v1/TimeSource",
-            payload=dict(host=new_time_server_source),
-            check_mode=module.check_mode,
+        raise errors.ScaleComputingError(
+            "Time Server: There is no Time Server configuration."
         )
-        TaskTag.wait_task(rest_client, create_task_tag)
-        after = TimeServer.get_state(rest_client)
-        return True, {}, dict(before={}, after=after)
 
     # Otherwise, continue with modifying the configuration
     before = time_server.to_ansible()
     old_state = TimeServer.get_state(
         rest_client=rest_client
     )  # get the state of Time Server before modification
+
+    # Get new time_server source host
+    new_time_server_source = module.params["source"]
 
     # Init return values and return if no changes were made
     change, record, diff = (

--- a/plugins/modules/time_server.py
+++ b/plugins/modules/time_server.py
@@ -84,20 +84,25 @@ def modify_time_server(
     # GET method to get the Time Server by UUID
     time_server = TimeServer.get_by_uuid(module.params, rest_client)
 
-    # If Time Server doesn't exist, raise an exception (error)
+    # Get new time_server source host
+    new_time_server_source = module.params["source"]
+
+    # If Time Server doesn't exist, create one
     if not time_server:
-        raise errors.ScaleComputingError(
-            "Time Server: There is no Time Server configuration."
+        create_task_tag = rest_client.create_record(
+            endpoint="/rest/v1/TimeSource",
+            payload=dict(host=new_time_server_source),
+            check_mode=module.check_mode,
         )
+        TaskTag.wait_task(rest_client, create_task_tag)
+        after = TimeServer.get_state(rest_client)
+        return True, {}, dict(before={}, after=after)
 
     # Otherwise, continue with modifying the configuration
     before = time_server.to_ansible()
     old_state = TimeServer.get_state(
         rest_client=rest_client
     )  # get the state of Time Server before modification
-
-    # Get new time_server source host
-    new_time_server_source = module.params["source"]
 
     # Init return values and return if no changes were made
     change, record, diff = (

--- a/tests/integration/targets/time_server/tasks/02_time_server.yml
+++ b/tests/integration/targets/time_server/tasks/02_time_server.yml
@@ -7,54 +7,17 @@
   vars:
     time_server_a: 2.pool.ntp.org
     time_server_b: 3.pool.ntp.org
+    actual_uuid: timesource_guid
 
   block:
-    - name: Get default configs
-      scale_computing.hypercore.api:
-        action: get
-        endpoint: /rest/v1/TimeSource/timesource_guid
-      register: time_server
-    - ansible.builtin.debug:
-        msg: time_server.record {{ time_server.record }}
-    - ansible.builtin.set_fact:
-        actual_host: "pool.ntp.org"  # "{{ time_server.record.0.host }}"
-        actual_uuid: "{{ time_server.record.0.uuid }}"
-
-    # Test cluster is already configured with pool.ntp.org,
-    # but it does not want to accept 0.pool.ntp.org.
-    # We will reconfigure it using corresponding IP address.
-    # Assumption: ansible-controller is running close to HyperCore server,
-    # so that returned IP address will be accepted by HyperCore server.
-    # How to install python dependencies for ansible-test?
-    # File tests/integration/requirements.txt is used with
-    # "ansible-test integration time_server -vv --venv",
-    # but otherwise - not/not always?
-
-    # This was needed/useful on previous test cluster (action runner "westfield")
-    # Problem is, the first IP from DNS A record might be down at time of test.
-    #    - ansible.builtin.command: pip install dnspython==2.3.0
-    #    - ansible.builtin.command: python -c 'import dns.resolver; ans=dns.resolver.resolve("{{ actual_host }}", "A"); print(str(ans[0]));'
-    #      changed_when: false
-    #      register: actual_host_ip_address_result
-    #    - ansible.builtin.set_fact:
-    #        actual_host_ip_address: "{{ actual_host_ip_address_result.stdout }}"
-
-    # On cluster 10.5.11.50, [0-3].pool.ntp.org is accepted.
-    - ansible.builtin.set_fact:
-        actual_host_ip_address: "3.pool.ntp.org"
-
-    - name: Set NTP server to IP address {{ actual_host_ip_address }} using api module
-      scale_computing.hypercore.api:
-        action: patch
-        endpoint: /rest/v1/TimeSource/timesource_guid
-        data:
-          host: "{{ actual_host_ip_address }}"
+    - name: Remove all TimeServer objects
+      include_tasks: helper_api_time_server_delete_all.yml
 
     # ------------------------------------------------
 
-    - name: Change NTP server
+    - name: Create TimeServer object
       scale_computing.hypercore.time_server:
-        source: "{{ actual_host }}"
+        source: "{{ time_server_a }}"
       register: result
     - scale_computing.hypercore.time_server_info:
       register: info
@@ -62,12 +25,12 @@
         that:
           - result.changed == True
           - result.diff.before != result.diff.after
-          - info.record.host == actual_host
+          - info.record.host == time_server_a
           - info.record.uuid == actual_uuid
 
-    - name: Update with NTP server from previous task
+    - name: Create TimeServer object - idempotence
       scale_computing.hypercore.time_server:
-        source: "{{ actual_host }}"
+        source: "{{ time_server_a }}"
       register: result
     - scale_computing.hypercore.time_server_info:
       register: info
@@ -75,14 +38,31 @@
         that:
           - result.changed == False
           - result.diff.before == result.diff.after
-          - info.record.host == actual_host
+          - info.record.host == time_server_a
           - info.record.uuid == actual_uuid
 
-    # ------------------------------------------------
-  always:
-    - name: Restore back to default
-      scale_computing.hypercore.api:
-        action: post
-        endpoint: /rest/v1/TimeSource/timesource_guid
-        data:
-          host: "{{ actual_host }}"
+    - name: Change NTP server
+      scale_computing.hypercore.time_server:
+        source: "{{ time_server_b }}"
+      register: result
+    - scale_computing.hypercore.time_server_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - result.diff.before != result.diff.after
+          - info.record.host == time_server_b
+          - info.record.uuid == actual_uuid
+
+    - name: Change NTP server - idempotence
+      scale_computing.hypercore.time_server:
+        source: "{{ time_server_b }}"
+      register: result
+    - scale_computing.hypercore.time_server_info:
+      register: info
+    - ansible.builtin.assert:
+        that:
+          - result.changed == False
+          - result.diff.before == result.diff.after
+          - info.record.host == time_server_b
+          - info.record.uuid == actual_uuid

--- a/tests/integration/targets/time_server/tasks/02_time_server.yml
+++ b/tests/integration/targets/time_server/tasks/02_time_server.yml
@@ -4,6 +4,9 @@
     SC_USERNAME: "{{ sc_username }}"
     SC_PASSWORD: "{{ sc_password }}"
     SC_TIMEOUT: "{{ sc_timeout * 10 }}"
+  vars:
+    time_server_a: 2.pool.ntp.org
+    time_server_b: 3.pool.ntp.org
 
   block:
     - name: Get default configs

--- a/tests/integration/targets/time_server/tasks/helper_api_time_server_create_one.yml
+++ b/tests/integration/targets/time_server/tasks/helper_api_time_server_create_one.yml
@@ -1,0 +1,21 @@
+---
+# Create TimeSource config.
+# Assumes all TimeSource were deleted before.
+
+# Create/POST, not update/PATCH!
+- name: Create a desired TimeSource config
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/TimeSource
+    data:
+      host: "{{ time_server_config.source }}"
+# TODO wait on TaskTag
+
+- name: Get current TimeSource
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/TimeSource
+  register: time_server_config_result
+- name: Show current TimeSource
+  ansible.builtin.debug:
+    var: time_server_config_result

--- a/tests/integration/targets/time_server/tasks/helper_api_time_server_delete_all.yml
+++ b/tests/integration/targets/time_server/tasks/helper_api_time_server_delete_all.yml
@@ -1,0 +1,18 @@
+---
+# Remove TimeSource config.
+
+- name: Get current TimeSource
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/TimeSource
+  register: time_server_config_result
+- name: Show current TimeSource
+  ansible.builtin.debug:
+    var: time_server_config_result
+
+- name: Remove all existing TimeSource configs
+  scale_computing.hypercore.api:
+    action: delete
+    endpoint: /rest/v1/TimeSource/{{ item.uuid }}
+  with_items: "{{ time_server_config_result.record }}"
+# TODO wait on TaskTag

--- a/tests/integration/targets/time_server/tasks/helper_api_time_server_reset.yml
+++ b/tests/integration/targets/time_server/tasks/helper_api_time_server_reset.yml
@@ -1,0 +1,14 @@
+---
+# Reset NTP time server configuration when testing is finished.
+# Configure using raw API module.
+# Should work even when all other modules are broken.
+
+- name: Show desired time_server_config
+  ansible.builtin.debug:
+    var: time_server_config
+
+- name: Delete all TimeSource objects
+  include_tasks: helper_api_time_server_delete_all.yml
+
+- name: Create one TimeSource object
+  include_tasks: helper_api_time_server_create_one.yml

--- a/tests/integration/targets/time_server/tasks/main.yml
+++ b/tests/integration/targets/time_server/tasks/main.yml
@@ -9,3 +9,7 @@
   block:
     - include_tasks: 01_time_server_info.yml
     - include_tasks: 02_time_server.yml
+  always:
+    - include_tasks: helper_api_time_server_reset.yml
+      vars:
+        time_server_config: "{{ sc_config[sc_host].time_server }}"


### PR DESCRIPTION
Fixed time_server module not working on an empty cluster in which case it now creates one instead of printing out a warning message.