### PR TITLE
fix 502 bad gateway problem with oidc_config module

### DIFF
--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -23,6 +23,7 @@ class UnexpectedAPIResponse(ScaleComputingError):
         self.message = "Unexpected response - {0} {1}".format(
             response.status, response.data
         )
+        self.response_status = response.status
         super(UnexpectedAPIResponse, self).__init__(self.message)
 
 

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -97,8 +97,6 @@ def ensure_present(
         task = oidc_obj_ansible.send_create_request(rest_client)
     else:
         task = oidc_obj_ansible.send_update_request(rest_client)
-    if not unit:
-        sleep(10)  # Wait for the cluster login (Avoid BAD GATEWAY response)
     TaskTag.wait_task(rest_client, task)
     updated_oidc = Oidc.get(rest_client)
     after = updated_oidc.to_ansible() if updated_oidc else None

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -88,7 +88,6 @@ from time import sleep
 def ensure_present(
     module: AnsibleModule,
     rest_client: RestClient,
-    unit: bool,
 ) -> Tuple[bool, Union[TypedOidcToAnsible, None], TypedDiff]:
     oidc_obj_ansible = Oidc.from_ansible(module.params)
     # If we get "502 bad gateway" during reconfiguration, we need to retry.
@@ -119,9 +118,9 @@ def ensure_present(
 
 
 def run(
-    module: AnsibleModule, rest_client: RestClient, unit: bool = False
+    module: AnsibleModule, rest_client: RestClient
 ) -> Tuple[bool, Union[TypedOidcToAnsible, None], TypedDiff]:
-    return ensure_present(module, rest_client, unit)
+    return ensure_present(module, rest_client)
 
 
 def main() -> None:

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -102,7 +102,8 @@ def ensure_present(
     TaskTag.wait_task(rest_client, task)
     updated_oidc = Oidc.get(rest_client)
     after = updated_oidc.to_ansible() if updated_oidc else None
-    return is_changed(before, after), after, dict(before=before, after=after)
+    # We always sent POST or PATCH, so it is always changed=True
+    return True, after, dict(before=before, after=after)
 
 
 def run(

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -105,7 +105,9 @@ def ensure_present(
             break
         except UnexpectedAPIResponse as ex:
             if ex.response_status in [500, 502]:
-                module.warn(f"API misbehaving during reconfiguration, retry {ii+1}/{max_retries}")
+                module.warn(
+                    f"API misbehaving during reconfiguration, retry {ii+1}/{max_retries}"
+                )
                 sleep(1)
                 continue
             else:

--- a/tests/integration/targets/oidc_config/tasks/oidc_config.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_config.yml
@@ -10,11 +10,11 @@
   register: oidc_config_set
 - ansible.builtin.assert:
     that:
-      - oidc_config is succeeded
-      - oidc_config is changed
-      - oidc_config.record.client_id == "{{ oidc_config.client_id_test }}"
-      - oidc_config.record.config_url == "{{ oidc_config.config_url_test }}"
-      - oidc_config.record.scopes == "openid+profile"
+      - oidc_config_set is succeeded
+      - oidc_config_set is changed
+      - oidc_config_set.record.client_id == "{{ oidc_config.client_id_test }}"
+      - oidc_config_set.record.config_url == "{{ oidc_config.config_url_test }}"
+      - oidc_config_set.record.scopes == "openid+profile"
 
 - name: Read OIDC config - make sure it is updated
   scale_computing.hypercore.oidc_config_info:

--- a/tests/integration/targets/oidc_config/tasks/oidc_config.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_config.yml
@@ -32,8 +32,8 @@
 # all reconnect/retry (502 bad gateway) problems.
 - name: Create or update OIDC config - in loop
   scale_computing.hypercore.oidc_config:
-    client_id: "{{ oidc_config.client_id_test }}"
-    shared_secret: "{{ oidc_config.shared_secret_test }}"
+    client_id: "{{ oidc_config.client_id_test }}-{{ item }}"
+    shared_secret: "{{ oidc_config.shared_secret_test }}-{{ item }}"
     config_url: "{{ oidc_config.config_url_test }}"
     scopes: "openid+profile"
   loop: "{{ range(0, 10, 1) | list }}"

--- a/tests/integration/targets/oidc_config/tasks/oidc_config.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_config.yml
@@ -26,3 +26,26 @@
       - oidc_config_info_data.record.client_id == "{{ oidc_config.client_id_test }}"
       - oidc_config_info_data.record.config_url == "{{ oidc_config.config_url_test }}"
       - oidc_config_info_data.record.scopes == "openid+profile"
+
+# Idempotence test does not apply, shared_secret is not returned, and module needs to always set it.
+# Here we want to test robustness - we call module in tight loop, and expect module to handle
+# all reconnect/retry (502 bad gateway) problems.
+- name: Create or update OIDC config - in loop
+  scale_computing.hypercore.oidc_config:
+    client_id: "{{ oidc_config.client_id_test }}"
+    shared_secret: "{{ oidc_config.shared_secret_test }}"
+    config_url: "{{ oidc_config.config_url_test }}"
+    scopes: "openid+profile"
+  loop: "{{ range(0, 10, 1) | list }}"
+  register: oidc_config_all
+- ansible.builtin.assert:
+    that:
+      - oidc_config_all is succeeded
+      # - oidc_config_one is succeeded
+      - oidc_config_one is changed
+      - oidc_config_one.record.client_id == "{{ oidc_config.client_id_test }}"
+      - oidc_config_one.record.config_url == "{{ oidc_config.config_url_test }}"
+      - oidc_config_one.record.scopes == "openid+profile"
+  loop: "{{ oidc_config_all.results }}"
+  loop_control:
+    label: "oidc_config_one"

--- a/tests/integration/targets/oidc_config/tasks/oidc_config.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_config.yml
@@ -71,10 +71,8 @@
     that:
       - oidc_config_all is succeeded
       # - oidc_config_one is succeeded
-      - oidc_config_one is changed
-      - oidc_config_one.record.client_id == "{{ oidc_config.client_id_test }}"
-      - oidc_config_one.record.config_url == "{{ oidc_config.config_url_test }}"
-      - oidc_config_one.record.scopes == "openid+profile"
+      - item is changed
+      - (oidc_config.client_id_test + '-') in item.record.client_id
+      - item.record.config_url == "{{ oidc_config.config_url_test }}"
+      - item.record.scopes == "openid+profile"
   loop: "{{ oidc_config_all.results }}"
-  loop_control:
-    label: "oidc_config_one"

--- a/tests/integration/targets/oidc_config/tasks/oidc_config.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_config.yml
@@ -55,6 +55,8 @@
       - oidc_config_info_data.record.client_id == "{{ oidc_config.client_id_test }}"
       - oidc_config_info_data.record.config_url == "{{ oidc_config.config_url_test }}"
       - oidc_config_info_data.record.scopes == "openid+profile"
+
+#-------------------------------------------------------------------------------
 # Here we want to test robustness - we call module in tight loop, and expect module to handle
 # all reconnect/retry (502 bad gateway) problems.
 - name: Create or update OIDC config - in loop

--- a/tests/integration/targets/oidc_config/tasks/oidc_config.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_config.yml
@@ -1,6 +1,7 @@
 ---
 # Test oidc_config and oidc_config_info modules
 
+#-------------------------------------------------------------------------------
 - name: Create or update OIDC config (different App - "Scale-test-xlab" in AzureAD)
   scale_computing.hypercore.oidc_config:
     client_id: "{{ oidc_config.client_id_test }}"
@@ -27,7 +28,33 @@
       - oidc_config_info_data.record.config_url == "{{ oidc_config.config_url_test }}"
       - oidc_config_info_data.record.scopes == "openid+profile"
 
+#-------------------------------------------------------------------------------
 # Idempotence test does not apply, shared_secret is not returned, and module needs to always set it.
+- name: Create or update OIDC config (different App - "Scale-test-xlab" in AzureAD) - not idempotent
+  scale_computing.hypercore.oidc_config:
+    client_id: "{{ oidc_config.client_id_test }}"
+    shared_secret: "{{ oidc_config.shared_secret_test }}"
+    config_url: "{{ oidc_config.config_url_test }}"
+    scopes: "openid+profile"
+  register: oidc_config_set
+- ansible.builtin.assert:
+    that:
+      - oidc_config_set is succeeded
+      - oidc_config_set is changed
+      - oidc_config_set.record.client_id == "{{ oidc_config.client_id_test }}"
+      - oidc_config_set.record.config_url == "{{ oidc_config.config_url_test }}"
+      - oidc_config_set.record.scopes == "openid+profile"
+
+- name: Read OIDC config - make sure it is updated - not idempotent
+  scale_computing.hypercore.oidc_config_info:
+  register: oidc_config_info_data
+- ansible.builtin.assert:
+    that:
+      - oidc_config_info_data is succeeded
+      - oidc_config_info_data is not changed
+      - oidc_config_info_data.record.client_id == "{{ oidc_config.client_id_test }}"
+      - oidc_config_info_data.record.config_url == "{{ oidc_config.config_url_test }}"
+      - oidc_config_info_data.record.scopes == "openid+profile"
 # Here we want to test robustness - we call module in tight loop, and expect module to handle
 # all reconnect/retry (502 bad gateway) problems.
 - name: Create or update OIDC config - in loop

--- a/tests/integration/targets/oidc_config/tasks/oidc_reset.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_reset.yml
@@ -26,7 +26,13 @@
       sharedSecret: "{{ oidc_config.shared_secret_default }}"
       configurationURL: "{{ oidc_config.config_url_default }}"
       scopes: "{{ oidc_config.scopes }}"
-  ignore_errors: true # We always get BAD GATEWAY here for some reason (Seems like API issue)
+  # Frequently we get HTML document with "502 Bad Gateway" message,
+  # instead of normal json response (with taskTag etc).
+  # If this happens, just retry after short delay.
+  register: api_oidc_result
+  retries: 5
+  delay: 5
+  until: api_oidc_result is succeeded
 
 - name: Wait N sec - Cluster needs to finish login
   ansible.builtin.pause:

--- a/tests/integration/targets/oidc_config/tasks/oidc_reset.yml
+++ b/tests/integration/targets/oidc_config/tasks/oidc_reset.yml
@@ -1,20 +1,23 @@
 ---
 # Reset OIDC values in the webUI
 
-- name: Wait N sec - Cluster needs to finish login
-  ansible.builtin.pause:
-    seconds: 15
-
+# The oidc_config module should wait on reconfiguration to finish -
+# this will make it easy to use.
+# This recovery playbook does wait on any previous OIDC reconfiguration to finish anyway.
+# The recovery should work also if module is "incorrectly" implemented.
+# We cannot wait on TaskTag of previous OIDC reconfiguration, because we do not know it.
+# The observed problem is that also "GET /rest/v1/OIDCConfig" returns "502 Bad Gateway".
 - name: Get current oidc values
   scale_computing.hypercore.api:
     action: get
     endpoint: /rest/v1/OIDCConfig
   register: oidc_config_result
+  retries: 5
+  delay: 5
+  until: oidc_config_result is succeeded
+
 - name: Show current OIDC
   ansible.builtin.debug:
-    var: oidc_config_result
-
-- ansible.builtin.debug:
     var: oidc_config_result
 
 - name: Replace current OIDC values
@@ -35,5 +38,10 @@
   until: api_oidc_result is succeeded
 
 - name: Wait N sec - Cluster needs to finish login
-  ansible.builtin.pause:
-    seconds: 15
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/TaskTag/{{ api_oidc_result.record.taskTag }}
+  register: api_tasktag_result
+  retries: 5
+  delay: 5
+  until: api_tasktag_result.record[0].state == "COMPLETE"


### PR DESCRIPTION
Module will be easier to use if ignore or retry on 500/502 error is hidden inside module.
A small stress test is added to ensure we hit the API errors frequently.