### PR TITLE
Add unit tests for syslog_server module.

### DIFF
--- a/plugins/modules/syslog_server.py
+++ b/plugins/modules/syslog_server.py
@@ -159,15 +159,6 @@ def create_syslog_server(
     )  # changed, records, diff
 
 
-def build_new_entry(
-    param_val: Union[str, int], api_val: Union[str, int], default: Union[str, int]
-) -> Any:
-    new_entry = api_val
-    if param_val and (param_val != default and param_val != api_val):
-        new_entry = param_val
-    return new_entry
-
-
 def build_update_payload(
     module: AnsibleModule, syslog_server: SyslogServer
 ) -> Dict[Any, Any]:
@@ -261,21 +252,6 @@ def run(
     return delete_syslog_server(syslog_server, module, rest_client)  # type: ignore
 
 
-def validate_params(module: AnsibleModule) -> None:
-    params = []
-    if module.params["state"] != "present":  # if state == "absent"
-        if module.params["host_new"] is not None:
-            params.append("host_new")
-        if module.params["port"] is not None:
-            params.append("port")
-        if module.params["protocol"] is not None:
-            params.append("protocol")
-
-    if params:
-        msg = ", ".join(params) + " can be used only if state==present"
-        module.fail_json(msg=msg)
-
-
 def main() -> None:
     module = AnsibleModule(
         supports_check_mode=False,
@@ -311,7 +287,6 @@ def main() -> None:
     try:
         client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
-        # validate_params(module)  # might actually not be needed
         changed, record, diff = run(module, rest_client)
         module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:

--- a/tests/unit/plugins/module_utils/test_syslog_server.py
+++ b/tests/unit/plugins/module_utils/test_syslog_server.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server import (
+    SyslogServer,
+)
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.utils import (
+    MIN_PYTHON_VERSION,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < MIN_PYTHON_VERSION,
+    reason=f"requires python{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher",
+)
+
+
+class TestSyslogServer:
+    def setup_method(self):
+        self.syslog_server = SyslogServer(
+            uuid="test",
+            alert_tag_uuid="0",
+            host="0.0.0.0",
+            port=42,
+            protocol="protocol",
+            resend_delay=123,
+            silent_period=123,
+            latest_task_tag={},
+        )
+        self.from_hypercore_dict = dict(
+            uuid="test",
+            alertTagUUID="0",
+            host="0.0.0.0",
+            port=42,
+            protocol="protocol",
+            resendDelay=123,
+            silentPeriod=123,
+            latestTaskTag={},
+        )
+        self.to_hypercore_dict = dict(
+            host="0.0.0.0",
+            port=42,
+            protocol="protocol",
+        )
+        self.ansible_dict = dict(
+            uuid="test",
+            alert_tag_uuid="0",
+            host="0.0.0.0",
+            port=42,
+            protocol="protocol",
+            resend_delay=123,
+            silent_period=123,
+            latest_task_tag={},
+        )
+
+    def test_syslog_server_to_hypercore(self):
+        assert self.syslog_server.to_hypercore() == self.to_hypercore_dict
+
+    def test_syslog_server_from_hypercore_dict_not_empty(self):
+        syslog_server_from_hypercore = SyslogServer.from_hypercore(
+            self.from_hypercore_dict
+        )
+        assert self.syslog_server == syslog_server_from_hypercore
+
+    def test_syslog_server_from_hypercore_dict_empty(self):
+        assert SyslogServer.from_hypercore([]) is None
+
+    def test_syslog_server_to_ansible(self):
+        assert self.syslog_server.to_ansible() == self.ansible_dict
+
+    def test_syslog_server_from_ansible(self):
+        syslog_server_from_ansible = SyslogServer.from_ansible(self.ansible_dict)
+        assert syslog_server_from_ansible == SyslogServer(
+            uuid=syslog_server_from_ansible.uuid,
+            host=syslog_server_from_ansible.host,
+            port=syslog_server_from_ansible.port,
+            protocol=syslog_server_from_ansible.protocol,
+        )
+
+    def test_get_by_uuid(self, rest_client):
+        rest_client.get_record.return_value = dict(**self.from_hypercore_dict)
+        ansible_dict = dict(
+            uuid="test",
+        )
+        syslog_server_from_hypercore = SyslogServer.get_by_uuid(
+            ansible_dict, rest_client
+        )
+        assert syslog_server_from_hypercore == self.syslog_server
+
+    def test_get_state(self, rest_client):
+        rest_client.list_records.return_value = [
+            self.from_hypercore_dict,
+            self.from_hypercore_dict,
+        ]
+
+        expected = {
+            "uuid": "test",
+            "alert_tag_uuid": "0",
+            "host": "0.0.0.0",
+            "port": 42,
+            "protocol": "protocol",
+            "resend_delay": 123,
+            "silent_period": 123,
+            "latest_task_tag": {},
+        }
+        result = SyslogServer.get_state(rest_client)
+        print(result)
+
+        assert result == [expected, expected]
+
+    def test_get_state_no_record(self, rest_client):
+        rest_client.list_records.return_value = []
+
+        result = SyslogServer.get_state(rest_client)
+        assert result == []
+
+    def test_get_by_host(self, rest_client):
+        rest_client.get_record.return_value = dict(**self.from_hypercore_dict)
+
+        result = SyslogServer.get_by_host("0.0.0.0", rest_client)
+        assert result == self.syslog_server

--- a/tests/unit/plugins/modules/test_syslog_server.py
+++ b/tests/unit/plugins/modules/test_syslog_server.py
@@ -1,0 +1,472 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+from unittest import mock
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server import (
+    SyslogServer,
+)
+from ansible_collections.scale_computing.hypercore.plugins.modules import syslog_server
+
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.utils import (
+    MIN_PYTHON_VERSION,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < MIN_PYTHON_VERSION,
+    reason=f"requires python{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher",
+)
+
+
+UDP = "SYSLOG_PROTOCOL_UDP"
+TCP = "SYSLOG_PROTOCOL_TCP"
+
+
+class TestModifySyslogServer:
+    def setup_method(self):
+        self.cluster_instance = dict(
+            host="https://0.0.0.0",
+            username="admin",
+            password="admin",
+        )
+        self.magic = mock.MagicMock()
+
+    @pytest.mark.parametrize(("protocol", "expected"), [("udp", UDP), ("tcp", TCP)])
+    def test_get_protocol(self, protocol, expected):
+        result = syslog_server.get_protocol(protocol)
+        assert result == expected
+
+    def test_create_syslog_server(
+        self,
+        create_module,
+        rest_client,
+        task_wait,
+        mocker,
+    ):
+        module = create_module(
+            params=dict(
+                cluster_instance=self.cluster_instance,
+                host="0.0.0.0",
+                port=514,
+                protocol="udp",
+                state="present",
+            )
+        )
+
+        expected_return = (
+            True,
+            dict(
+                uuid="test",
+                alert_tag_uuid="0",
+                host="0.0.0.0",
+                port=42,
+                protocol=UDP,
+                resend_delay=123,
+                silent_period=123,
+                latest_task_tag={},
+            ),
+        )
+
+        task_tag = {
+            "taskTag": 123,
+            "createdUUID": "test",
+        }
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server.SyslogServer.get_by_uuid"
+        ).return_value = SyslogServer(**expected_return[1])
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server.SyslogServer.get_by_host"
+        ).return_value = None
+        rest_client.create_record.return_value = task_tag
+
+        called_with_dict = dict(
+            rest_client=rest_client,
+            payload=dict(host="0.0.0.0", port=514, protocol=UDP),
+            check_mode=False,
+        )
+
+        changed, record, diff = syslog_server.create_syslog_server(module, rest_client)
+        SyslogServer.create = mock.create_autospec(SyslogServer.create)
+        syslog_server.create_syslog_server(module, rest_client)
+
+        SyslogServer.create.assert_called_once_with(**called_with_dict)
+
+        assert changed == expected_return[0]
+        assert record == expected_return[1]  # after
+
+    @pytest.mark.parametrize(
+        ("host", "host_new", "port", "protocol", "expected"),
+        [
+            ("0.0.0.0", "1.2.3.4", None, None, ("1.2.3.4", 514, UDP)),
+            ("0.0.0.0", "1.2.3.4", 42, "tcp", ("1.2.3.4", 42, TCP)),
+            ("0.0.0.0", "0.0.0.0", 42, None, ("0.0.0.0", 42, UDP)),
+            ("0.0.0.0", "0.0.0.0", None, "tcp", ("0.0.0.0", 514, TCP)),
+            ("0.0.0.0", "0.0.0.0", 42, "tcp", ("0.0.0.0", 42, TCP)),
+        ],
+    )
+    def test_build_update_payload(
+        self, create_module, host, host_new, port, protocol, expected
+    ):
+        module = create_module(
+            params=dict(
+                cluster_instance=self.cluster_instance,
+                host=host,
+                host_new=host_new,
+                port=port,
+                protocol=protocol,
+                state="present",
+            )
+        )
+        if not port:
+            module.params["port"] = 514
+        if not protocol:
+            module.params["protocol"] = "udp"
+
+        _syslog_server = SyslogServer(
+            host=host,
+            port=514,
+            protocol=UDP,
+        )
+
+        result = syslog_server.build_update_payload(module, _syslog_server)
+        print("result:", result)
+        assert result == dict(
+            host=expected[0],
+            port=expected[1],
+            protocol=expected[2],
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "rc_host",
+            "rc_port",
+            "rc_protocol",
+            "host_param",
+            "host_new_param",
+            "port_param",
+            "protocol_param",
+            "expected_host",
+            "expected_port",
+            "expected_protocol",
+            "expected_change",
+        ),
+        [
+            (
+                # RC
+                "0.0.0.0",
+                42,
+                UDP,
+                # PARAMS
+                "0.0.0.0",
+                "1.2.3.4",
+                None,
+                None,
+                # EXPECTED
+                "1.2.3.4",
+                42,
+                UDP,
+                True,
+            ),
+            (
+                # RC
+                "0.0.0.0",
+                42,
+                UDP,
+                # PARAMS
+                "0.0.0.0",
+                "0.0.0.0",
+                None,
+                None,
+                # EXPECTED
+                "0.0.0.0",
+                42,
+                UDP,
+                False,
+            ),
+            (
+                # RC
+                None,
+                None,
+                None,
+                # PARAMS
+                "0.0.0.0",
+                "1.2.3.4",
+                None,
+                None,
+                # EXPECTED
+                None,
+                None,
+                None,
+                False,
+            ),
+            (
+                # RC
+                "1.2.3.4",
+                42,
+                UDP,
+                # PARAMS
+                "0.0.0.0",
+                "1.2.3.4",
+                None,
+                None,
+                # EXPECTED
+                "1.2.3.4",
+                42,
+                UDP,
+                False,
+            ),
+            (
+                # RC
+                "0.0.0.0",
+                42,
+                UDP,
+                # PARAMS
+                "0.0.0.0",
+                "0.0.0.0",
+                32,
+                "tcp",
+                # EXPECTED
+                "0.0.0.0",
+                32,
+                TCP,
+                True,
+            ),
+        ],
+    )
+    def test_update_syslog_server(
+        self,
+        create_module,
+        rest_client,
+        task_wait,
+        mocker,
+        rc_host,
+        rc_port,
+        rc_protocol,
+        host_param,
+        host_new_param,
+        port_param,
+        protocol_param,
+        expected_host,
+        expected_port,
+        expected_protocol,
+        expected_change,
+    ):
+        module = create_module(
+            params=dict(
+                cluster_instance=self.cluster_instance,
+                host=host_param,
+                host_new=host_new_param,
+                port=port_param,
+                protocol=protocol_param,
+                state="present",
+            )
+        )
+
+        if not port_param:
+            module.params["port"] = 514
+        if not protocol_param:
+            module.params["protocol"] = "udp"
+
+        task_tag = {
+            "taskTag": 123,
+        }
+
+        if rc_host is None and rc_protocol is None and rc_port is None:
+            rc_syslog_server = None
+        else:
+            rc_syslog_server = SyslogServer(
+                uuid="test",
+                alert_tag_uuid="0",
+                host=rc_host,
+                port=rc_port,
+                protocol=rc_protocol,
+                resend_delay=123,
+                silent_period=123,
+                latest_task_tag={},
+            )
+
+        expected_syslog_dict = dict(
+            uuid="test",
+            alert_tag_uuid="0",
+            host=expected_host,
+            port=expected_port,
+            protocol=expected_protocol,
+            resend_delay=123,
+            silent_period=123,
+            latest_task_tag={},
+        )
+
+        if not expected_host and not expected_port and not expected_protocol:
+            expected_syslog_dict = {}
+            mocker.patch(
+                "ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server.SyslogServer.get_by_host"
+            ).return_value = rc_syslog_server
+        else:
+            mocker.patch(
+                "ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server.SyslogServer.get_by_host"
+            ).return_value = SyslogServer(**expected_syslog_dict)
+        rest_client.update_record.return_value = task_tag
+
+        called_with_dict = dict(
+            rest_client=rest_client,
+            payload=dict(
+                host=expected_host, port=expected_port, protocol=expected_protocol
+            ),
+            check_mode=False,
+        )
+
+        SyslogServer.update = mock.create_autospec(SyslogServer.update)
+        changed, record, diff = syslog_server.update_syslog_server(
+            rc_syslog_server, module, rest_client
+        )
+        if not rc_syslog_server:
+            old_payload = None
+        else:
+            old_payload = rc_syslog_server.to_hypercore()
+
+        if (not old_payload) or called_with_dict.get("payload") == old_payload:
+            SyslogServer.update.assert_not_called()
+        else:
+            SyslogServer.update.assert_called_once_with(
+                rc_syslog_server, **called_with_dict
+            )
+
+        print("record:", record)
+        print("expect:", expected_syslog_dict)
+
+        assert changed == expected_change
+        assert record == expected_syslog_dict
+
+    @pytest.mark.parametrize(
+        ("rc_syslog_server", "host", "expected_return"),
+        [
+            (None, "0.0.0.0", (False, {})),
+            (
+                SyslogServer(
+                    uuid="test",
+                    alert_tag_uuid="0",
+                    host="0.0.0.0",
+                    port=42,
+                    protocol="protocol",
+                    resend_delay=123,
+                    silent_period=123,
+                    latest_task_tag={},
+                ),
+                "0.0.0.0",
+                (True, {}),
+            ),
+        ],
+    )
+    def test_delete_syslog_server(
+        self,
+        create_module,
+        rest_client,
+        task_wait,
+        mocker,
+        rc_syslog_server,
+        host,
+        expected_return,
+    ):
+        module = create_module(
+            params=dict(
+                cluster_instance=self.cluster_instance,
+                host=host,
+                state="absent",
+            )
+        )
+        task_tag = {
+            "taskTag": 123,
+        }
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.syslog_server.SyslogServer.get_by_host"
+        ).return_value = rc_syslog_server
+        rest_client.update_record.return_value = task_tag
+
+        called_with_dict = dict(
+            rest_client=rest_client,
+            check_mode=False,
+        )
+
+        changed, record, diff = syslog_server.delete_syslog_server(
+            rc_syslog_server, module, rest_client
+        )
+
+        SyslogServer.delete = mock.create_autospec(SyslogServer.delete)
+        syslog_server.delete_syslog_server(rc_syslog_server, module, rest_client)
+        if rc_syslog_server:
+            SyslogServer.delete.assert_called_once_with(
+                rc_syslog_server, **called_with_dict
+            )
+        else:
+            SyslogServer.delete.assert_not_called()
+
+        assert changed == expected_return[0]
+        assert record == expected_return[1]
+
+
+class TestMain:
+    def setup_method(self):
+        self.cluster_instance = dict(
+            host="https://0.0.0.0",
+            username="admin",
+            password="admin",
+        )
+
+    def test_fail(self, run_main):
+        success, result = run_main(syslog_server)
+
+        print(result["msg"])
+
+        assert success is False
+        assert (
+            "missing required arguments: state, host" in result["msg"]
+            or "missing required arguments: host, state" in result["msg"]
+        )
+
+    @pytest.mark.parametrize(
+        ("host", "host_new", "port", "protocol", "state"),
+        [
+            ("0.0.0.0", None, None, None, "present"),
+            ("0.0.0.0", "1.2.3.4", None, None, "present"),
+            ("0.0.0.0", "1.2.3.4", 42, "tcp", "present"),
+            ("0.0.0.0", None, None, None, "absent"),
+        ],
+    )
+    def test_params(
+        self,
+        run_main,
+        host,
+        host_new,
+        port,
+        protocol,
+        state,
+    ):
+        params = dict(
+            cluster_instance=self.cluster_instance,
+            host=host,
+            host_new=host_new,
+            port=port,
+            protocol=protocol,
+            state=state,
+        )
+
+        # put them to default if None
+        if not port:
+            params["port"] = 514
+        if not protocol:
+            params["protocol"] = "udp"
+
+        success, result = run_main(syslog_server, params)
+
+        print(result)
+
+        assert success is True

--- a/tests/unit/plugins/modules/test_syslog_server_info.py
+++ b/tests/unit/plugins/modules/test_syslog_server_info.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# # Copyright: (c) 2023, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+import pytest
+
+from ansible_collections.scale_computing.hypercore.plugins.modules import (
+    syslog_server_info,
+)
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.utils import (
+    MIN_PYTHON_VERSION,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < MIN_PYTHON_VERSION,
+    reason=f"requires python{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher",
+)
+
+
+class TestRun:
+    def test_run_record_present(self, rest_client):
+        rest_client.list_records.return_value = [
+            dict(
+                uuid="test",
+                alertTagUUID="0",
+                host="0.0.0.0",
+                port=42,
+                protocol="protocol",
+                resendDelay=123,
+                silentPeriod=123,
+                latestTaskTag={},
+            )
+        ]
+
+        result = syslog_server_info.run(rest_client)
+        assert result == [
+            {
+                "uuid": "test",
+                "alert_tag_uuid": "0",
+                "host": "0.0.0.0",
+                "port": 42,
+                "protocol": "protocol",
+                "resend_delay": 123,
+                "silent_period": 123,
+                "latest_task_tag": {},
+            }
+        ]
+
+    def test_run_record_absent(self, rest_client):
+        rest_client.list_records.return_value = []
+
+        result = syslog_server_info.run(rest_client)
+        assert result == []


### PR DESCRIPTION
Unit tests for ``syslog_server`` module weren't yet implemented, so the implementation was added.
Tests are:
- ``tests/unit/plugins/module_utils/test_syslog_server.py``
- ``tests/unit/plugins/modules/test_syslog_server.py``
- ``tests/unit/plugins/modules/test_syslog_server_info.py``