### PR TITLE
Make use_auth read-only (remove from create/update payload).

### DIFF
--- a/examples/smtp.yml
+++ b/examples/smtp.yml
@@ -12,7 +12,6 @@
     server: smtp-relay.gmail.com
     port: 25
     use_ssl: false
-    use_auth: true
     auth_user: example
     auth_password: example123
     from_address: example@example.com

--- a/plugins/modules/smtp.py
+++ b/plugins/modules/smtp.py
@@ -43,12 +43,6 @@ options:
         in clear text. Ensure the SMTP server supports SSL/TLS connections.
     required: False
     default: False
-  use_auth:
-    type: bool
-    description:
-      - Enable/disable authentication with C(auth_user) and C(auth_password).
-    required: False
-    default: False
   auth_user:
     type: str
     description:
@@ -76,7 +70,6 @@ EXAMPLES = r"""
     server: smtp-relay.gmail.com
     port: 25
     use_ssl: false
-    use_auth: false
     from_address: example@example.com
 
 - name: Modify SMTP configuration (authorization enabled)
@@ -84,7 +77,6 @@ EXAMPLES = r"""
     server: smtp-relay.gmail.com
     port: 25
     use_ssl: false
-    use_auth: true
     auth_user: example
     auth_password: example123
     from_address: example@example.com

--- a/plugins/modules/smtp.py
+++ b/plugins/modules/smtp.py
@@ -169,7 +169,6 @@ def modify_smtp_config(
         smtpServer=module.params["server"],
         port=module.params["port"],
         useSSL=module.params["use_ssl"],
-        useAuth=module.params["use_auth"],
         authUser=new_auth_user,
         authPassword=new_auth_password,
         fromAddress=new_from_address,
@@ -204,9 +203,6 @@ def modify_smtp_config(
     new_use_ssl, new_use_ssl_change_needed = build_entry(
         before.get("use_ssl"), module.params["use_ssl"]
     )
-    new_use_auth, new_use_auth_change_needed = build_entry(
-        before.get("use_auth"), module.params["use_auth"]
-    )
     new_auth_user, new_auth_user_change_needed = build_entry(
         before.get("auth_user"), module.params["auth_user"]
     )
@@ -225,7 +221,6 @@ def modify_smtp_config(
         new_smtp_server_change_needed
         or new_port_change_needed
         or new_use_ssl_change_needed
-        or new_use_auth_change_needed
         or new_auth_user_change_needed
         or new_auth_password_change_needed
         or new_from_address_change_needed,
@@ -240,7 +235,6 @@ def modify_smtp_config(
         smtpServer=new_smtp_server,
         port=new_port,
         useSSL=new_use_ssl,
-        useAuth=new_use_auth,
         authUser=new_auth_user,
         authPassword=new_auth_password,
         fromAddress=new_from_address,

--- a/plugins/modules/smtp.py
+++ b/plugins/modules/smtp.py
@@ -285,11 +285,6 @@ def main() -> None:
                 default=False,
                 required=False,
             ),
-            use_auth=dict(
-                type="bool",
-                default=False,
-                required=False,
-            ),
             auth_user=dict(
                 type="str",
                 required=False,
@@ -304,16 +299,6 @@ def main() -> None:
                 required=False,
             ),
         ),
-        required_if=[
-            (
-                "use_auth",
-                True,
-                (
-                    "auth_user",
-                    "auth_password",
-                ),
-            )
-        ],
     )
 
     try:

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -46,7 +46,6 @@ sc_config:
       port: 25
       use_ssl: false
       from_address: PUBx@scalecomputing.com
-      use_auth: false
       auth_user: ""
       auth_password: ""
     oidc:

--- a/tests/integration/targets/smtp/tasks/02_smtp.yml
+++ b/tests/integration/targets/smtp/tasks/02_smtp.yml
@@ -11,7 +11,6 @@
       host: mail.example.com
       port: 25
       use_ssl: False
-      use_auth: False
       auth_user: ""
       auth_password: ""
       from_address: "ci-test@example.com"
@@ -83,7 +82,6 @@
     server: smtp.office365.com
     port: 26
     use_ssl: False
-    use_auth: False
     from_address: test@test.com
   register: result
 - scale_computing.hypercore.smtp_info:
@@ -106,7 +104,6 @@
     server: smtp.office365.com
     port: 26
     use_ssl: False
-    use_auth: False
     from_address: test@test.com
   register: result
 - scale_computing.hypercore.smtp_info:
@@ -134,7 +131,6 @@
     server: smtp-relay.gmail.com
     port: 25
     use_ssl: False
-    use_auth: True
     auth_user: test
     auth_password: test123
     from_address: test@test.com
@@ -159,7 +155,6 @@
     server: smtp-relay.gmail.com
     port: 25
     use_ssl: False
-    use_auth: True
     auth_user: test
     auth_password: test123
     from_address: test@test.com

--- a/tests/integration/targets/smtp/tasks/helper_api_smtp_create_one.yml
+++ b/tests/integration/targets/smtp/tasks/helper_api_smtp_create_one.yml
@@ -22,7 +22,6 @@
       # port: "{{ smtp_config.port | int }}"
       port: 25
       useSSL: "{{ smtp_config.use_ssl }}"
-      useAuth: "{{ smtp_config.use_auth }}"
       authUser: "{{ smtp_config.auth_user }}"
       authPassword: "{{ smtp_config.auth_password }}"
       fromAddress: "{{ smtp_config.from_address }}"

--- a/tests/unit/plugins/modules/test_smtp.py
+++ b/tests/unit/plugins/modules/test_smtp.py
@@ -51,7 +51,6 @@ class TestModifySMTP:
             "smtp_server_param",
             "port_param",
             "use_ssl_param",
-            "use_auth_param",
             "auth_user_param",
             "auth_password_param",
             "from_address_param",
@@ -78,7 +77,6 @@ class TestModifySMTP:
                 # PARAMS
                 "test.com",
                 21,
-                False,
                 False,
                 "",
                 "",
@@ -108,7 +106,6 @@ class TestModifySMTP:
                 "test.com",
                 21,
                 True,
-                True,
                 "test",
                 "123",
                 "test@test.com",
@@ -137,7 +134,6 @@ class TestModifySMTP:
                 "test.com",
                 21,
                 False,
-                True,
                 "test",
                 "123",  # auth_password_param
                 "test@test.com",
@@ -171,7 +167,6 @@ class TestModifySMTP:
         smtp_server_param,
         port_param,
         use_ssl_param,
-        use_auth_param,
         auth_user_param,
         auth_password_param,
         from_address_param,
@@ -192,7 +187,6 @@ class TestModifySMTP:
                 server=smtp_server_param,
                 port=port_param,
                 use_ssl=use_ssl_param,
-                use_auth=use_auth_param,
                 auth_user=auth_user_param,
                 auth_password=auth_password_param,
                 from_address=from_address_param,
@@ -248,7 +242,6 @@ class TestModifySMTP:
                     server="test.com",
                     port=25,
                     use_ssl=True,
-                    use_auth=True,
                     auth_user="test",
                     auth_password="123",
                     from_address="test@test.com",
@@ -278,24 +271,11 @@ class TestMain:
             or "missing required arguments: server, port" in result["msg"]
         )
 
-    def test_required_if(self, run_main):
-        params = dict(
-            cluster_instance=self.cluster_instance,
-            server="test.com",
-            port=25,
-            use_auth=True,
-        )
-        success, result = run_main(smtp, params)
-
-        assert success is False
-        assert result["msg"]
-
     @pytest.mark.parametrize(
         (
             "server",
             "port",
             "use_ssl",
-            "use_auth",
             "auth_user",
             "auth_password",
             "from_address",
@@ -304,7 +284,6 @@ class TestMain:
             (
                 "test.com",
                 25,
-                True,
                 True,
                 "test",
                 "123",
@@ -317,12 +296,10 @@ class TestMain:
                 None,
                 None,
                 None,
-                None,
             ),
             (
                 "test.com",
                 25,
-                False,
                 False,
                 None,
                 None,
@@ -336,7 +313,6 @@ class TestMain:
         server,
         port,
         use_ssl,
-        use_auth,
         auth_user,
         auth_password,
         from_address,
@@ -345,7 +321,6 @@ class TestMain:
             cluster_instance=self.cluster_instance,
             server=server,
             port=port,
-            use_auth=use_auth,
             auth_user=auth_user,
             auth_password=auth_password,
             from_address=from_address,

--- a/tests/unit/plugins/modules/test_smtp.py
+++ b/tests/unit/plugins/modules/test_smtp.py
@@ -224,7 +224,6 @@ class TestModifySMTP:
                 smtpServer=expected_smtp_server,
                 port=expected_port,
                 useSSL=expected_use_ssl,
-                useAuth=expected_use_auth,
                 authUser=expected_auth_user,
                 authPassword=expected_auth_password,
                 fromAddress=expected_from_address,


### PR DESCRIPTION
For the ``smtp`` module is better that the ``use_auth`` param is ``read-only``, so that was updated.