### PR TITLE
Fix timeout error in case when a lot of VMs need to be shutdown

### DIFF
--- a/changelogs/fragments/cluster_modules.yml
+++ b/changelogs/fragments/cluster_modules.yml
@@ -1,0 +1,8 @@
+---
+major_changes:
+  - Added cluster_name and cluster_info module. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/112)
+  - Added cluster_shutdown module. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/117)
+
+minor_changes:
+  - Updated version check in cluster_name module. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/123)
+  - Fixed timeout error in cluster_shutdown module. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/127)

--- a/plugins/module_utils/cluster.py
+++ b/plugins/module_utils/cluster.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 __metaclass__ = type
 
+from time import sleep
 from ..module_utils.utils import PayloadMapper
 from ..module_utils.rest_client import RestClient
+from ..module_utils.errors import ScaleComputingError
 from ..module_utils.typed_classes import TypedClusterToAnsible, TypedTaskTag
 from typing import Any
 
@@ -76,6 +78,24 @@ class Cluster(PayloadMapper):
     def shutdown(
         rest_client: RestClient, force_shutdown: bool = False, check_mode: bool = False
     ) -> None:
-        rest_client.create_record(
-            "/rest/v1/Cluster/shutdown", dict(forceShutdown=force_shutdown), check_mode
-        )
+        try:
+            rest_client.create_record(
+                "/rest/v1/Cluster/shutdown",
+                dict(forceShutdown=force_shutdown),
+                check_mode,
+            )
+        except ScaleComputingError as e:
+            # To avoid timeout when there are a lot of VMs to shutdown
+            if "Request timed out" in str(e):
+                try:
+                    while True:
+                        # get cluster until "[Errno 111] Connection refused"
+                        Cluster.get(rest_client)
+                        sleep(5)
+                except ScaleComputingError as e2:
+                    if "Connection refused" in str(e2):  # cluster is shutdown
+                        pass
+                    else:
+                        raise e2  # Some other unexpected error
+            else:
+                raise e  # UnexpectedAPIResponse error

--- a/plugins/modules/cluster_shutdown.py
+++ b/plugins/modules/cluster_shutdown.py
@@ -14,9 +14,9 @@ module: cluster_shutdown
 
 author:
   - Polona Mihalič (@PolonaM)
-short_description: Shutdown cluster.
+short_description: Shutdown the cluster.
 description:
-  - Shutdown cluster.
+  - Shutdown the cluster. All running VirDomains will be restarted on next system boot.
 version_added: 1.2.0
 extends_documentation_fragment:
   - scale_computing.hypercore.cluster_instance
@@ -72,7 +72,7 @@ def main() -> None:
         client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
         shutdown = run(module, rest_client)
-        module.exit_json(shutdown=shutdown)
+        module.exit_json(changed=True, shutdown=shutdown)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/tests/unit/plugins/module_utils/test_cluster.py
+++ b/tests/unit/plugins/module_utils/test_cluster.py
@@ -9,9 +9,13 @@ import pytest
 from ansible_collections.scale_computing.hypercore.plugins.module_utils.cluster import (
     Cluster,
 )
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.utils import (
+    MIN_PYTHON_VERSION,
+)
 
 pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="requires python3.8 or higher"
+    sys.version_info < MIN_PYTHON_VERSION,
+    reason=f"requires python{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher",
 )
 
 


### PR DESCRIPTION
Fixed timeout error in case when a lot of VMs need to be shutdown - the timeout error is ignored (but not the UnexpectedAPIResponse error). Also get request to rest/v1/Cluster is added to check when connection is refused, and only then the cluster_shutdown module successfully exits. 