### PR TITLE
Do not run oidc_config test with other tests

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -14,14 +14,17 @@ on:
       # vm_import|vm_export - they need SMB server
       # dns_config|time_server - NTP cannot be reconfigured if DNS is invalid
       # git_issues - slow, do not run on each push. TODO - run them only once a day
+      # oidc_config - during reconfiguration API returns 500/502 errors for other requests
       integ_tests_exclude:
         type: string
         description: |-
           List integration tests to exclude.
           Use "*" to exclude all tests.
           Use regex like 'node|^git_issue|^dns_config$' to exclude only a subset.
-        default: "^dns_config$|^vm_import$|^vm_export$|^cluster_shutdown$"
+        default: "^dns_config$|^cluster_shutdown$|^oidc_config$"
 env:
+  INTEG_TESTS_INCLUDE_SCHEDULE: "*"
+  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^oidc_config$"
   WORKDIR: /work-dir/ansible_collections/scale_computing/hypercore
 # Run only one workflow for specific branch.
 concurrency:
@@ -79,15 +82,16 @@ jobs:
       - run: cp -a ./  $WORKDIR
       # We want to run all integ tests periodically - "integ_tests_include || '*'", the '*' is used.
       # When running with workflow-dispatch, user is required to put some non-empty string into integ_tests_include.
-      - run: echo INTEG_TESTS_EXCLUDE="${{ github.event.inputs.integ_tests_exclude || '^no-test-to-exclude-awyvfks$' }}"
-      - run: echo INTEG_TESTS_INCLUDE="${{ github.event.inputs.integ_tests_include || '*' }}"
+      - run: echo 'INTEG_TESTS_INCLUDE=${{ github.event.inputs.integ_tests_include || env.INTEG_TESTS_INCLUDE_SCHEDULE }}' >> $GITHUB_ENV
+      - run: echo 'INTEG_TESTS_EXCLUDE=${{ github.event.inputs.integ_tests_exclude || env.INTEG_TESTS_EXCLUDE_SCHEDULE }}' >> $GITHUB_ENV
+
       - id: set-matrix
         shell: bash
         run: |-
           echo "matrix=$(
             ls -r $WORKDIR/tests/integration/targets |
-            grep -v -E "${{ github.event.inputs.integ_tests_exclude || '^no-test-to-exclude-awyvfks$' }}" |
-            grep -E "${{ github.event.inputs.integ_tests_include || '*' }}" |
+            grep -v -E "${{ env.INTEG_TESTS_EXCLUDE }}" |
+            grep -E "${{ env.INTEG_TESTS_INCLUDE }}" |
             jq -R -s -c 'split("\n")[:-1]'
           )" >> $GITHUB_OUTPUT
     if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"


### PR DESCRIPTION
During OIDC reconfiguration API seems to be restarted, and any other test will fail.
See https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4239901225/jobs/7368389276
- most failed jobs have 502 error.

We want to have exclude-tests list used both on scheduled run and on interactive run. On interactive run,
github.event.inputs.integ_tests_exclude is non-empty and is used. On scheduled run github.event.inputs.integ_tests_exclude is empty, so the same string is retrived from INTEG_TESTS_EXCLUDE_SCHEDULE environ variable.