### PR TITLE
Fix time zone and time server integ tests

### DIFF
--- a/tests/integration/targets/time_server/tasks/01_time_server_info.yml
+++ b/tests/integration/targets/time_server/tasks/01_time_server_info.yml
@@ -5,18 +5,22 @@
     SC_PASSWORD: "{{ sc_password }}"
 
   vars:
-    actual_uuid: ""
-    actual_host: ""
+    actual_uuid: "timesource_guid"
+    actual_host: "3.pool.ntp.org"
 
   block:
-    - name: Get expected configs
+    # -------------------------------------------------------
+    # Test with no TimeSource objects
+    - include_tasks: helper_api_time_server_delete_all.yml
+
+    - name: Check expected configs
       scale_computing.hypercore.api:
         action: get
-        endpoint: /rest/v1/TimeSource/timesource_guid
+        endpoint: /rest/v1/TimeSource
       register: time_server
-    - ansible.builtin.set_fact:
-        actual_host: "{{ time_server.record.0.host }}"
-        actual_uuid: "{{ time_server.record.0.uuid }}"
+    - ansible.builtin.assert:
+        that:
+          - time_server.record | length == 0
 
     - name: Retrieve info about Time Server
       scale_computing.hypercore.time_server_info:
@@ -25,7 +29,34 @@
         msg: "{{ result.record }}"
     - ansible.builtin.assert:
         that:
-          - result.record != []
+          - result.record == {}
+
+    # -------------------------------------------------------
+    # Test with 1 TimeSource objects
+    - include_tasks: helper_api_time_server_create_one.yml
+      vars:
+        time_server_config:
+          source: "{{ actual_host }}"
+
+    - name: Check expected configs
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/TimeSource
+      register: time_server
+    - ansible.builtin.assert:
+        that:
+          - time_server.record | length == 1
+          - actual_host == time_server.record.0.host
+          - actual_uuid == time_server.record.0.uuid
+
+    - name: Retrieve info about Time Server
+      scale_computing.hypercore.time_server_info:
+      register: result
+    - ansible.builtin.debug:
+        msg: "{{ result.record }}"
+    - ansible.builtin.assert:
+        that:
+          - result.record != {}
           - "{{ result.record.keys() | sort == ['host', 'latest_task_tag', 'uuid'] }}"
           - result.record.uuid == actual_uuid
           - result.record.host == actual_host

--- a/tests/integration/targets/time_zone/tasks/01_time_zone_info.yml
+++ b/tests/integration/targets/time_zone/tasks/01_time_zone_info.yml
@@ -5,27 +5,58 @@
     SC_PASSWORD: "{{ sc_password }}"
 
   vars:
-    actual_uuid: ""
-    actual_zone: ""
+    actual_uuid: "timezone_guid"
+    actual_zone: "Europe/Belgrade"
 
   block:
+    # -------------------------------------------------------
+    # Test with no TimeZone objects
+    - include_tasks: helper_api_time_zone_delete_all.yml
+
     - name: Get expected configs
       scale_computing.hypercore.api:
         action: get
-        endpoint: /rest/v1/TimeZone/timezone_guid
+        endpoint: /rest/v1/TimeZone
       register: actual
-    - ansible.builtin.set_fact:
-        actual_zone: "{{ actual.record.0.timeZone }}"
-        actual_uuid: "{{ actual.record.0.uuid }}"
+    - ansible.builtin.assert:
+        that:
+          - actual.record | length == 0
 
-    - name: Retrieve info about Time Zone
+    - name: Retrieve info about Time Zone - 0 objects
       scale_computing.hypercore.time_zone_info:
       register: result
     - ansible.builtin.debug:
         msg: "{{ result }}"
     - ansible.builtin.assert:
         that:
-          - result.record != []
+          - result.record == {}
+
+    # -------------------------------------------------------
+    # Test with one TimeZone object
+    - include_tasks: helper_api_time_zone_create_one.yml
+      vars:
+        time_zone_config:
+          zone: "{{ actual_zone }}"
+
+    - name: Get expected configs
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/TimeZone
+      register: actual
+    - ansible.builtin.assert:
+        that:
+          - actual.record | length == 1
+          - actual_zone == actual.record.0.timeZone
+          - actual_uuid == actual.record.0.uuid
+
+    - name: Retrieve info about Time Zone - 1 object
+      scale_computing.hypercore.time_zone_info:
+      register: result
+    - ansible.builtin.debug:
+        msg: "{{ result }}"
+    - ansible.builtin.assert:
+        that:
+          - result.record != {}
           - "{{ result.record.keys() | sort == ['latest_task_tag', 'time_zone', 'uuid'] }}"
           - result.record.uuid == actual_uuid
           - result.record.time_zone == actual_zone


### PR DESCRIPTION
Ensure time_zone_info is tested with 0 and 1 time zone configured

Test https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4259825907/jobs/7412400599
failed because no timezone was present, and "actual.record.0.timeZone"
tried to get first record from empty list.

Ensure time_server_info is tested with 0 and 1 time server configured

Test
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4259825907/jobs/7412400755
failed because no timeserver was present, and "time_server.record.0.host"
tried to get first record from empty list.
 