### PR TITLE
Test syslog_server_info with 0 and 1 syslog server present

### DIFF
--- a/tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml
+++ b/tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml
@@ -3,16 +3,47 @@
     SC_HOST: "{{ sc_host }}"
     SC_USERNAME: "{{ sc_username }}"
     SC_PASSWORD: "{{ sc_password }}"
+  vars:
+    # payload to be POST-ed to api
+    syslog_server_config_5:
+      host: 1.2.3.5
+      # port: 43
+      protocol: tcp
 
   block:
+    # -------------------------------------------------------
+    # Test with no AlertSyslogTarget objects
+    - include_tasks: helper_api_syslog_server_delete_all.yml
+
     - name: Retrieve info about Syslog servers
       scale_computing.hypercore.syslog_server_info:
       register: syslog_servers
     - ansible.builtin.debug:
         msg: "{{ syslog_servers.records }}"
-    - ansible.builtin.assert:
+    - name: Assert syslog_server_info with 0 servers
+      ansible.builtin.assert:
+        that:
+          - syslog_servers.records == []
+
+    # -------------------------------------------------------
+    # Test with 1 AlertSyslogTarget object
+    - include_tasks: helper_api_syslog_server_create_one.yml
+      vars:
+        syslog_server_config: "{{ syslog_server_config_5 }}"
+
+    - name: Retrieve info about Syslog servers
+      scale_computing.hypercore.syslog_server_info:
+      register: syslog_servers
+    - ansible.builtin.debug:
+        msg: "{{ syslog_servers.records }}"
+    - name: Assert syslog_server_info with 1 server
+      ansible.builtin.assert:
         that:
           - syslog_servers.records != []
+          - syslog_servers.records | length == 1
           - syslog_servers.records[0].keys() | sort ==
             ['alert_tag_uuid', 'host', 'latest_task_tag', 'port',
             'protocol', 'resend_delay', 'silent_period', 'uuid']
+          - syslog_servers.records[0].host == "1.2.3.5"
+          - syslog_servers.records[0].port == 514
+          #- syslog_servers.records[0].protocol == "tcp"  # fix in module syslog_server_info needed here

--- a/tests/integration/targets/syslog_server/tasks/helper_api_syslog_server_create_one.yml
+++ b/tests/integration/targets/syslog_server/tasks/helper_api_syslog_server_create_one.yml
@@ -1,0 +1,23 @@
+---
+# Create AlertSyslogTarget config.
+# Assumes all AlertSyslogTarget were deleted before.
+
+# Create/POST, not update/PATCH!
+- name: Create a desired AlertSyslogTarget config
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/AlertSyslogTarget
+    data:
+      host: "{{ syslog_server_config.host }}"
+      # port: "{{ (syslog_server_config.port | default(514)) | int }}"  # problem with value having str type, not int.
+      protocol: "{{ (syslog_server_config.protocol | default('udp') == 'udp') | ternary('SYSLOG_PROTOCOL_UDP', 'SYSLOG_PROTOCOL_TCP') }}"
+# TODO wait on TaskTag
+
+- name: Get current AlertSyslogTarget
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/AlertSyslogTarget
+  register: syslog_server_config_result
+- name: Show current AlertSyslogTarget
+  ansible.builtin.debug:
+    var: syslog_server_config_result

--- a/tests/integration/targets/syslog_server/tasks/helper_api_syslog_server_delete_all.yml
+++ b/tests/integration/targets/syslog_server/tasks/helper_api_syslog_server_delete_all.yml
@@ -1,0 +1,18 @@
+---
+# Remove AlertSyslogTarget config.
+
+- name: Get current AlertSyslogTarget
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/AlertSyslogTarget
+  register: syslog_server_config_result
+- name: Show current AlertSyslogTarget
+  ansible.builtin.debug:
+    var: syslog_server_config_result
+
+- name: Remove all existing AlertSyslogTarget configs
+  scale_computing.hypercore.api:
+    action: delete
+    endpoint: /rest/v1/AlertSyslogTarget/{{ item.uuid }}
+  with_items: "{{ syslog_server_config_result.record }}"
+# TODO wait on TaskTag

--- a/tests/integration/targets/syslog_server/tasks/helper_api_syslog_server_reset.yml
+++ b/tests/integration/targets/syslog_server/tasks/helper_api_syslog_server_reset.yml
@@ -1,0 +1,14 @@
+---
+# Reset syslog server configuration when testing is finished.
+# Configure using raw API module.
+# Should work even when all other modules are broken.
+
+- name: Show desired syslog_server_config
+  ansible.builtin.debug:
+    var: syslog_server_config
+
+- name: Delete all AlertSyslogTarget objects
+  include_tasks: helper_api_syslog_server_delete_all.yml
+
+- name: Create one AlertSyslogTarget object
+  include_tasks: helper_api_syslog_server_create_one.yml


### PR DESCRIPTION
Test
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4259825907/jobs/7412400903 failed, there was no syslog server configured.

One extra task for you: line at end of tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml:

```
          #- syslog_servers.records[0].protocol == "tcp"  # fix in module syslog_server_info needed here
```

Info module does not convert `SYSLOG_PROTOCOL_UDP` to `udp`, but it should.
The syslog_server_info module should return values that are same as those accepted by syslog_server module.
You want to be able to directly compare.
Please fix this is separate PR. You can create a new jira issue if you want.