### PR TITLE
Fix syslog_syslog_server_info module output, update tests.

### DIFF
--- a/plugins/module_utils/syslog_server.py
+++ b/plugins/module_utils/syslog_server.py
@@ -147,7 +147,7 @@ class SyslogServer(PayloadMapper):
         ]
 
         for s in state:
-            s["protocol"] = protocols[s["protocol"]]
+            s["protocol"] = protocols[s["protocol"]]  # type: ignore
 
         return state
 

--- a/plugins/module_utils/syslog_server.py
+++ b/plugins/module_utils/syslog_server.py
@@ -64,7 +64,7 @@ class SyslogServer(PayloadMapper):
             alert_tag_uuid=hypercore_data["alertTagUUID"],
             host=hypercore_data["host"],
             port=hypercore_data["port"],
-            protocol=hypercore_data["protocol"],
+            protocol=protocols[hypercore_data["protocol"]],
             resend_delay=hypercore_data["resendDelay"],
             silent_period=hypercore_data["silentPeriod"],
             latest_task_tag=hypercore_data["latestTaskTag"],
@@ -145,9 +145,6 @@ class SyslogServer(PayloadMapper):
                 "/rest/v1/AlertSyslogTarget/"
             )
         ]
-
-        for s in state:
-            s["protocol"] = protocols[s["protocol"]]  # type: ignore
 
         return state
 

--- a/plugins/module_utils/syslog_server.py
+++ b/plugins/module_utils/syslog_server.py
@@ -20,6 +20,8 @@ from ..module_utils.typed_classes import (
 )
 from typing import List, Union, Any, Dict
 
+protocols = {"SYSLOG_PROTOCOL_TCP": "tcp", "SYSLOG_PROTOCOL_UDP": "udp"}
+
 
 class SyslogServer(PayloadMapper):
     def __init__(
@@ -143,6 +145,9 @@ class SyslogServer(PayloadMapper):
                 "/rest/v1/AlertSyslogTarget/"
             )
         ]
+
+        for s in state:
+            s["protocol"] = protocols[s["protocol"]]
 
         return state
 

--- a/plugins/modules/syslog_server.py
+++ b/plugins/modules/syslog_server.py
@@ -177,7 +177,7 @@ def build_update_payload(
     if module.params["protocol"]:
         protocol = get_protocol(module.params["protocol"])
         if protocol != UDP and protocol != syslog_server.protocol:
-            payload["protocol"] = protocol
+            payload["protocol"] = module.params["protocol"]
     return payload
 
 
@@ -202,6 +202,8 @@ def update_syslog_server(
         return False, before, dict(before=before, after=before)
 
     # Otherwise, update with new parameters
+    payload["protocol"] = get_protocol(payload["protocol"])
+
     old_syserver.update(
         rest_client=rest_client,
         payload=payload,

--- a/tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml
+++ b/tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml
@@ -46,4 +46,4 @@
             'protocol', 'resend_delay', 'silent_period', 'uuid']
           - syslog_servers.records[0].host == "1.2.3.5"
           - syslog_servers.records[0].port == 514
-          - syslog_servers.records[0].protocol == "tcp"  # fix in module syslog_server_info needed here
+          - syslog_servers.records[0].protocol == "tcp"

--- a/tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml
+++ b/tests/integration/targets/syslog_server/tasks/01_syslog_server_info.yml
@@ -46,4 +46,4 @@
             'protocol', 'resend_delay', 'silent_period', 'uuid']
           - syslog_servers.records[0].host == "1.2.3.5"
           - syslog_servers.records[0].port == 514
-          #- syslog_servers.records[0].protocol == "tcp"  # fix in module syslog_server_info needed here
+          - syslog_servers.records[0].protocol == "tcp"  # fix in module syslog_server_info needed here

--- a/tests/integration/targets/syslog_server/tasks/02_syslog_server.yml
+++ b/tests/integration/targets/syslog_server/tasks/02_syslog_server.yml
@@ -6,8 +6,8 @@
 
   vars:
     default_port: 514
-    tcp_protocol: SYSLOG_PROTOCOL_TCP
-    udp_protocol: SYSLOG_PROTOCOL_UDP
+    tcp_protocol: "tcp"
+    udp_protocol: "udp"
     create_syslog_server:
       host: 0.0.0.0
       port: 42

--- a/tests/unit/plugins/module_utils/test_syslog_server.py
+++ b/tests/unit/plugins/module_utils/test_syslog_server.py
@@ -23,6 +23,9 @@ pytestmark = pytest.mark.skipif(
     reason=f"requires python{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher",
 )
 
+PROTOCOL_TCP = "SYSLOG_PROTOCOL_TCP"
+ANSIBLE_TCP = "tcp"
+
 
 class TestSyslogServer:
     def setup_method(self):
@@ -31,7 +34,7 @@ class TestSyslogServer:
             alert_tag_uuid="0",
             host="0.0.0.0",
             port=42,
-            protocol="protocol",
+            protocol=PROTOCOL_TCP,
             resend_delay=123,
             silent_period=123,
             latest_task_tag={},
@@ -41,7 +44,7 @@ class TestSyslogServer:
             alertTagUUID="0",
             host="0.0.0.0",
             port=42,
-            protocol="protocol",
+            protocol=PROTOCOL_TCP,
             resendDelay=123,
             silentPeriod=123,
             latestTaskTag={},
@@ -49,14 +52,14 @@ class TestSyslogServer:
         self.to_hypercore_dict = dict(
             host="0.0.0.0",
             port=42,
-            protocol="protocol",
+            protocol=PROTOCOL_TCP,
         )
         self.ansible_dict = dict(
             uuid="test",
             alert_tag_uuid="0",
             host="0.0.0.0",
             port=42,
-            protocol="protocol",
+            protocol=PROTOCOL_TCP,
             resend_delay=123,
             silent_period=123,
             latest_task_tag={},
@@ -107,7 +110,7 @@ class TestSyslogServer:
             "alert_tag_uuid": "0",
             "host": "0.0.0.0",
             "port": 42,
-            "protocol": "protocol",
+            "protocol": ANSIBLE_TCP,
             "resend_delay": 123,
             "silent_period": 123,
             "latest_task_tag": {},

--- a/tests/unit/plugins/module_utils/test_syslog_server.py
+++ b/tests/unit/plugins/module_utils/test_syslog_server.py
@@ -23,8 +23,8 @@ pytestmark = pytest.mark.skipif(
     reason=f"requires python{MIN_PYTHON_VERSION[0]}.{MIN_PYTHON_VERSION[1]} or higher",
 )
 
-PROTOCOL_TCP = "SYSLOG_PROTOCOL_TCP"
-ANSIBLE_TCP = "tcp"
+HYPERCORE_PROTOCOL_TCP = "SYSLOG_PROTOCOL_TCP"
+ANSIBLE_PROTOCOL_TCP = "tcp"
 
 
 class TestSyslogServer:
@@ -34,7 +34,7 @@ class TestSyslogServer:
             alert_tag_uuid="0",
             host="0.0.0.0",
             port=42,
-            protocol=PROTOCOL_TCP,
+            protocol=ANSIBLE_PROTOCOL_TCP,
             resend_delay=123,
             silent_period=123,
             latest_task_tag={},
@@ -44,7 +44,7 @@ class TestSyslogServer:
             alertTagUUID="0",
             host="0.0.0.0",
             port=42,
-            protocol=PROTOCOL_TCP,
+            protocol=HYPERCORE_PROTOCOL_TCP,
             resendDelay=123,
             silentPeriod=123,
             latestTaskTag={},
@@ -52,14 +52,14 @@ class TestSyslogServer:
         self.to_hypercore_dict = dict(
             host="0.0.0.0",
             port=42,
-            protocol=PROTOCOL_TCP,
+            protocol=ANSIBLE_PROTOCOL_TCP,
         )
         self.ansible_dict = dict(
             uuid="test",
             alert_tag_uuid="0",
             host="0.0.0.0",
             port=42,
-            protocol=PROTOCOL_TCP,
+            protocol=ANSIBLE_PROTOCOL_TCP,
             resend_delay=123,
             silent_period=123,
             latest_task_tag={},
@@ -110,7 +110,7 @@ class TestSyslogServer:
             "alert_tag_uuid": "0",
             "host": "0.0.0.0",
             "port": 42,
-            "protocol": ANSIBLE_TCP,
+            "protocol": ANSIBLE_PROTOCOL_TCP,
             "resend_delay": 123,
             "silent_period": 123,
             "latest_task_tag": {},

--- a/tests/unit/plugins/modules/test_syslog_server_info.py
+++ b/tests/unit/plugins/modules/test_syslog_server_info.py
@@ -25,14 +25,22 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestRun:
-    def test_run_record_present(self, rest_client):
+    # This also tests the get_state() method from module_utils/test_syslog_server again
+    @pytest.mark.parametrize(
+        ("protocol", "expected_protocol"),
+        [
+            ("SYSLOG_PROTOCOL_UDP", "udp"),
+            ("SYSLOG_PROTOCOL_TCP", "tcp"),
+        ],
+    )
+    def test_run_record_present(self, rest_client, protocol, expected_protocol):
         rest_client.list_records.return_value = [
             dict(
                 uuid="test",
                 alertTagUUID="0",
                 host="0.0.0.0",
                 port=42,
-                protocol="protocol",
+                protocol=protocol,
                 resendDelay=123,
                 silentPeriod=123,
                 latestTaskTag={},
@@ -46,7 +54,7 @@ class TestRun:
                 "alert_tag_uuid": "0",
                 "host": "0.0.0.0",
                 "port": 42,
-                "protocol": "protocol",
+                "protocol": expected_protocol,
                 "resend_delay": 123,
                 "silent_period": 123,
                 "latest_task_tag": {},


### PR DESCRIPTION
Fixed a minor issue pointed out in pull request #132.
> Info module does not convert ``SYSLOG_PROTOCOL_UDP`` to ``udp``, but it should.
> The syslog_server_info module should return values that are same as those accepted by syslog_server module.