### PR TITLE
Replace 'email_address' to 'email' in records return.

### DIFF
--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -26,14 +26,14 @@ class EmailAlert(PayloadMapper):
         self,
         uuid: Union[str, None] = None,
         alert_tag_uuid: Union[str, None] = None,
-        email_address: Union[str, None] = None,
+        email: Union[str, None] = None,
         resend_delay: Union[int, None] = None,
         silent_period: Union[int, None] = None,
         latest_task_tag: Union[TypedTaskTag, dict[Any, Any], None] = None,
     ):
         self.uuid = uuid
         self.alert_tag_uuid = alert_tag_uuid
-        self.email_address = email_address
+        self.email = email
         self.resend_delay = resend_delay
         self.silent_period = silent_period
         self.latest_task_tag = latest_task_tag if latest_task_tag is not None else {}
@@ -43,7 +43,7 @@ class EmailAlert(PayloadMapper):
         return EmailAlert(
             uuid=ansible_data["uuid"],
             alert_tag_uuid=ansible_data["alert_tag_uuid"],
-            email_address=ansible_data["email_address"],
+            email=ansible_data["email"],
         )
 
     @classmethod
@@ -53,7 +53,7 @@ class EmailAlert(PayloadMapper):
         return cls(
             uuid=hypercore_data["uuid"],
             alert_tag_uuid=hypercore_data["alertTagUUID"],
-            email_address=hypercore_data["emailAddress"],
+            email=hypercore_data["emailAddress"],
             resend_delay=hypercore_data["resendDelay"],
             silent_period=hypercore_data["silentPeriod"],
             latest_task_tag=hypercore_data["latestTaskTag"],
@@ -62,7 +62,7 @@ class EmailAlert(PayloadMapper):
     def to_hypercore(self) -> dict[Any, Any]:
         return dict(
             alertTagUUID=self.alert_tag_uuid,
-            emailAddress=self.email_address,
+            emailAddress=self.email,
             resendDelay=self.resend_delay,
             silentPeriod=self.silent_period,
         )
@@ -71,7 +71,7 @@ class EmailAlert(PayloadMapper):
         return dict(
             uuid=self.uuid,
             alert_tag_uuid=self.alert_tag_uuid,
-            email_address=self.email_address,
+            email=self.email,
             resend_delay=self.resend_delay,
             silent_period=self.silent_period,
             latest_task_tag=self.latest_task_tag,
@@ -85,7 +85,7 @@ class EmailAlert(PayloadMapper):
             (
                 self.uuid == other.uuid,
                 self.alert_tag_uuid == other.alert_tag_uuid,
-                self.email_address == other.email_address,
+                self.email == other.email,
                 self.resend_delay == other.resend_delay,
                 self.silent_period == other.silent_period,
                 self.latest_task_tag == other.latest_task_tag,
@@ -115,8 +115,8 @@ class EmailAlert(PayloadMapper):
     ):
         query = get_query(
             ansible_dict,
-            "email_address",
-            ansible_hypercore_map=dict(email_address="emailAddress"),
+            "email",
+            ansible_hypercore_map=dict(email="emailAddress"),
         )
         hypercore_dict = rest_client.get_record(
             "/rest/v1/AlertEmailTarget", query, must_exist=must_exist

--- a/plugins/module_utils/typed_classes.py
+++ b/plugins/module_utils/typed_classes.py
@@ -138,7 +138,7 @@ class TypedSmtpFromAnsible(TypedDict):
 class TypedEmailAlertToAnsible(TypedDict):
     uuid: Union[str, None]
     alert_tag_uuid: Union[str, None]
-    email_address: Union[str, None]
+    email: Union[str, None]
     resend_delay: Union[int, None]
     silent_period: Union[int, None]
     latest_task_tag: Union[TypedTaskTag, dict[Any, Any], None]
@@ -147,7 +147,7 @@ class TypedEmailAlertToAnsible(TypedDict):
 class TypedEmailAlertFromAnsible(TypedDict):
     uuid: Union[str, None]
     alert_tag_uuid: Union[str, None]
-    email_address: Union[str, None]
+    email: Union[str, None]
     resend_delay: Union[int, None]
     silent_period: Union[int, None]
     latest_task_tag: Union[TypedTaskTag, None]

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -81,7 +81,7 @@ records:
   type: dict
   sample:
     alert_tag_uuid: 0
-    email_address: sample@sample.com
+    email: sample@sample.com
     latest_task_tag:
       completed: 1675680830
       created: 1675680830
@@ -116,7 +116,7 @@ from ..module_utils.email_alert import EmailAlert
 
 def create_email_alert(module: AnsibleModule, rest_client: RestClient):
     email_alert = EmailAlert.get_by_email(
-        dict(email_address=module.params["email"]), rest_client
+        dict(email=module.params["email"]), rest_client
     )
 
     # If that email alert recipient already exists, it will not be created again (no duplicates)
@@ -142,13 +142,11 @@ def create_email_alert(module: AnsibleModule, rest_client: RestClient):
 
 def update_email_alert(module: AnsibleModule, rest_client: RestClient):
     # Get record of old emailAlert by email
-    old_email = EmailAlert.get_by_email(
-        dict(email_address=module.params["email"]), rest_client
-    )
+    old_email = EmailAlert.get_by_email(dict(email=module.params["email"]), rest_client)
 
     if not old_email:
         old_email = EmailAlert.get_by_email(
-            dict(email_address=module.params["email_new"]), rest_client
+            dict(email=module.params["email_new"]), rest_client
         )
         if not old_email:
             raise errors.ScaleComputingError(
@@ -159,7 +157,7 @@ def update_email_alert(module: AnsibleModule, rest_client: RestClient):
 
     # Return if there are no changes
     if (
-        module.params["email_new"] == old_email.to_ansible().get("email_address")
+        module.params["email_new"] == old_email.to_ansible().get("email")
         or module.params["email_new"] == module.params["email"]
     ):
         return False, before, dict(before=before, after=before)
@@ -171,7 +169,7 @@ def update_email_alert(module: AnsibleModule, rest_client: RestClient):
         check_mode=module.check_mode,
     )
     new_email = EmailAlert.get_by_email(
-        dict(email_address=module.params["email_new"]), rest_client
+        dict(email=module.params["email_new"]), rest_client
     )
     after = new_email.to_ansible()
 
@@ -184,7 +182,7 @@ def update_email_alert(module: AnsibleModule, rest_client: RestClient):
 
 def delete_email_alert(module: AnsibleModule, rest_client: RestClient):
     delete_email = EmailAlert.get_by_email(
-        dict(email_address=module.params["email"]), rest_client
+        dict(email=module.params["email"]), rest_client
     )
 
     if not delete_email:
@@ -202,7 +200,7 @@ def delete_email_alert(module: AnsibleModule, rest_client: RestClient):
 
 def send_test(module: AnsibleModule, rest_client: RestClient):
     send_email = EmailAlert.get_by_email(
-        dict(email_address=module.params["email"]), rest_client
+        dict(email=module.params["email"]), rest_client
     )
 
     if (
@@ -217,7 +215,7 @@ def send_test(module: AnsibleModule, rest_client: RestClient):
     )
 
     after_send_email = EmailAlert.get_by_email(
-        dict(email_address=module.params["email"]), rest_client
+        dict(email=module.params["email"]), rest_client
     )
     after = after_send_email.to_ansible()
 

--- a/plugins/modules/email_alert_info.py
+++ b/plugins/modules/email_alert_info.py
@@ -39,7 +39,7 @@ records:
   type: list
   sample:
     - alert_tag_uuid: 0
-      email_address: sample@sample.com
+      email: sample@sample.com
       latest_task_tag:
         completed: 1675680830
         created: 1675680830

--- a/tests/integration/targets/email_alert/tasks/01_email_alert_info.yml
+++ b/tests/integration/targets/email_alert/tasks/01_email_alert_info.yml
@@ -8,9 +8,11 @@
     - name: Retrieve info about Email alert recipients
       scale_computing.hypercore.email_alert_info:
       register: emails
+    - ansible.builtin.debug:
+        var: emails
     - ansible.builtin.assert:
         that:
           - emails.records != []
           - emails.records[0].keys() | sort ==
-            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            ['alert_tag_uuid', 'email', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']

--- a/tests/integration/targets/email_alert/tasks/02_email_alert.yml
+++ b/tests/integration/targets/email_alert/tasks/02_email_alert.yml
@@ -21,7 +21,7 @@
 
     - name: Prepare for test - cleanup (also test Remove with loop)
       scale_computing.hypercore.email_alert:
-        email: "{{ item.email_address }}"
+        email: "{{ item.email }}"
         state: absent
       loop: "{{ starting_emails }}"
     - scale_computing.hypercore.email_alert_info:
@@ -48,10 +48,10 @@
         that:
           - result.record != {}
           - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            ['alert_tag_uuid', 'email', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']
           - info.records|length == 1|int
-          - info.records[0].email_address == "{{ create_email }}"
+          - info.records[0].email == "{{ create_email }}"
 
     - name: Create new Email Alert Recipient - idempotence
       scale_computing.hypercore.email_alert:
@@ -82,7 +82,7 @@
         that:
           - result.record != {}
           - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            ['alert_tag_uuid', 'email', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']
           - info.records|length == 1|int
 
@@ -116,7 +116,7 @@
           - info.records|length == 1|int
           - result.record != {}
           - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            ['alert_tag_uuid', 'email', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']
 
 
@@ -136,7 +136,7 @@
           - info.records|length == 1|int
           - result.record != {}
           - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email_address', 'latest_task_tag',
+            ['alert_tag_uuid', 'email', 'latest_task_tag',
             'resend_delay', 'silent_period', 'uuid']
 
 

--- a/tests/unit/plugins/module_utils/test_email_alert.py
+++ b/tests/unit/plugins/module_utils/test_email_alert.py
@@ -29,7 +29,7 @@ class TestEmailAlert:
         self.email_alert = EmailAlert(
             uuid="8664ed18-c354-4bab-be96-78dae5f6377f",
             alert_tag_uuid="0",
-            email_address="test@test.com",
+            email="test@test.com",
             resend_delay=123,
             silent_period=123,
             latest_task_tag={},
@@ -51,7 +51,7 @@ class TestEmailAlert:
         self.ansible_dict = dict(
             uuid="8664ed18-c354-4bab-be96-78dae5f6377f",
             alert_tag_uuid="0",
-            email_address="test@test.com",
+            email="test@test.com",
             resend_delay=123,
             silent_period=123,
             latest_task_tag={},
@@ -75,7 +75,7 @@ class TestEmailAlert:
         assert email_alert_from_ansible == EmailAlert(
             uuid=email_alert_from_ansible.uuid,
             alert_tag_uuid=email_alert_from_ansible.alert_tag_uuid,
-            email_address=email_alert_from_ansible.email_address,
+            email=email_alert_from_ansible.email,
         )
 
     def test_get_by_uuid(self, rest_client):
@@ -95,7 +95,7 @@ class TestEmailAlert:
         expected = {
             "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
             "alert_tag_uuid": "0",
-            "email_address": "test@test.com",
+            "email": "test@test.com",
             "resend_delay": 123,
             "silent_period": 123,
             "latest_task_tag": {},
@@ -114,7 +114,5 @@ class TestEmailAlert:
     def test_get_by_email(self, rest_client):
         rest_client.get_record.return_value = dict(**self.from_hypercore_dict)
 
-        result = EmailAlert.get_by_email(
-            dict(email_address="test@test.com"), rest_client
-        )
+        result = EmailAlert.get_by_email(dict(email="test@test.com"), rest_client)
         assert result == self.email_alert

--- a/tests/unit/plugins/modules/test_email_alert.py
+++ b/tests/unit/plugins/modules/test_email_alert.py
@@ -50,7 +50,7 @@ class TestModifyEmailAlert:
                     dict(
                         uuid="test",
                         alert_tag_uuid="0",
-                        email_address="test@test.com",
+                        email="test@test.com",
                         resend_delay=123,
                         silent_period=123,
                         latest_task_tag={},
@@ -61,7 +61,7 @@ class TestModifyEmailAlert:
                 EmailAlert(
                     uuid="test",
                     alert_tag_uuid="0",
-                    email_address="test@test.com",
+                    email="test@test.com",
                     resend_delay=123,
                     silent_period=123,
                     latest_task_tag={},
@@ -71,7 +71,7 @@ class TestModifyEmailAlert:
                     dict(
                         uuid="test",
                         alert_tag_uuid="0",
-                        email_address="test@test.com",
+                        email="test@test.com",
                         resend_delay=123,
                         silent_period=123,
                         latest_task_tag={},
@@ -137,7 +137,7 @@ class TestModifyEmailAlert:
                     dict(
                         uuid="test",
                         alert_tag_uuid="0",
-                        email_address="new@test.com",
+                        email="new@test.com",
                         resend_delay=123,
                         silent_period=123,
                         latest_task_tag={},
@@ -154,7 +154,7 @@ class TestModifyEmailAlert:
                     dict(
                         uuid="test",
                         alert_tag_uuid="0",
-                        email_address="test@test.com",
+                        email="test@test.com",
                         resend_delay=123,
                         silent_period=123,
                         latest_task_tag={},
@@ -188,7 +188,7 @@ class TestModifyEmailAlert:
             rc_email_alert = EmailAlert(
                 uuid="test",
                 alert_tag_uuid="0",
-                email_address=email_on_client,
+                email=email_on_client,
                 resend_delay=123,
                 silent_period=123,
                 latest_task_tag={},
@@ -252,7 +252,7 @@ class TestModifyEmailAlert:
                 EmailAlert(
                     uuid="test",
                     alert_tag_uuid="0",
-                    email_address="test@test.com",
+                    email="test@test.com",
                     resend_delay=123,
                     silent_period=123,
                     latest_task_tag={},
@@ -314,7 +314,7 @@ class TestModifyEmailAlert:
                 EmailAlert(
                     uuid="test",
                     alert_tag_uuid="0",
-                    email_address="test@test.com",
+                    email="test@test.com",
                     resend_delay=123,
                     silent_period=123,
                     latest_task_tag={},

--- a/tests/unit/plugins/modules/test_email_alert_info.py
+++ b/tests/unit/plugins/modules/test_email_alert_info.py
@@ -42,7 +42,7 @@ class TestRun:
             {
                 "uuid": "8664ed18-c354-4bab-be96-78dae5f6377f",
                 "alert_tag_uuid": "0",
-                "email_address": "test@test.com",
+                "email": "test@test.com",
                 "resend_delay": 123,
                 "silent_period": 123,
                 "latest_task_tag": {},


### PR DESCRIPTION
Names of return values didn't match the names of input parameters.
- renamed ``email_address`` to ``email``