### PR TITLE
Fix documentation for time_zone_info.

### DIFF
--- a/plugins/modules/time_zone_info.py
+++ b/plugins/modules/time_zone_info.py
@@ -15,7 +15,7 @@ author:
   - Ana Zobec (@anazobec)
 short_description: List Time Zone configuration on HyperCore API
 description:
-  - Use this module to list information about the DNS configuration on HyperCore API.
+  - Use this module to list information about the Time Zone configuration on HyperCore API.
 version_added: 1.2.0
 extends_documentation_fragment:
   - scale_computing.hypercore.cluster_instance


### PR DESCRIPTION
The description in ``time_zone_info`` was not about the said module (copy-paste mistake), so it had to be changed.