### PR TITLE
Fix OIDC typo

### DIFF
--- a/examples/oidc_config_setup_azure_ad.yml
+++ b/examples/oidc_config_setup_azure_ad.yml
@@ -3,6 +3,15 @@
   hosts: localhost
   connection: local
   gather_facts: false
+  # We do not want to reconfigure cluster with bogus example values.
+  # OIDC cannot be removed once setup!
+  check_mode: true
+
+  vars:
+    oidc_client_id: your_client_id
+    oidc_shared_secret: your_client_secret
+    oidc_config_url: https://login.microsoftonline.com/your_uuid/v2.0/.well-known/openid-configuration
+    oidc_scopes: "openid+profile"
 
   tasks:
     # ------------------------------------------------------
@@ -16,10 +25,10 @@
 
     - name: Create or update OIDC config
       scale_computing.hypercore.oidc_config:
-        client_id: <your_client_id>
-        shared_secret: <your_shared_secret>
-        config_url: <your_configuration_url>
-        scopes: <your_scopes>
+        client_id: "{{ oidc_client_id }}"
+        shared_secret: "{{ oidc_shared_secret }}"
+        config_url: "{{ oidc_config_url }}"
+        scopes: "{{ oidc_scopes }}"
 
     - name: List updated oidc config
       scale_computing.hypercore.oidc_config_info:

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -57,7 +57,6 @@ EXAMPLES = r"""
     certificate: plain_text_from_x509
     config_url: https:somwhere.com/this/endpoint
     scopes: required_scopes
-    state: present
 """
 
 RETURN = r"""

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -46,6 +46,7 @@ options:
     type: str
     required: true
 notes:
+  - Module is not idempotent, it will always report changed=True.
   - C(check_mode) is not supported.
 """
 

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -55,8 +55,8 @@ EXAMPLES = r"""
     client_id: 12345
     shared_secret: secret_stuff
     certificate: plain_text_from_x509
-    config_url: https:somwhere.com/this/endpoint
-    scopes: required_scopes
+    config_url: https://login.microsoftonline.com/your_uuid/v2.0/.well-known/openid-configuration
+    scopes: "openid+profile"
 """
 
 RETURN = r"""
@@ -66,9 +66,9 @@ record:
   returned: success
   type: dict
   sample:
-    client_id: 1234
-    config_url: https://somewhere.com/this/endpoint
-    scopes: required_scopes
+    client_id: 12345
+    config_url: https://login.microsoftonline.com/your_uuid/v2.0/.well-known/openid-configuration
+    scopes: "openid+profile"
 """
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
oidc module has no `state` param.

Example in oidc.py is updated with copy-paste friendly values.
Example in examples/ is update to be runnable with `-e`. E.g. with `ansible-playbook -e oidc_client_id=my_id ...` you can directly setup a valid configuration.