### PR TITLE
Document smtp module is not idempotent if authentication is used

### DIFF
--- a/plugins/modules/smtp.py
+++ b/plugins/modules/smtp.py
@@ -63,6 +63,8 @@ notes:
   - SMTP authentication can be configured using username and password.
     In this case the configured username is returned, but password is not.
     Returned password is always empty string ("").
+  - Module is not idempotent if authentication is used.
+    In this case it will always report C(changed=True).
 """
 
 


### PR DESCRIPTION
Document smtp module is not idempotent if authentication is used