### PR TITLE
Fix typo in update_status_check, fix force shutdown.

### DIFF
--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -9,11 +9,24 @@
 - name: Shutdown running VMs
   scale_computing.hypercore.vm_params:
     vm_name: "{{ item.vm_name }}"
-    power_state: stop
+    power_state: shutdown
   when: item.power_state == 'started'
   loop: "{{ vms.records }}"
   register: vm_shutdown_result
+  ignore_errors: true  # if VMs fail to shut down without force, error will occur, so we skip and try on to shut down with force
 
 - name: Show shutdown results
   ansible.builtin.debug:
     var: vm_shutdown_result
+
+- name: Force shutdown the remaining running VMs
+  scale_computing.hypercore.vm_params:
+    vm_name: "{{ item.item.vm_name }}"
+    power_state: stop
+  when: item.item.power_state == 'started'
+  loop: "{{ vm_shutdown_result.results }}"
+  register: vm_stop_result
+
+- name: Show VM stop results
+  ansible.builtin.debug:
+    var: vm_stop_result

--- a/roles/version_update_single_node/tasks/update_status_check.yml
+++ b/roles/version_update_single_node/tasks/update_status_check.yml
@@ -3,7 +3,7 @@
   block:
     - name: Increment retry_count
       ansible.builtin.set_fact:
-        retry_count: "{{ 0 if retry_count is undefined else retries | int + 1 }}"
+        retry_count: "{{ 0 if retry_count is undefined else retry_count | int + 1 }}"
 
     # We might be able to remove this task
     - name: Pause before checking update status - checks will report FAILED-RETRYING until update COMPLETE/TERMINATED


### PR DESCRIPTION
There was a typo in ``roles/version_update_single_node/update_status_check.yml``, so that had to be fixed.

In ``roles/version_update_single_node/shutdown_vms.yml`` shutting down VMs was done by using "stop" power state (force shutdwon) right away. This was changed, so that we first try shutting down VMs usinng the "shutdown" power state (regular shutdown) and then, if that fails, we use "stop" power state to forcibly shut down the rest of the VMs.