### PR TITLE
Document VM shutdown options

### DIFF
--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -66,6 +66,13 @@ options:
       - Desired VM state.
       - States C(PAUSE) and C(LIVEMIGRATE) are not exposed in this module
         (this can be done with raw api module).
+      - Note that
+        - I(shutdown) will trigger a graceful ACPI shutdown.
+        - I(reboot) will trigger a graceful ACPI reboot.
+        - I(stop) will trigger an abrupt shutdown (force power off).
+          VM might loose data, and filesystem might be corrupted afterwards.
+        - I(reset) will trigger an abrupt reset (force power reset).
+          VM might loose data, and filesystem might be corrupted afterwards.
     choices: [ start, shutdown, stop, reboot, reset ]
     type: str
     default: start

--- a/plugins/modules/vm_params.py
+++ b/plugins/modules/vm_params.py
@@ -51,7 +51,15 @@ options:
   power_state:
     description:
       - Desired VM state.
-      - States C(PAUSE) and C(LIVEMIGRATE) are not exposed in this module (this can be done with raw api module).
+      - States C(PAUSE) and C(LIVEMIGRATE) are not exposed in this module
+        (this can be done with raw api module).
+      - Note that
+        - I(shutdown) will trigger a graceful ACPI shutdown.
+        - I(reboot) will trigger a graceful ACPI reboot.
+        - I(stop) will trigger an abrupt shutdown (force power off).
+          VM might loose data, and filesystem might be corrupted afterwards.
+        - I(reset) will trigger an abrupt reset (force power reset).
+          VM might loose data, and filesystem might be corrupted afterwards.
     choices: [ start, shutdown, stop, reboot, reset ]
     type: str
   operating_system:


### PR DESCRIPTION
Extend VM shutdown options documentation. I do not want to duplicate what is already documented in Scale docs, but this one is just easy to miss. We ended using force shutdown during node upgrade - bad. So we need a bit more documentation.