### PR TITLE
Ignore SSL protocol violation during certificate replacement

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,7 +9,7 @@ jobs:
   mypy:
     name: Type checks (mypy)
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -26,7 +26,7 @@ jobs:
 
   docs:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -40,7 +40,7 @@ jobs:
 
   sanity-test:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -58,7 +58,7 @@ jobs:
 
   units-test:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -41,7 +41,7 @@ jobs:
   # to delay integ-test until integration-prepare-env finishes.
   integration-prepare-env:
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     env:
       ANSIBLE_COLLECTIONS_PATH:  $GITHUB_WORKSPACE/work-dir
     defaults:
@@ -68,7 +68,7 @@ jobs:
 
   integ-matrix:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -97,7 +97,7 @@ jobs:
 
   examples-matrix:
     runs-on: [ ubuntu-latest ]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -125,7 +125,7 @@ jobs:
     needs:
       - examples-matrix
     runs-on: [ self-hosted2 ]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     env:
       ANSIBLE_COLLECTIONS_PATH:  $GITHUB_WORKSPACE/work-dir
       DEBIAN_FRONTEND: noninteractive
@@ -164,7 +164,7 @@ jobs:
       - integ-matrix
       # - units-test
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     env:
       DEBIAN_FRONTEND: noninteractive
     defaults:
@@ -203,7 +203,7 @@ jobs:
     needs:
       - integ
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     env:
       ANSIBLE_COLLECTIONS_PATH:  $GITHUB_WORKSPACE/work-dir
     defaults:
@@ -230,7 +230,7 @@ jobs:
     needs:
       - integ
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:1
+    container: quay.io/justinc1_github/scale_ci_integ:2
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}

--- a/ci-infra/docker-image/Dockerfile
+++ b/ci-infra/docker-image/Dockerfile
@@ -9,7 +9,7 @@ ARG ANSIBLE_CORE_VERSION
 
 ENV LANG=en_US.UTF-8
 
-RUN apt update && apt install -y git make smbclient genisoimage qemu-utils jq
+RUN apt update && apt install -y git make smbclient genisoimage qemu-utils jq sudo procps
 RUN pip install --upgrade pip wheel
 
 COPY all.requirements /code/ci-infra/docker-image/

--- a/ci-infra/docker-image/build.sh
+++ b/ci-infra/docker-image/build.sh
@@ -11,7 +11,7 @@ set -eux
 # Where to push images
 DOCKER_REGISTRY_REPO=quay.io/justinc1_github/scale_ci_integ
 # Tag to push
-DOCKER_IMAGE_TAG=1
+DOCKER_IMAGE_TAG=2
 
 DOCKER_CACHE="${DOCKER_CACHE:-n}"
 if [ "$DOCKER_CACHE" == "n" ]
@@ -24,7 +24,7 @@ fi
 THIS_SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 REPO_DIR="$(realpath "$THIS_SCRIPT_DIR/../.." )"
 
-cat "$REPO_DIR/{docs,test,sanity,mypy}.requirements" > all.requirements
+cat "$REPO_DIR"/{docs,test,sanity,mypy}.requirements > all.requirements
 # TODO but is ghrc.io feature available/enabled?
 # Or push to quay.io?
 docker build "$DOCKER_BUILD_OPT" -t "$DOCKER_REGISTRY_REPO:$DOCKER_IMAGE_TAG" .

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 __metaclass__ = type
 
 import json
+import ssl
 from typing import Any, Optional, Union
 
 from ansible.module_utils.urls import Request, basic_auth_header
@@ -141,6 +142,13 @@ class Client:
                 and type(e.args[0]) == ConnectionResetError
             ):
                 raise ConnectionResetError(e)
+            elif (
+                e.args
+                and isinstance(e.args, tuple)
+                and type(e.args[0])
+                in [ssl.SSLEOFError, ssl.SSLZeroReturnError, ssl.SSLSyscallError]
+            ):
+                raise type(e.args[0])(e)
             raise ScaleComputingError(e.reason)
         return Response(raw_resp.status, raw_resp.read(), raw_resp.headers)
 

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -116,28 +116,14 @@ def ensure_present(
             )
             sleep(2)
             continue
-        except errors.ScaleComputingError as ex:
+        except (ssl.SSLEOFError, ssl.SSLZeroReturnError, ssl.SSLSyscallError) as ex:
             # Ignore "EOF occurred in violation of protocol (_ssl.c:997)"
-            # Also other have same problem - https://github.com/psf/requests/issues/3006#issuecomment-183394849.
-            # We do not use requests library, but problem is the same.
-            # ex.args - this is what Exception.__init__() stores into object.
-            ex_reason = ex.args[0]
-            # ex_reason is instance of SSLEOFError or ssl.SSLEOFError
-            strerror = ex_reason.strerror
-            if (
-                "EOF occurred in violation of protocol" in strerror
-                and "ssl.c" in strerror
-            ):
-                module.warn(
-                    f"retry {ii}/{max_retries}, SSLEOFError - ignore and continue"
-                )
-                sleep(2)
-                continue
-            else:
-                module.warn(
-                    f"retry {ii}/{max_retries}, re-raise unexpected exception" + str(ex)
-                )
-                raise
+            # Alternative message "TLS/SSL connection has been closed (EOF) (_ssl.c:1129)".
+            module.warn(
+                f"retry {ii}/{max_retries}, SSL error {ex.__class__.__name__} - ignore and continue"
+            )
+            sleep(2)
+            continue
     after: TypedCertificateToAnsible = dict(certificate=get_certificate(module))
     return True, after, dict(before=before, after=after)
 

--- a/tests/integration/targets/certificate/files/pyproxy.py
+++ b/tests/integration/targets/certificate/files/pyproxy.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-__author__      = 'Radoslaw Matusiak'
-__copyright__   = 'Copyright (c) 2016 Radoslaw Matusiak'
-__license__     = 'MIT'
-__version__     = '0.1'
+__author__ = "Radoslaw Matusiak"
+__copyright__ = "Copyright (c) 2016 Radoslaw Matusiak"
+__license__ = "MIT"
+__version__ = "0.1"
 
 
 """
@@ -15,45 +15,49 @@ module certificate.py.
 """
 
 import argparse
-import signal
 import logging
 import select
 import socket
 import time
 
 
-FORMAT = '%(asctime)-15s %(levelname)-10s %(message)s'
+FORMAT = "%(asctime)-15s %(levelname)-10s %(message)s"
 logging.basicConfig(format=FORMAT)
 LOGGER = logging.getLogger()
 
-LOCAL_DATA_HANDLER = lambda x:x
-REMOTE_DATA_HANDLER = lambda x:x
 
-BUFFER_SIZE = 2 ** 10  # 1024. Keep buffer size as power of 2.
+def noop_data_handler(x):
+    return x
+
+
+LOCAL_DATA_HANDLER = noop_data_handler
+REMOTE_DATA_HANDLER = noop_data_handler
+
+BUFFER_SIZE = 2**10  # 1024. Keep buffer size as power of 2.
 
 
 def udp_proxy(src, dst):
     """Run UDP proxy.
-    
+
     Arguments:
     src -- Source IP address and port string. I.e.: '127.0.0.1:8000'
     dst -- Destination IP address and port. I.e.: '127.0.0.1:8888'
     """
-    LOGGER.debug('Starting UDP proxy...')
-    LOGGER.debug('Src: {}'.format(src))
-    LOGGER.debug('Dst: {}'.format(dst))
-    
+    LOGGER.debug("Starting UDP proxy...")
+    LOGGER.debug("Src: {}".format(src))
+    LOGGER.debug("Dst: {}".format(dst))
+
     proxy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     proxy_socket.bind(ip_to_tuple(src))
-    
+
     client_address = None
     server_address = ip_to_tuple(dst)
-    
-    LOGGER.debug('Looping proxy (press Ctrl-Break to stop)...')
+
+    LOGGER.debug("Looping proxy (press Ctrl-Break to stop)...")
     while True:
         data, address = proxy_socket.recvfrom(BUFFER_SIZE)
-        
-        if client_address == None:
+
+        if client_address is None:
             client_address = address
 
         if address == client_address:
@@ -64,21 +68,23 @@ def udp_proxy(src, dst):
             proxy_socket.sendto(data, client_address)
             client_address = None
         else:
-            LOGGER.warning('Unknown address: {}'.format(str(address)))
-# end-of-function udp_proxy    
-    
-    
+            LOGGER.warning("Unknown address: {}".format(str(address)))
+
+
+# end-of-function udp_proxy
+
+
 def tcp_proxy(src, dst):
     """Run TCP proxy.
-    
+
     Arguments:
     src -- Source IP address and port string. I.e.: '127.0.0.1:8000'
     dst -- Destination IP address and port. I.e.: '127.0.0.1:8888'
     """
-    LOGGER.debug('Starting TCP proxy...')
-    LOGGER.debug('Src: {}'.format(src))
-    LOGGER.debug('Dst: {}'.format(dst))
-    
+    LOGGER.debug("Starting TCP proxy...")
+    LOGGER.debug("Src: {}".format(src))
+    LOGGER.debug("Dst: {}".format(dst))
+
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(ip_to_tuple(src))
@@ -88,6 +94,8 @@ def tcp_proxy(src, dst):
     while 1:
         tcp_proxy_one_conn(s, dst, connection_count)
         connection_count += 1
+
+
 # end-of-function tcp_proxy
 
 
@@ -113,17 +121,16 @@ def tcp_proxy_one_conn(s, dst, connection_count):
     ]
 
     restart = False
-    byte_count_dst = 0
     while True:
         s_read, _, _ = select.select(sockets, [], [])
-        source = "SRC" if s_read == s_src else "DST"
+        # source = "SRC" if s_read == s_src else "DST"
         # LOGGER.debug('select from {}'.format(source))
 
         for s in s_read:
             try:
                 data = s.recv(BUFFER_SIZE)
             except ConnectionResetError:
-                LOGGER.info(f'ConnectionResetError on socket {s}, close and restart')
+                LOGGER.info(f"ConnectionResetError on socket {s}, close and restart")
                 restart = True
                 break
 
@@ -146,7 +153,9 @@ def tcp_proxy_one_conn(s, dst, connection_count):
                     restart = True
                     break
                 if inject_ssl_eof_error(connection_count):
-                    LOGGER.info(f"Injecting SSL EOF to connection {s_src.getpeername()}")
+                    LOGGER.info(
+                        f"Injecting SSL EOF to connection {s_src.getpeername()}"
+                    )
                     restart = True
                     break
                 s_src.sendall(d)
@@ -175,44 +184,55 @@ def inject_ssl_eof_error(connection_count):
 
 def ip_to_tuple(ip):
     """Parse IP string and return (ip, port) tuple.
-    
+
     Arguments:
     ip -- IP address:port string. I.e.: '127.0.0.1:8000'.
     """
-    ip, port = ip.split(':')
+    ip, port = ip.split(":")
     return (ip, int(port))
+
+
 # end-of-function ip_to_tuple
 
 
 def main():
     """Main method."""
-    parser = argparse.ArgumentParser(description='TCP/UPD proxy.')
-    
+    parser = argparse.ArgumentParser(description="TCP/UPD proxy.")
+
     # TCP UPD groups
     proto_group = parser.add_mutually_exclusive_group(required=True)
-    proto_group.add_argument('--tcp', action='store_true', help='TCP proxy')
-    proto_group.add_argument('--udp', action='store_true', help='UDP proxy')
-    
-    parser.add_argument('-s', '--src', required=True, help='Source IP and port, i.e.: 127.0.0.1:8000')
-    parser.add_argument('-d', '--dst', required=True, help='Destination IP and port, i.e.: 127.0.0.1:8888')
-    
+    proto_group.add_argument("--tcp", action="store_true", help="TCP proxy")
+    proto_group.add_argument("--udp", action="store_true", help="UDP proxy")
+
+    parser.add_argument(
+        "-s", "--src", required=True, help="Source IP and port, i.e.: 127.0.0.1:8000"
+    )
+    parser.add_argument(
+        "-d",
+        "--dst",
+        required=True,
+        help="Destination IP and port, i.e.: 127.0.0.1:8888",
+    )
+
     output_group = parser.add_mutually_exclusive_group()
-    output_group.add_argument('-q', '--quiet', action='store_true', help='Be quiet')
-    output_group.add_argument('-v', '--verbose', action='store_true', help='Be loud')
-    
+    output_group.add_argument("-q", "--quiet", action="store_true", help="Be quiet")
+    output_group.add_argument("-v", "--verbose", action="store_true", help="Be loud")
+
     args = parser.parse_args()
-    
+
     if args.quiet:
         LOGGER.setLevel(logging.CRITICAL)
     if args.verbose:
         LOGGER.setLevel(logging.NOTSET)
-    
+
     if args.udp:
         udp_proxy(args.src, args.dst)
     elif args.tcp:
         tcp_proxy(args.src, args.dst)
-# end-of-function main    
 
 
-if __name__ == '__main__':
+# end-of-function main
+
+
+if __name__ == "__main__":
     main()

--- a/tests/integration/targets/certificate/files/pyproxy.py
+++ b/tests/integration/targets/certificate/files/pyproxy.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+
+__author__      = 'Radoslaw Matusiak'
+__copyright__   = 'Copyright (c) 2016 Radoslaw Matusiak'
+__license__     = 'MIT'
+__version__     = '0.1'
+
+
+"""
+TCP/UDP proxy.
+
+Modified by @justinc1, to reproduce "EOF occurred in violation of protocol (_ssl.c:997)".
+For https://github.com/ScaleComputing/HyperCoreAnsibleCollection,
+module certificate.py.
+"""
+
+import argparse
+import signal
+import logging
+import select
+import socket
+import time
+
+
+FORMAT = '%(asctime)-15s %(levelname)-10s %(message)s'
+logging.basicConfig(format=FORMAT)
+LOGGER = logging.getLogger()
+
+LOCAL_DATA_HANDLER = lambda x:x
+REMOTE_DATA_HANDLER = lambda x:x
+
+BUFFER_SIZE = 2 ** 10  # 1024. Keep buffer size as power of 2.
+
+
+def udp_proxy(src, dst):
+    """Run UDP proxy.
+    
+    Arguments:
+    src -- Source IP address and port string. I.e.: '127.0.0.1:8000'
+    dst -- Destination IP address and port. I.e.: '127.0.0.1:8888'
+    """
+    LOGGER.debug('Starting UDP proxy...')
+    LOGGER.debug('Src: {}'.format(src))
+    LOGGER.debug('Dst: {}'.format(dst))
+    
+    proxy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    proxy_socket.bind(ip_to_tuple(src))
+    
+    client_address = None
+    server_address = ip_to_tuple(dst)
+    
+    LOGGER.debug('Looping proxy (press Ctrl-Break to stop)...')
+    while True:
+        data, address = proxy_socket.recvfrom(BUFFER_SIZE)
+        
+        if client_address == None:
+            client_address = address
+
+        if address == client_address:
+            data = LOCAL_DATA_HANDLER(data)
+            proxy_socket.sendto(data, server_address)
+        elif address == server_address:
+            data = REMOTE_DATA_HANDLER(data)
+            proxy_socket.sendto(data, client_address)
+            client_address = None
+        else:
+            LOGGER.warning('Unknown address: {}'.format(str(address)))
+# end-of-function udp_proxy    
+    
+    
+def tcp_proxy(src, dst):
+    """Run TCP proxy.
+    
+    Arguments:
+    src -- Source IP address and port string. I.e.: '127.0.0.1:8000'
+    dst -- Destination IP address and port. I.e.: '127.0.0.1:8888'
+    """
+    LOGGER.debug('Starting TCP proxy...')
+    LOGGER.debug('Src: {}'.format(src))
+    LOGGER.debug('Dst: {}'.format(dst))
+    
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(ip_to_tuple(src))
+    s.listen(1)
+
+    connection_count = 0
+    while 1:
+        tcp_proxy_one_conn(s, dst, connection_count)
+        connection_count += 1
+# end-of-function tcp_proxy
+
+
+def tcp_proxy_one_conn(s, dst, connection_count):
+    s_src, _ = s.accept()
+    LOGGER.info(f"New connection from {s_src.getpeername()}")
+
+    s_dst = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s_dst.connect(ip_to_tuple(dst))
+    except ConnectionRefusedError:
+        # we need to retry.
+        # Alternative - forward ConnectionRefusedError to our client,
+        # by not listening on src if dest is not available.
+        # But how to detect in realtime dest is not available?
+        LOGGER.warning(f"ConnectionRefusedError for {dst}, ignore and retry")
+        time.sleep(1)
+        pass
+
+    sockets = [
+        s_src,
+        s_dst,
+    ]
+
+    restart = False
+    byte_count_dst = 0
+    while True:
+        s_read, _, _ = select.select(sockets, [], [])
+        source = "SRC" if s_read == s_src else "DST"
+        # LOGGER.debug('select from {}'.format(source))
+
+        for s in s_read:
+            try:
+                data = s.recv(BUFFER_SIZE)
+            except ConnectionResetError:
+                LOGGER.info(f'ConnectionResetError on socket {s}, close and restart')
+                restart = True
+                break
+
+            if s == s_src:
+                d = LOCAL_DATA_HANDLER(data)
+                # LOGGER.debug(f'{source} received {len(d)} bytes')
+                if len(d) == 0:
+                    restart = True
+                    break
+                try:
+                    s_dst.sendall(d)
+                except BrokenPipeError:
+                    LOGGER.warning(f"BrokenPipeError for {s_dst}, ignore and restart")
+                    restart = True
+                    break
+            elif s == s_dst:
+                d = REMOTE_DATA_HANDLER(data)
+                # LOGGER.debug(f'{source} received {len(d)} bytes')
+                if len(d) == 0:
+                    restart = True
+                    break
+                if inject_ssl_eof_error(connection_count):
+                    LOGGER.info(f"Injecting SSL EOF to connection {s_src.getpeername()}")
+                    restart = True
+                    break
+                s_src.sendall(d)
+            # time.sleep(0.1)
+        if restart:
+            break
+    for sock in sockets:
+        LOGGER.info(f"Closing connection {sock}")
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            # after BrokenPipeError we want to ignore
+            # "OSError: [Errno 107] Transport endpoint is not connected"
+            pass
+        sock.close()
+
+
+def inject_ssl_eof_error(connection_count):
+    # We want to let 2 connections pass,
+    # 3rd - SSL EOF error,
+    # then pass
+    if connection_count in [2]:
+        return True
+    return False
+
+
+def ip_to_tuple(ip):
+    """Parse IP string and return (ip, port) tuple.
+    
+    Arguments:
+    ip -- IP address:port string. I.e.: '127.0.0.1:8000'.
+    """
+    ip, port = ip.split(':')
+    return (ip, int(port))
+# end-of-function ip_to_tuple
+
+
+def main():
+    """Main method."""
+    parser = argparse.ArgumentParser(description='TCP/UPD proxy.')
+    
+    # TCP UPD groups
+    proto_group = parser.add_mutually_exclusive_group(required=True)
+    proto_group.add_argument('--tcp', action='store_true', help='TCP proxy')
+    proto_group.add_argument('--udp', action='store_true', help='UDP proxy')
+    
+    parser.add_argument('-s', '--src', required=True, help='Source IP and port, i.e.: 127.0.0.1:8000')
+    parser.add_argument('-d', '--dst', required=True, help='Destination IP and port, i.e.: 127.0.0.1:8888')
+    
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument('-q', '--quiet', action='store_true', help='Be quiet')
+    output_group.add_argument('-v', '--verbose', action='store_true', help='Be loud')
+    
+    args = parser.parse_args()
+    
+    if args.quiet:
+        LOGGER.setLevel(logging.CRITICAL)
+    if args.verbose:
+        LOGGER.setLevel(logging.NOTSET)
+    
+    if args.udp:
+        udp_proxy(args.src, args.dst)
+    elif args.tcp:
+        tcp_proxy(args.src, args.dst)
+# end-of-function main    
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/certificate/files/pyproxy.py
+++ b/tests/integration/targets/certificate/files/pyproxy.py
@@ -44,8 +44,8 @@ def udp_proxy(src, dst):
     dst -- Destination IP address and port. I.e.: '127.0.0.1:8888'
     """
     LOGGER.debug("Starting UDP proxy...")
-    LOGGER.debug("Src: {}".format(src))
-    LOGGER.debug("Dst: {}".format(dst))
+    LOGGER.debug("Src: %s", src)
+    LOGGER.debug("Dst: %s", dst)
 
     proxy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     proxy_socket.bind(ip_to_tuple(src))
@@ -68,7 +68,7 @@ def udp_proxy(src, dst):
             proxy_socket.sendto(data, client_address)
             client_address = None
         else:
-            LOGGER.warning("Unknown address: {}".format(str(address)))
+            LOGGER.warning("Unknown address: %s", str(address))
 
 
 # end-of-function udp_proxy
@@ -82,8 +82,8 @@ def tcp_proxy(src, dst):
     dst -- Destination IP address and port. I.e.: '127.0.0.1:8888'
     """
     LOGGER.debug("Starting TCP proxy...")
-    LOGGER.debug("Src: {}".format(src))
-    LOGGER.debug("Dst: {}".format(dst))
+    LOGGER.debug("Src: %s", src)
+    LOGGER.debug("Dst: %s", dst)
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -100,8 +100,8 @@ def tcp_proxy(src, dst):
 
 
 def tcp_proxy_one_conn(s, dst, connection_count):
-    s_src, _ = s.accept()
-    LOGGER.info(f"New connection from {s_src.getpeername()}")
+    s_src, _ignored1 = s.accept()
+    LOGGER.info("New connection from %s", s_src.getpeername())
 
     s_dst = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
@@ -111,7 +111,7 @@ def tcp_proxy_one_conn(s, dst, connection_count):
         # Alternative - forward ConnectionRefusedError to our client,
         # by not listening on src if dest is not available.
         # But how to detect in realtime dest is not available?
-        LOGGER.warning(f"ConnectionRefusedError for {dst}, ignore and retry")
+        LOGGER.warning("ConnectionRefusedError for %s, ignore and retry", dst)
         time.sleep(1)
         pass
 
@@ -122,7 +122,7 @@ def tcp_proxy_one_conn(s, dst, connection_count):
 
     restart = False
     while True:
-        s_read, _, _ = select.select(sockets, [], [])
+        s_read, _ignored2, _ignored3 = select.select(sockets, [], [])
         # source = "SRC" if s_read == s_src else "DST"
         # LOGGER.debug('select from {}'.format(source))
 
@@ -130,7 +130,7 @@ def tcp_proxy_one_conn(s, dst, connection_count):
             try:
                 data = s.recv(BUFFER_SIZE)
             except ConnectionResetError:
-                LOGGER.info(f"ConnectionResetError on socket {s}, close and restart")
+                LOGGER.info("ConnectionResetError on socket %s, close and restart", s)
                 restart = True
                 break
 
@@ -143,7 +143,7 @@ def tcp_proxy_one_conn(s, dst, connection_count):
                 try:
                     s_dst.sendall(d)
                 except BrokenPipeError:
-                    LOGGER.warning(f"BrokenPipeError for {s_dst}, ignore and restart")
+                    LOGGER.warning("BrokenPipeError for %s, ignore and restart", s_dst)
                     restart = True
                     break
             elif s == s_dst:
@@ -154,7 +154,7 @@ def tcp_proxy_one_conn(s, dst, connection_count):
                     break
                 if inject_ssl_eof_error(connection_count):
                     LOGGER.info(
-                        f"Injecting SSL EOF to connection {s_src.getpeername()}"
+                        "Injecting SSL EOF to connection %s", s_src.getpeername()
                     )
                     restart = True
                     break
@@ -163,7 +163,7 @@ def tcp_proxy_one_conn(s, dst, connection_count):
         if restart:
             break
     for sock in sockets:
-        LOGGER.info(f"Closing connection {sock}")
+        LOGGER.info("Closing connection %s", sock)
         try:
             sock.shutdown(socket.SHUT_RDWR)
         except OSError:

--- a/tests/integration/targets/certificate/tasks/01_normal.yml
+++ b/tests/integration/targets/certificate/tasks/01_normal.yml
@@ -1,0 +1,68 @@
+---
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_username }}"
+    SC_PASSWORD: "{{ sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+
+  connection: local
+
+  block:
+    - name: Get default cert from cluster
+      community.crypto.get_certificate:
+        host: "{{ sc_host | replace('https://','') | replace('http://','') }}"
+        port: 443
+      delegate_to: localhost
+      run_once: true
+      register: default_cert_info
+
+    - name: Show default certificate info
+      debug:
+        var: default_cert_info
+
+    - name: Generate private key
+      community.crypto.openssl_privatekey:
+        path: private_key_example.pem
+
+    - name: Generate a certificate signing request
+      community.crypto.openssl_csr:
+        path: crs_example.csr
+        privatekey_path: private_key_example.pem
+        common_name: scale-10-10-10-50
+        country_name: US
+        organization_name: Scale Computing Inc.
+        organizational_unit_name: Engineering
+        email_address: support@scalecomputing.com
+        state_or_province_name: CA
+        locality_name: San Francisco
+
+    - name: Generate and sign a certificate with private key from certificate signing request
+      community.crypto.x509_certificate:
+        path: certificate_example.crt
+        csr_path: crs_example.csr
+        privatekey_path: private_key_example.pem
+        provider: selfsigned
+
+    - name: Upload certificate to API with certificate module
+      scale_computing.hypercore.certificate:
+        private_key: "{{ lookup('file', 'private_key_example.pem') }}"
+        certificate: "{{ lookup('file', 'certificate_example.crt') }}"
+      register: certificate_info
+    - ansible.builtin.assert:
+        that:
+          - certificate_info is succeeded
+          - certificate_info is changed
+          - certificate_info.record.certificate != default_cert_info.cert
+          - "{{ certificate_info.record.certificate | replace('\n','') == lookup('file', 'certificate_example.crt') | replace('\n','') }}"
+
+    - name: Get new / uploaded cert from cluster
+      community.crypto.get_certificate:
+        host: "{{ sc_host | replace('https://','') | replace('http://','') }}"
+        port: 443
+      delegate_to: localhost
+      run_once: true
+      register: uploaded_cert_info
+    - ansible.builtin.assert:
+        that:
+          - uploaded_cert_info.cert != default_cert_info.cert
+          - certificate_info.record.certificate == uploaded_cert_info.cert

--- a/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
+++ b/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
@@ -44,8 +44,10 @@
         src: files/pyproxy.py
         dest: /tmp/pyproxy.py
 
+    # this is needed only when testing locally
     - name: kill pyproxy.py before
       ansible.builtin.shell: sudo kill $(pgrep -f '{{ pyproxy_cmd }}')
+      failed_when: false
 
     - name: run pyproxy.py
       ansible.builtin.command: "sudo {{ pyproxy_cmd }}"

--- a/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
+++ b/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
@@ -1,0 +1,84 @@
+---
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_username }}"
+    SC_PASSWORD: "{{ sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+
+  connection: local
+
+  block:
+    - name: Set pyproxy_cmd
+      ansible.builtin.set_fact:
+        pyproxy_cmd: python3 /tmp/pyproxy.py --tcp -s 127.0.0.50:443 -d {{ sc_host | replace('https://', '') }}:443 -v
+
+    - name: Generate private key
+      community.crypto.openssl_privatekey:
+        path: private_key_example.pem
+
+    - name: Generate a certificate signing request
+      community.crypto.openssl_csr:
+        path: crs_example.csr
+        privatekey_path: private_key_example.pem
+        common_name: scale-10-10-10-50
+        country_name: US
+        organization_name: Scale Computing Inc.
+        organizational_unit_name: Engineering
+        email_address: support@scalecomputing.com
+        state_or_province_name: CA
+        locality_name: San Francisco
+
+    - name: Generate and sign a certificate with private key from certificate signing request
+      community.crypto.x509_certificate:
+        path: certificate_example.crt
+        csr_path: crs_example.csr
+        privatekey_path: private_key_example.pem
+        provider: selfsigned
+
+    # get and run pyproxy.py
+    - name: get pyproxy.py
+      ansible.builtin.get_url:
+        # branch ssl-eof-error, commit 7df232733f4cf6deb24d886321ceb4812a114ca4, 2023.03.16
+        url: https://raw.githubusercontent.com/justinc1/pyproxy/ssl-eof-error/code/pyproxy.py
+        dest: /tmp/pyproxy.py
+
+    - name: kill pyproxy.py before
+      ansible.builtin.shell: sudo kill $(pgrep -f '{{ pyproxy_cmd }}')
+
+    - name: run pyproxy.py
+      ansible.builtin.command: "sudo {{ pyproxy_cmd }}"
+      async: 300
+      poll: 0
+      register: pyproxy_cmd_result
+
+    - name: Upload certificate to API with certificate module
+      scale_computing.hypercore.certificate:
+        private_key: "{{ lookup('file', 'private_key_example.pem') }}"
+        certificate: "{{ lookup('file', 'certificate_example.crt') }}"
+      register: certificate_info
+      environment:
+        SC_HOST: https://127.0.0.50
+
+    - ansible.builtin.assert:
+        that:
+          - certificate_info is succeeded
+          - certificate_info is changed
+          # - certificate_info.record.certificate != default_cert_info.cert
+          - "{{ certificate_info.record.certificate | replace('\n','') == lookup('file', 'certificate_example.crt') | replace('\n','') }}"
+          - certificate_info.warnings | length >= 1
+          - certificate_info.warnings[0] == "retry 0/10, SSLEOFError - ignore and continue"
+
+    - name: Get new / uploaded cert from cluster
+      community.crypto.get_certificate:
+        host: "{{ sc_host | replace('https://','') | replace('http://','') }}"
+        port: 443
+      delegate_to: localhost
+      run_once: true
+      register: uploaded_cert_info
+    - ansible.builtin.assert:
+        that:
+          # - uploaded_cert_info.cert != default_cert_info.cert
+          - certificate_info.record.certificate == uploaded_cert_info.cert
+
+    - name: kill pyproxy.py after
+      ansible.builtin.shell: sudo kill $(pgrep -f '{{ pyproxy_cmd }}')

--- a/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
+++ b/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
@@ -68,7 +68,7 @@
           # - certificate_info.record.certificate != default_cert_info.cert
           - "{{ certificate_info.record.certificate | replace('\n','') == lookup('file', 'certificate_example.crt') | replace('\n','') }}"
           - certificate_info.warnings | length >= 1
-          - certificate_info.warnings[0] == "retry 0/10, SSLEOFError - ignore and continue"
+          - certificate_info.warnings[0] == "retry 0/10, SSL error SSLZeroReturnError - ignore and continue"
 
     - name: Get new / uploaded cert from cluster
       community.crypto.get_certificate:

--- a/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
+++ b/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
@@ -91,3 +91,5 @@
 
     - name: kill pyproxy.py after
       ansible.builtin.shell: sudo kill $(pgrep -f '{{ pyproxy_cmd }}')
+      # not sure why this fails in github CI (different disto, or we are in docker?)
+      failed_when: false

--- a/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
+++ b/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
@@ -63,6 +63,8 @@
       environment:
         SC_HOST: https://127.0.0.50
 
+    # Seems we get SSLEOFError when testing in github CI in docker image,
+    # and SSLZeroReturnError when testing locally (on Fedora 36 host).
     - ansible.builtin.assert:
         that:
           - certificate_info is succeeded
@@ -70,7 +72,10 @@
           # - certificate_info.record.certificate != default_cert_info.cert
           - "{{ certificate_info.record.certificate | replace('\n','') == lookup('file', 'certificate_example.crt') | replace('\n','') }}"
           - certificate_info.warnings | length >= 1
-          - certificate_info.warnings[0] == "retry 0/10, SSL error SSLZeroReturnError - ignore and continue"
+          - certificate_info.warnings[0] in [
+              "retry 0/10, SSL error SSLEOFError - ignore and continue",
+              "retry 0/10, SSL error SSLZeroReturnError - ignore and continue",
+            ]
 
     - name: Get new / uploaded cert from cluster
       community.crypto.get_certificate:

--- a/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
+++ b/tests/integration/targets/certificate/tasks/02_ssl_eof_error.yml
@@ -37,9 +37,11 @@
 
     # get and run pyproxy.py
     - name: get pyproxy.py
-      ansible.builtin.get_url:
+      ansible.builtin.copy:
         # branch ssl-eof-error, commit 7df232733f4cf6deb24d886321ceb4812a114ca4, 2023.03.16
-        url: https://raw.githubusercontent.com/justinc1/pyproxy/ssl-eof-error/code/pyproxy.py
+        # url: https://raw.githubusercontent.com/justinc1/pyproxy/ssl-eof-error/code/pyproxy.py
+        # The file was committed into the collection.
+        src: files/pyproxy.py
         dest: /tmp/pyproxy.py
 
     - name: kill pyproxy.py before

--- a/tests/integration/targets/certificate/tasks/main.yml
+++ b/tests/integration/targets/certificate/tasks/main.yml
@@ -5,64 +5,6 @@
     SC_PASSWORD: "{{ sc_password }}"
     SC_TIMEOUT: "{{ sc_timeout }}"
 
-  connection: local
-
   block:
-    - name: Get default cert from cluster
-      community.crypto.get_certificate:
-        host: "{{ sc_host | replace('https://','') | replace('http://','') }}"
-        port: 443
-      delegate_to: localhost
-      run_once: true
-      register: default_cert_info
-
-    - name: Show default certificate info
-      debug:
-        var: default_cert_info
-
-    - name: Generate private key
-      community.crypto.openssl_privatekey:
-        path: private_key_example.pem
-
-    - name: Generate a certificate signing request
-      community.crypto.openssl_csr:
-        path: crs_example.csr
-        privatekey_path: private_key_example.pem
-        common_name: scale-10-10-10-50
-        country_name: US
-        organization_name: Scale Computing Inc.
-        organizational_unit_name: Engineering
-        email_address: support@scalecomputing.com
-        state_or_province_name: CA
-        locality_name: San Francisco
-
-    - name: Generate and sign a certificate with private key from certificate signing request
-      community.crypto.x509_certificate:
-        path: certificate_example.crt
-        csr_path: crs_example.csr
-        privatekey_path: private_key_example.pem
-        provider: selfsigned
-
-    - name: Upload certificate to API with certificate module
-      scale_computing.hypercore.certificate:
-        private_key: "{{ lookup('file', 'private_key_example.pem') }}"
-        certificate: "{{ lookup('file', 'certificate_example.crt') }}"
-      register: certificate_info
-    - ansible.builtin.assert:
-        that:
-          - certificate_info is succeeded
-          - certificate_info is changed
-          - certificate_info.record.certificate != default_cert_info.cert
-          - "{{ certificate_info.record.certificate | replace('\n','') == lookup('file', 'certificate_example.crt') | replace('\n','') }}"
-
-    - name: Get new / uploaded cert from cluster
-      community.crypto.get_certificate:
-        host: "{{ sc_host | replace('https://','') | replace('http://','') }}"
-        port: 443
-      delegate_to: localhost
-      run_once: true
-      register: uploaded_cert_info
-    - ansible.builtin.assert:
-        that:
-          - uploaded_cert_info.cert != default_cert_info.cert
-          - certificate_info.record.certificate == uploaded_cert_info.cert
+    - include_tasks: 01_normal.yml
+    - include_tasks: 02_ssl_eof_error.yml


### PR DESCRIPTION
@ddemlow had problem replacing certificate, and this happened only it server  was access via VPN. Likely VPN resulted in just correct timing to raise unexpected SSL error - in python code we got "EOF occurred in violation of protocol (_ssl.c:997)".

PR catches ScaleComputingError exception, and checks if message had this particular message inside.
I didn't try to refactor the ScaleComputingError to have a dedicated exception - I'm not able to reproduce the problem, so it is hard to test any code modification. For same reason, it is hard to add any integration test for this.

The extra `module.warn` were added, to help debugging if anything similar happens later. I hope warn message is kind enough ("... ignore and continue") - I do not want to make anyone nervous.