### PR TITLE
CI use SMB cleanup variables from integration_config.yml

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -239,4 +239,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - run: cd tests/integration/cleanup && ./smb_cleanup.sh ${{ secrets.SMB_SERVER }} ${{ secrets.SMB_SHARE }} "${{ secrets.SMB_USERNAME }}" ${{ secrets.SMB_PASSWORD }}
+      - run: |
+          echo "${{ vars.CI_CONFIG_HC_IP50 }}" > tests/integration/integration_config.yml
+          cat tests/integration/integration_config.yml
+          echo "sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}" >> tests/integration/integration_config.yml
+          echo "smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}" >> tests/integration/integration_config.yml
+          echo "sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}" >> tests/integration/integration_config.yml
+          ls -al tests/integration/integration_config.yml
+      - run: |
+          cd tests/integration/cleanup && ./smb_cleanup.sh \
+            "$(cat ../integration_config.yml | yq '.smb_server' | sed -e 's/^"//' -e 's/"$//')" \
+            "$(cat ../integration_config.yml | yq '.smb_share' | sed -e 's/^"//' -e 's/"$//')" \
+            "$(cat ../integration_config.yml | yq '.smb_username' | sed -e 's/^"//' -e 's/"$//')" \
+            "$(cat ../integration_config.yml | yq '.smb_password' | sed -e 's/^"//' -e 's/"$//')"

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -7,6 +7,7 @@ sc_timeout: 60
 # CI tests for vm_import/vm_export require a SMB server
 smb_server: <example 10.0.0.3>
 smb_share: <example /users>
+# Provide username as "domain;username" or only ";username".
 smb_username: <example myusername>
 smb_password: <example mypassword>
 # Replication cluster needs to be cleaned up.


### PR DESCRIPTION
Initially we had a configuration variable/secret for every possible line in `integration_config.yml`. Later we decided to have whole `integration_config.yml` except about 3 passwords as a single CI variable, and then we add only missing passwords to it.

The `smb_cleanup.sh` was not yet updated to get required configuration (SMB server, username etc) from `integration_config.yml`. This PR does this.

CI job to show that `smb_cleanup` integration "test" does pass - https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4465664492/jobs/7842970112