### PR TITLE
Handle case when update_status.json doesnt exist

### DIFF
--- a/changelogs/fragments/version_update_status_info_bugfix.yml
+++ b/changelogs/fragments/version_update_status_info_bugfix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - This fix now handles case if no update_status.json exists yet. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/174)

--- a/examples/version_update_status_info.yml
+++ b/examples/version_update_status_info.yml
@@ -1,0 +1,15 @@
+---
+- name: Show HyperCore software version update status info
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+  # ------------------------------------------------------
+    - name: Get version update status
+      scale_computing.hypercore.version_update_status_info:
+      register: version_update_status_info_result
+
+    - name: Show version update status
+      debug:
+        var: version_update_status_info_result

--- a/plugins/module_utils/hypercore_version.py
+++ b/plugins/module_utils/hypercore_version.py
@@ -333,6 +333,8 @@ class UpdateStatus(PayloadMapper):
         )
 
     @classmethod
-    def get(cls, rest_client: RestClient, check_mode: bool = False) -> UpdateStatus:
-        update_status = rest_client.client.get("update/update_status.json").json
-        return cls.from_hypercore(update_status)
+    def get(cls, rest_client: RestClient) -> Optional[UpdateStatus]:
+        response = rest_client.client.get("update/update_status.json")
+        if response.status == 404:  # .get() lets 200 and 404 through
+            return None
+        return cls.from_hypercore(response.json)

--- a/plugins/modules/version_update_status_info.py
+++ b/plugins/modules/version_update_status_info.py
@@ -34,6 +34,7 @@ RETURN = r"""
 record:
   description:
     - Status of the latest update applied
+    - None/null is returned if no update was ever applied.
   returned: success
   type: dict
   sample:

--- a/plugins/modules/version_update_status_info.py
+++ b/plugins/modules/version_update_status_info.py
@@ -47,6 +47,7 @@ record:
       to_version: 9.1.18.209840
 """
 
+from typing import Optional
 from ansible.module_utils.basic import AnsibleModule
 
 from ..module_utils import arguments, errors
@@ -56,8 +57,11 @@ from ..module_utils.hypercore_version import UpdateStatus
 from ..module_utils.typed_classes import TypedUpdateStatusToAnsible
 
 
-def run(rest_client: RestClient) -> TypedUpdateStatusToAnsible:
-    return UpdateStatus.get(rest_client).to_ansible()
+def run(rest_client: RestClient) -> Optional[TypedUpdateStatusToAnsible]:
+    status = UpdateStatus.get(rest_client)
+    if status:
+        return status.to_ansible()
+    return None
 
 
 def main() -> None:

--- a/tests/unit/plugins/modules/test_version_update_status_info.py
+++ b/tests/unit/plugins/modules/test_version_update_status_info.py
@@ -54,3 +54,12 @@ class TestRun:
             to_build="209840",
             to_version="9.1.18.209840",
         )
+
+    def test_run_no_record(self, rest_client, mocker):
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.modules.version_update_status_info.UpdateStatus.get"
+        ).return_value = None
+
+        record = version_update_status_info.run(rest_client)
+
+        assert record is None


### PR DESCRIPTION
In case of “fresh cluster” no updates have ever been done so no update_status.json exists yet. Instead "404 Not found" is returned which caused module version_update_status_info (and consequently the version_update_single_node role) to fail.
With this PR the version_update_status_info module is fixed but the role version_update_single_node still needs to be revisited.