### PR TITLE
Http put with content length

### DIFF
--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -180,6 +180,7 @@ records:
 
 
 from ansible.module_utils.basic import AnsibleModule
+import os
 
 from ..module_utils import errors, arguments
 from ..module_utils.client import Client
@@ -260,6 +261,7 @@ PUT_TIMEOUT_TIME = 3600
 
 
 def put_record(module, rest_client):
+    file_size = os.stat(module.params["source"]).st_size
     with open(module.params["source"], "rb") as source_file:
         result = rest_client.put_record(
             endpoint=module.params["endpoint"],
@@ -271,6 +273,7 @@ def put_record(module, rest_client):
             headers={
                 "Content-Type": "application/octet-stream",
                 "Accept": "application/json",
+                "Content-Length": file_size,
             },
         )
     return True, result

--- a/plugins/modules/iso.py
+++ b/plugins/modules/iso.py
@@ -125,6 +125,7 @@ def ensure_present(module, rest_client):
     TaskTag.wait_task(rest_client, task_tag_create)
 
     # Uploading ISO image.
+    file_size = os.stat(module.params["source"]).st_size
     with open(module.params["source"], "rb") as source_file:
         rest_client.put_record(
             endpoint="/rest/v1/ISO/%s/data" % iso_uuid,
@@ -135,6 +136,7 @@ def ensure_present(module, rest_client):
             headers={
                 "Content-Type": "application/octet-stream",
                 "Accept": "application/json",
+                "Content-Length": file_size,
             },
         )
 

--- a/tests/unit/plugins/modules/test_api.py
+++ b/tests/unit/plugins/modules/test_api.py
@@ -97,7 +97,9 @@ class TestPutMethod:
                 data=dict(),
             )
         )
-        mocker.patch("builtins.open", mocker.mock_open(read_data="this-data"))
+        this_data = "this-data"
+        mocker.patch("builtins.open", mocker.mock_open(read_data=this_data))
+        mocker.patch("os.stat").return_value = mocker.Mock(st_size=len(this_data))
         rest_client.put_record.return_value = "this-value"
         result = api.put_record(module, rest_client)
         assert result == (True, "this-value")


### PR DESCRIPTION
It is safer to always PUT binary data to HC3 with  Content-Length HTTP header.
PUT is used only in api, iso (and in future in virtual_disk module).

This does fix uploading virtual disk using raw api module example - `examples/virtual_disk.yml`.
It will also allow integration test for virtual_disk_info module to pass (the test VD is uploaded using api module).