### PR TITLE
CI run integration tests against multiple HyperCore versions

### DIFF
--- a/.github/actions/make-integ-config/action.yml
+++ b/.github/actions/make-integ-config/action.yml
@@ -1,0 +1,54 @@
+---
+name: 'Create ansible-test integration_config.yml'
+description: 'Create ansible-test integration_config.yml'
+inputs:
+  ci_config_all:
+    description: 'CI config for all yperCore hosts'
+    required: true
+  sc_host:  # id of input
+    description: 'SC_HOST environ variable'
+    required: true
+    # default: 'World'
+  sc_username:
+    description: 'sc_username variable'
+    required: true
+  sc_password:
+    description: 'sc_password variable'
+    required: true
+  smb_password:
+    description: 'smb_password variable'
+    required: true
+  sc_replication_dest_password:
+    description: 'sc_replication_dest_password variable'
+    required: true
+  working_directory:
+    description: 'Path to working directory'
+    required: true
+#outputs:
+#  integ_config:
+#    description: "Random number"
+#    value: ${{ steps.random-number-generator.outputs.random-number }}
+runs:
+  using: "composite"
+  steps:
+    - run: echo Creating integration-config.yml for sc_host=${{ inputs.sc_host }}.
+      shell: bash
+#    - id: random-number-generator
+#      run: echo "random-number=$(echo $RANDOM)" >> $GITHUB_OUTPUT
+#      shell: bash
+#    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
+#      shell: bash
+    - run: |
+        cd ${{ inputs.working_directory }}
+        echo "${{ inputs.ci_config_all }}" > tests/integration/integration_config.yml
+        cat tests/integration/integration_config.yml
+        echo "sc_host: ${{ inputs.sc_host }}" >> tests/integration/integration_config.yml
+        echo "sc_username: ${{ inputs.sc_username }}" >> tests/integration/integration_config.yml
+        echo "sc_password: ${{ inputs.sc_password }}" >> tests/integration/integration_config.yml
+        echo "smb_password: ${{ inputs.smb_password }}" >> tests/integration/integration_config.yml
+        echo "sc_replication_dest_password: ${{ inputs.sc_replication_dest_password }}" >> tests/integration/integration_config.yml
+        pwd
+        ls -al tests/integration/integration_config.yml
+      shell: bash
+#    - run: goodbye.sh
+#      shell: bash

--- a/.github/actions/make-integ-config/action.yml
+++ b/.github/actions/make-integ-config/action.yml
@@ -3,7 +3,7 @@ name: 'Create ansible-test integration_config.yml'
 description: 'Create ansible-test integration_config.yml'
 inputs:
   ci_config_all:
-    description: 'CI config for all yperCore hosts'
+    description: 'CI config for all HyperCore hosts'
     required: true
   sc_host:  # id of input
     description: 'SC_HOST environ variable'

--- a/.github/actions/make-integ-config/action.yml
+++ b/.github/actions/make-integ-config/action.yml
@@ -24,20 +24,11 @@ inputs:
   working_directory:
     description: 'Path to working directory'
     required: true
-#outputs:
-#  integ_config:
-#    description: "Random number"
-#    value: ${{ steps.random-number-generator.outputs.random-number }}
 runs:
   using: "composite"
   steps:
     - run: echo Creating integration-config.yml for sc_host=${{ inputs.sc_host }}.
       shell: bash
-#    - id: random-number-generator
-#      run: echo "random-number=$(echo $RANDOM)" >> $GITHUB_OUTPUT
-#      shell: bash
-#    - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
-#      shell: bash
     - run: |
         cd ${{ inputs.working_directory }}
         echo "${{ inputs.ci_config_all }}" > tests/integration/integration_config.yml
@@ -50,5 +41,3 @@ runs:
         pwd
         ls -al tests/integration/integration_config.yml
       shell: bash
-#    - run: goodbye.sh
-#      shell: bash

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -1,6 +1,5 @@
 name: integ-test
 on:
-  push:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
@@ -73,7 +72,7 @@ jobs:
       - run: ansible-playbook tests/integration/prepare/prepare_iso.yml
       - run: ansible-playbook tests/integration/prepare/prepare_vm.yml
       - run: ansible-playbook tests/integration/prepare/prepare_examples.yml
-    # if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
+    if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
 
   integ-matrix:
     runs-on: [ubuntu-latest]
@@ -102,7 +101,7 @@ jobs:
             grep -E "${{ env.INTEG_TESTS_INCLUDE }}" |
             jq -R -s -c 'split("\n")[:-1]'
           )" >> $GITHUB_OUTPUT
-    # if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
+    if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
 
   examples-matrix:
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -55,13 +55,15 @@ jobs:
           path: ${{ env.WORKDIR }}
       - run: ansible-galaxy collection install community.crypto community.general
       - run: ansible-galaxy collection list
-      - run: |
-          echo "${{ vars.CI_CONFIG_HC_IP50 }}" > tests/integration/integration_config.yml
-          cat tests/integration/integration_config.yml
-          echo "sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}" >> tests/integration/integration_config.yml
-          ls -al tests/integration/integration_config.yml
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
+          sc_host: https://10.5.11.50
+          sc_username: xlab
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
+          working_directory: ${{ env.WORKDIR }}
       - run: ansible-playbook tests/integration/prepare/prepare_iso.yml
       - run: ansible-playbook tests/integration/prepare/prepare_vm.yml
       - run: ansible-playbook tests/integration/prepare/prepare_examples.yml
@@ -147,13 +149,22 @@ jobs:
       - run: pip install ansible-core~=${{ matrix.ansible }}
       - run: ansible-galaxy collection install community.crypto community.general
       - run: ansible-galaxy collection list
+
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
+          sc_host: https://10.5.11.50
+          sc_username: xlab
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
+          working_directory: ${{ env.WORKDIR }}
       - run: |
-          echo "${{ vars.CI_CONFIG_HC_IP50 }}" > tests/integration/integration_config.yml
-          cat tests/integration/integration_config.yml
-          echo "sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}" >> tests/integration/integration_config.yml
+          pwd
           ls -al tests/integration/integration_config.yml
+          head tests/integration/integration_config.yml
+
       - run: |
           eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
           eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_username')
@@ -190,14 +201,16 @@ jobs:
       # But it does affect ansible-galaxy and ansible-test commands.
       - run: ansible-galaxy collection install community.crypto
       - run: ansible-galaxy collection list
-        # TODO - make integration_config.yml a reusable artifact/output of integration-prepare-env
-      - run: |
-          echo "${{ vars.CI_CONFIG_HC_IP50 }}" > tests/integration/integration_config.yml
-          cat tests/integration/integration_config.yml
-          echo "sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}" >> tests/integration/integration_config.yml
-          ls -al tests/integration/integration_config.yml
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
+          sc_host: https://10.5.11.50
+          sc_username: xlab
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
+          working_directory: ${{ env.WORKDIR }}
       - run: ansible-test integration --local ${{ matrix.test_name }}
 
 
@@ -217,14 +230,16 @@ jobs:
         with:
           path: ${{ env.WORKDIR }}
       - run: pip install ansible-core~=2.13.0
-        # ansible-test needs special directory structure.
-      - run: |
-          echo "${{ vars.CI_CONFIG_HC_IP50 }}" > tests/integration/integration_config.yml
-          cat tests/integration/integration_config.yml
-          echo "sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}" >> tests/integration/integration_config.yml
-          ls -al tests/integration/integration_config.yml
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
+          sc_host: https://10.5.11.50
+          sc_username: xlab
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
+          working_directory: ${{ env.WORKDIR }}
       - run: ansible-galaxy collection install community.general
       - run: ansible-playbook tests/integration/cleanup/ci_replica_cleanup.yml
 
@@ -241,13 +256,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - run: |
-          echo "${{ vars.CI_CONFIG_HC_IP50 }}" > tests/integration/integration_config.yml
-          cat tests/integration/integration_config.yml
-          echo "sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}" >> tests/integration/integration_config.yml
-          echo "sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}" >> tests/integration/integration_config.yml
-          ls -al tests/integration/integration_config.yml
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
+          sc_host: https://10.5.11.50
+          sc_username: xlab
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
+          working_directory: ${{ env.WORKDIR }}
       - run: |
           cd tests/integration/cleanup && ./smb_cleanup.sh \
             "$(cat ../integration_config.yml | yq '.smb_server' | sed -e 's/^"//' -e 's/"$//')" \

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -1,6 +1,5 @@
 name: integ-test
 on:
-  push:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
@@ -125,8 +124,8 @@ jobs:
     if: "${{ github.event.inputs || github.event.schedule }}"
 
   examples-run:
-    needs: []
-#      - examples-matrix
+    needs:
+      - examples-matrix
     runs-on: [ self-hosted2 ]
     container: quay.io/justinc1_github/scale_ci_integ:2
     env:
@@ -139,8 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         ansible: [ 2.13.0 ]
-#        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
-        example_name: ["iso_info.yml"]
+        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -173,8 +171,8 @@ jobs:
           ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
 
   integ:
-    needs: []
-#      - integ-matrix
+    needs:
+      - integ-matrix
       # - units-test
     runs-on: [self-hosted2]
     container: quay.io/justinc1_github/scale_ci_integ:2
@@ -188,8 +186,8 @@ jobs:
       matrix:
         ansible: [2.13.0]
         # python: [3.11]
-        test_name: ["virtual_disk_info", "cluster_info"]
-#        test_name: ${{ fromJson(needs.integ-matrix.outputs.matrix) }}
+        # test_name: [user_info]
+        test_name: ${{ fromJson(needs.integ-matrix.outputs.matrix) }}
         sc_host:
           - https://10.5.11.200
           - https://10.5.11.201

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -1,5 +1,6 @@
 name: integ-test
 on:
+  push:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
@@ -122,8 +123,8 @@ jobs:
     if: "${{ github.event.inputs || github.event.schedule }}"
 
   examples-run:
-    needs:
-      - examples-matrix
+    needs: []
+#      - examples-matrix
     runs-on: [ self-hosted2 ]
     container: quay.io/justinc1_github/scale_ci_integ:2
     env:
@@ -136,7 +137,8 @@ jobs:
       fail-fast: false
       matrix:
         ansible: [ 2.13.0 ]
-        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
+#        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
+        example_name: ["iso_info.yml"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -160,8 +162,8 @@ jobs:
           ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
 
   integ:
-    needs:
-      - integ-matrix
+    needs: []
+#      - integ-matrix
       # - units-test
     runs-on: [self-hosted2]
     container: quay.io/justinc1_github/scale_ci_integ:2
@@ -175,8 +177,8 @@ jobs:
       matrix:
         ansible: [2.13.0]
         # python: [3.11]
-        # test_name: [user_info]
-        test_name: ${{ fromJson(needs.integ-matrix.outputs.matrix) }}
+        test_name: ["virtual_disk_info", "cluster_info"]
+#        test_name: ${{ fromJson(needs.integ-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -58,9 +58,9 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.50
-          sc_username: xlab
-          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          sc_host: https://10.5.11.200
+          sc_username: admin
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
@@ -154,9 +154,9 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.50
-          sc_username: xlab
-          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          sc_host: https://10.5.11.200
+          sc_username: admin
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
@@ -205,9 +205,9 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.50
-          sc_username: xlab
-          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          sc_host: https://10.5.11.200
+          sc_username: admin
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
@@ -234,9 +234,9 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.50
-          sc_username: xlab
-          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          sc_host: https://10.5.11.200
+          sc_username: admin
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
@@ -260,9 +260,9 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.50
-          sc_username: xlab
-          sc_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          sc_host: https://10.5.11.200
+          sc_username: admin
+          sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           sc_replication_dest_password: ${{ secrets.CI_CONFIG_HC_IP50_SC_REPLICATION_DEST_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -190,6 +190,9 @@ jobs:
         # python: [3.11]
         test_name: ["virtual_disk_info", "cluster_info"]
 #        test_name: ${{ fromJson(needs.integ-matrix.outputs.matrix) }}
+        sc_host:
+          - https://10.5.11.200
+          - https://10.5.11.201
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -205,7 +208,7 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.200
+          sc_host: ${{ matrix.sc_host }}
           sc_username: admin
           sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -48,6 +48,12 @@ jobs:
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sc_host:
+          - https://10.5.11.200
+          - https://10.5.11.201
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,7 +64,7 @@ jobs:
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
           ci_config_all: ${{ vars.CI_CONFIG_HC_IP50 }}
-          sc_host: https://10.5.11.200
+          sc_host: ${{ matrix.sc_host }}
           sc_username: admin
           sc_password: ${{ secrets.CI_CONFIG_HC_IP200_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -1,5 +1,6 @@
 name: integ-test
 on:
+  push:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
@@ -66,7 +67,7 @@ jobs:
       - run: ansible-playbook tests/integration/prepare/prepare_iso.yml
       - run: ansible-playbook tests/integration/prepare/prepare_vm.yml
       - run: ansible-playbook tests/integration/prepare/prepare_examples.yml
-    if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
+    # if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
 
   integ-matrix:
     runs-on: [ubuntu-latest]
@@ -95,7 +96,7 @@ jobs:
             grep -E "${{ env.INTEG_TESTS_INCLUDE }}" |
             jq -R -s -c 'split("\n")[:-1]'
           )" >> $GITHUB_OUTPUT
-    if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
+    # if: "${{ github.event.inputs.integ_tests_include || github.event.schedule }}"
 
   examples-matrix:
     runs-on: [ ubuntu-latest ]

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -12,22 +12,22 @@ on:
           Use "*" to run all tests.
           Use regex like 'node|^git_issue' to run only a subset.
         default: ""
-      # vm_import|vm_export - they need SMB server
       # dns_config|time_server - NTP cannot be reconfigured if DNS is invalid
       # git_issues - slow, do not run on each push. TODO - run them only once a day
       # oidc_config - during reconfiguration API returns 500/502 errors for other requests
       # smtp - email_alert test requires a configured SMTP
-      # role_ - role cluster_config reconfigures DNS, SMTP, OIDC.
+      # role_cluster_config - role cluster_config reconfigures DNS, SMTP, OIDC. And it is slow.
+      # version_update_single_node - role would change version, VSNS system cannot be updated.
       integ_tests_exclude:
         type: string
         description: |-
           List integration tests to exclude.
           Use "*" to exclude all tests.
           Use regex like 'node|^git_issue|^dns_config$' to exclude only a subset.
-        default: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_"
+        default: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^version_update_single_node$"
 env:
   INTEG_TESTS_INCLUDE_SCHEDULE: "*"
-  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_"
+  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^version_update_single_node$"
   # ansible-test needs special directory structure.
   # WORKDIR is a subdir of GITHUB_WORKSPACE
   WORKDIR: work-dir/ansible_collections/scale_computing/hypercore


### PR DESCRIPTION
Run integration tests against 9.1 and 9.2 API. 

Test will run on VSNS (virtual single node clusters). This means we will be able to easy revert changes, but we will also not be able to test upgrades (we do not test them with CI anyway). Those two VSNS nodes also do not have remote replication configured - that can be added if/when we need it in out testing.

Some things will required later "fine tunning". Like what to do with virtual_disk test on 9.1. We can just skip it, or we can check if expected error message ("your server version X does not support Y feature") is shown. I plan to work on this in separate PRs.
