### PR TITLE
Add next and latest to return value

### DIFF
--- a/changelogs/fragments/version_update_info_add_option.yml
+++ b/changelogs/fragments/version_update_info_add_option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added option select to version_update_info module. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/189)

--- a/examples/version_update_info.yml
+++ b/examples/version_update_info.yml
@@ -1,0 +1,14 @@
+---
+- name: Update a HyperCore single-node system
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: List available updates
+      scale_computing.hypercore.version_update_info:
+      register: version_update_info_result
+
+    - name: Show update with count, lowest and highest version
+      ansible.builtin.debug:
+        msg: Host has {{ version_update_info_result.records | length }} updates available, lowest is {{ (version_update_info_result.records | first).uuid }}, highest is {{ (version_update_info_result.records | last).uuid }}

--- a/examples/version_update_info.yml
+++ b/examples/version_update_info.yml
@@ -7,8 +7,8 @@
   tasks:
     - name: List available updates
       scale_computing.hypercore.version_update_info:
-      register: version_update_info_result
+      register: result
 
     - name: Show update with count, lowest and highest version
       ansible.builtin.debug:
-        msg: Host has {{ version_update_info_result.records | length }} updates available, lowest is {{ (version_update_info_result.records | first).uuid }}, highest is {{ (version_update_info_result.records | last).uuid }}
+        msg: Host has {{ result.records | length }} updates available, lowest is {{ result.next.uuid }}, highest is {{ result.latest.uuid }}

--- a/examples/version_update_info.yml
+++ b/examples/version_update_info.yml
@@ -11,4 +11,8 @@
 
     - name: Show update with count, lowest and highest version
       ansible.builtin.debug:
-        msg: Host has {{ result.records | length }} updates available, lowest is {{ result.next.uuid }}, highest is {{ result.latest.uuid }}
+        msg: >-
+          Host has {{ result.records | length }} updates available.
+          All available updates: {{ result.records | map(attribute='uuid')}}.
+          Lowest update is "{{ result.next.uuid | default('') }}".
+          Highest update is "{{ result.latest.uuid | default('') }}".

--- a/plugins/modules/version_update_info.py
+++ b/plugins/modules/version_update_info.py
@@ -22,36 +22,18 @@ extends_documentation_fragment:
 seealso:
   - module: scale_computing.hypercore.version_update
   - module: scale_computing.hypercore.version_update_status_info
-options:
-  select:
-    description:
-      - List desired version update from list of updates
-      - If C(next), then version with the lowest number in the list of available updates is returned
-      - If C(latest), then version with the highest number in the list of available updates is returned
-    type: str
-    choices: [ next, latest ]
 """
 
 EXAMPLES = r"""
 - name: Get a list of updates
   scale_computing.hypercore.version_update_info:
   register: result
-
-- name: Get a list of updates and next update
-  scale_computing.hypercore.version_update_info:
-    select: next
-  register: result
-
-- name: Get a list of updates and latest update
-  scale_computing.hypercore.version_update_info:
-    select: latest
-  register: result
 """
 
 RETURN = r"""
 records:
   description:
-    - A list of updates that can be applied to this cluster.
+    - In ascending order sorted list of updates that can be applied to this cluster.
   returned: success
   type: list
   contains:
@@ -87,9 +69,47 @@ records:
       description: Unix timestamp when the update was released
       type: int
       sample: 0
-record:
+next:
   description:
-    - Next or latest update from list of updates, when option I(select) is specified
+    - Version with the lowest number in the list of available updates
+  returned: success
+  type: dict
+  contains:
+    uuid:
+      description: Unique identifier in format majorVersion.minorVersion.revision.buildID
+      type: str
+      sample: 9.2.11.210763
+    description:
+      description: Human-readable name for the update
+      type: str
+      sample: 9.2.11 General Availability
+    change_log:
+      description: Description of all changes that are in this update, in HTML format
+      type: str
+      sample: ...Please allow between 20-40 minutes per node for the update to complete...
+    build_id:
+      description: ID of the build which corresponds to this update
+      type: int
+      sample: 210763
+    major_version:
+      description: Major version number
+      type: int
+      sample: 9
+    minor_version:
+      description: Minor version number
+      type: int
+      sample: 2
+    revision:
+      description: Revision number
+      type: int
+      sample: 11
+    timestamp:
+      description: Unix timestamp when the update was released
+      type: int
+      sample: 0
+latest:
+  description:
+    - Version with the highest number in the list of available updates
   returned: success
   type: dict
   contains:
@@ -138,34 +158,25 @@ from typing import List, Optional, Tuple
 import operator
 
 
-def select_next_or_latest(
-    list_of_updates: List[TypedUpdateToAnsible], next_or_latest: str
-) -> Optional[TypedUpdateToAnsible]:
-    if not list_of_updates:
-        return None
-    sorted_list = list_of_updates.copy()  # so that we keep original records
-    sorted_list.sort(
-        key=operator.itemgetter(
-            "major_version", "minor_version", "revision", "build_id"
-        )
-    )
-    if next_or_latest == "next":
-        return sorted_list[0]
-    else:
-        return sorted_list[-1]
-
-
 def run(
-    module: AnsibleModule, rest_client: RestClient
-) -> Tuple[List[Optional[TypedUpdateToAnsible]], Optional[TypedUpdateToAnsible]]:
-    record = None
+    rest_client: RestClient,
+) -> Tuple[
+    List[Optional[TypedUpdateToAnsible]],
+    Optional[TypedUpdateToAnsible],
+    Optional[TypedUpdateToAnsible],
+]:
     records = [
         Update.from_hypercore(hypercore_data=hypercore_dict).to_ansible()  # type: ignore
         for hypercore_dict in rest_client.list_records("/rest/v1/Update")
     ]
-    if module.params["select"]:
-        record = select_next_or_latest(records, module.params["select"])
-    return records, record
+    if records:
+        records.sort(
+            key=operator.itemgetter(
+                "major_version", "minor_version", "revision", "build_id"
+            )
+        )
+        return records, records[0], records[-1]
+    return records, None, None
 
 
 def main() -> None:
@@ -173,15 +184,14 @@ def main() -> None:
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec("cluster_instance"),
-            select=dict(type="str", choices=["next", "latest"]),
         ),
     )
 
     try:
         client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
-        records, record = run(module, rest_client)
-        module.exit_json(changed=False, records=records, record=record)
+        records, next, latest = run(rest_client)
+        module.exit_json(changed=False, records=records, next=next, latest=latest)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/version_update_info.py
+++ b/plugins/modules/version_update_info.py
@@ -22,11 +22,29 @@ extends_documentation_fragment:
 seealso:
   - module: scale_computing.hypercore.version_update
   - module: scale_computing.hypercore.version_update_status_info
+options:
+  select:
+    description:
+      - List desired version update from list of updates
+      - If C(next), then version with the lowest number in the list of available updates is returned
+      - If C(latest), then version with the highest number in the list of available updates is returned
+    type: str
+    choices: [ next, latest ]
 """
 
 EXAMPLES = r"""
 - name: Get a list of updates
   scale_computing.hypercore.version_update_info:
+  register: result
+
+- name: Get a list of updates and next update
+  scale_computing.hypercore.version_update_info:
+    select: next
+  register: result
+
+- name: Get a list of updates and latest update
+  scale_computing.hypercore.version_update_info:
+    select: latest
   register: result
 """
 
@@ -36,15 +54,77 @@ records:
     - A list of updates that can be applied to this cluster.
   returned: success
   type: list
-  sample:
-    - uuid: 9.2.11.210763
-      description: 9.2.11 General Availability
-      change_log: ...Please allow between 20-40 minutes per node for the update to complete...
-      build_id: 210763
-      major_version: 9
-      minor_version: 2
-      revision: 11
-      timestamp: 0
+  contains:
+    uuid:
+      description: Unique identifier in format majorVersion.minorVersion.revision.buildID
+      type: str
+      sample: 9.2.11.210763
+    description:
+      description: Human-readable name for the update
+      type: str
+      sample: 9.2.11 General Availability
+    change_log:
+      description: Description of all changes that are in this update, in HTML format
+      type: str
+      sample: ...Please allow between 20-40 minutes per node for the update to complete...
+    build_id:
+      description: ID of the build which corresponds to this update
+      type: int
+      sample: 210763
+    major_version:
+      description: Major version number
+      type: int
+      sample: 9
+    minor_version:
+      description: Minor version number
+      type: int
+      sample: 2
+    revision:
+      description: Revision number
+      type: int
+      sample: 11
+    timestamp:
+      description: Unix timestamp when the update was released
+      type: int
+      sample: 0
+record:
+  description:
+    - Next or latest update from list of updates, when option I(select) is specified
+  returned: success
+  type: dict
+  contains:
+    uuid:
+      description: Unique identifier in format majorVersion.minorVersion.revision.buildID
+      type: str
+      sample: 9.2.11.210763
+    description:
+      description: Human-readable name for the update
+      type: str
+      sample: 9.2.11 General Availability
+    change_log:
+      description: Description of all changes that are in this update, in HTML format
+      type: str
+      sample: ...Please allow between 20-40 minutes per node for the update to complete...
+    build_id:
+      description: ID of the build which corresponds to this update
+      type: int
+      sample: 210763
+    major_version:
+      description: Major version number
+      type: int
+      sample: 9
+    minor_version:
+      description: Minor version number
+      type: int
+      sample: 2
+    revision:
+      description: Revision number
+      type: int
+      sample: 11
+    timestamp:
+      description: Unix timestamp when the update was released
+      type: int
+      sample: 0
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -54,14 +134,38 @@ from ..module_utils.rest_client import RestClient
 from ..module_utils.client import Client
 from ..module_utils.hypercore_version import Update
 from ..module_utils.typed_classes import TypedUpdateToAnsible
-from typing import List, Optional
+from typing import List, Optional, Tuple
+import operator
 
 
-def run(rest_client: RestClient) -> List[Optional[TypedUpdateToAnsible]]:
-    return [
+def select_next_or_latest(
+    list_of_updates: List[TypedUpdateToAnsible], next_or_latest: str
+) -> Optional[TypedUpdateToAnsible]:
+    if not list_of_updates:
+        return None
+    sorted_list = list_of_updates.copy()  # so that we keep original records
+    sorted_list.sort(
+        key=operator.itemgetter(
+            "major_version", "minor_version", "revision", "build_id"
+        )
+    )
+    if next_or_latest == "next":
+        return sorted_list[0]
+    else:
+        return sorted_list[-1]
+
+
+def run(
+    module: AnsibleModule, rest_client: RestClient
+) -> Tuple[List[Optional[TypedUpdateToAnsible]], Optional[TypedUpdateToAnsible]]:
+    record = None
+    records = [
         Update.from_hypercore(hypercore_data=hypercore_dict).to_ansible()  # type: ignore
         for hypercore_dict in rest_client.list_records("/rest/v1/Update")
     ]
+    if module.params["select"]:
+        record = select_next_or_latest(records, module.params["select"])
+    return records, record
 
 
 def main() -> None:
@@ -69,14 +173,15 @@ def main() -> None:
         supports_check_mode=True,
         argument_spec=dict(
             arguments.get_spec("cluster_instance"),
+            select=dict(type="str", choices=["next", "latest"]),
         ),
     )
 
     try:
         client = Client.get_client(module.params["cluster_instance"])
         rest_client = RestClient(client)
-        records = run(rest_client)
-        module.exit_json(changed=False, records=records)
+        records, record = run(module, rest_client)
+        module.exit_json(changed=False, records=records, record=record)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/tests/integration/targets/version_update_info/tasks/main.yml
+++ b/tests/integration/targets/version_update_info/tasks/main.yml
@@ -11,5 +11,26 @@
       register: updates
     - ansible.builtin.assert:
         that:
-          - updates.records != []
           - updates.records[0].keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+          - not updates.record
+      when: updates.records != []
+
+    - name: Get next version update
+      scale_computing.hypercore.version_update_info:
+       select: next
+      register: updates
+    - ansible.builtin.assert:
+        that:
+          - updates.records[0].keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+          - updates.record.keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+      when: updates.records != []
+    
+    - name: Get latest version update
+      scale_computing.hypercore.version_update_info:
+       select: latest
+      register: updates
+    - ansible.builtin.assert:
+        that:
+          - updates.records[0].keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+          - updates.record.keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+      when: updates.records != []

--- a/tests/integration/targets/version_update_info/tasks/main.yml
+++ b/tests/integration/targets/version_update_info/tasks/main.yml
@@ -12,25 +12,6 @@
     - ansible.builtin.assert:
         that:
           - updates.records[0].keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
-          - not updates.record
-      when: updates.records != []
-
-    - name: Get next version update
-      scale_computing.hypercore.version_update_info:
-       select: next
-      register: updates
-    - ansible.builtin.assert:
-        that:
-          - updates.records[0].keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
-          - updates.record.keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
-      when: updates.records != []
-    
-    - name: Get latest version update
-      scale_computing.hypercore.version_update_info:
-       select: latest
-      register: updates
-    - ansible.builtin.assert:
-        that:
-          - updates.records[0].keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
-          - updates.record.keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+          - updates.next.keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
+          - updates.latest.keys() | sort == ['build_id', 'change_log', 'description', 'major_version', 'minor_version', 'revision', 'timestamp', 'uuid']
       when: updates.records != []

--- a/tests/unit/plugins/modules/test_version_update_info.py
+++ b/tests/unit/plugins/modules/test_version_update_info.py
@@ -153,3 +153,12 @@ class TestRun:
             "revision": 11,
             "timestamp": 1676920067,
         }
+
+    def test_run_no_records(self, rest_client):
+        rest_client.list_records.return_value = []
+
+        records, next, latest = version_update_info.run(rest_client)
+
+        assert records == []
+        assert next is None
+        assert latest is None

--- a/tests/unit/plugins/modules/test_version_update_info.py
+++ b/tests/unit/plugins/modules/test_version_update_info.py
@@ -24,32 +24,173 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+class TestSelectNextOrLatest:
+    def test_select(self):
+        list_of_updates = [
+            {
+                "uuid": "9.2.11.210764",
+                "build_id": 210764,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 11,
+            },
+            {
+                "uuid": "9.2.12.210763",
+                "build_id": 210763,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 12,
+            },
+            {
+                "uuid": "9.2.11.210763",
+                "build_id": 210763,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 11,
+            },
+            {
+                "uuid": "10.2.11.210763",
+                "build_id": 210763,
+                "major_version": 10,
+                "minor_version": 2,
+                "revision": 11,
+            },
+            {
+                "uuid": "9.3.11.210763",
+                "build_id": 210763,
+                "major_version": 9,
+                "minor_version": 3,
+                "revision": 11,
+            },
+        ]
+        next = version_update_info.select_next_or_latest(list_of_updates, "next")
+        latest = version_update_info.select_next_or_latest(list_of_updates, "latest")
+
+        assert next == {
+            "uuid": "9.2.11.210763",
+            "build_id": 210763,
+            "major_version": 9,
+            "minor_version": 2,
+            "revision": 11,
+        }
+        assert latest == {
+            "uuid": "10.2.11.210763",
+            "build_id": 210763,
+            "major_version": 10,
+            "minor_version": 2,
+            "revision": 11,
+        }
+
+
 class TestRun:
-    def test_run(self, rest_client, mocker):
-        rest_client.list_records.return_value = [
-            dict(
-                uuid="9.2.11.210763",
-                description="description",
-                changeLog="change log",
-                buildID=210763,
-                majorVersion=9,
-                minorVersion=2,
-                revision=11,
-                timestamp=1676920067,
+    @pytest.mark.parametrize(
+        ("select", "select_record"),
+        [
+            (None, None),
+            (
+                "next",
+                {
+                    "uuid": "9.2.11.210763",
+                    "description": "description",
+                    "change_log": "change log",
+                    "build_id": 210763,
+                    "major_version": 9,
+                    "minor_version": 2,
+                    "revision": 11,
+                    "timestamp": 1676920067,
+                },
+            ),
+            (
+                "latest",
+                {
+                    "uuid": "10.2.11.210763",
+                    "description": "description",
+                    "change_log": "change log",
+                    "build_id": 210763,
+                    "major_version": 10,
+                    "minor_version": 2,
+                    "revision": 11,
+                    "timestamp": 1676920067,
+                },
+            ),
+        ],
+    )
+    def test_run(self, rest_client, create_module, select, select_record):
+        module = create_module(
+            params=dict(
+                cluster_instance=dict(
+                    host="https://0.0.0.0",
+                    username=None,
+                    password=None,
+                ),
+                select=select,
             )
+        )
+        rest_client.list_records.return_value = [
+            {
+                "uuid": "9.2.12.210763",
+                "description": "description",
+                "changeLog": "change log",
+                "buildID": 210763,
+                "majorVersion": 9,
+                "minorVersion": 2,
+                "revision": 12,
+                "timestamp": 1676920067,
+            },
+            {
+                "uuid": "9.2.11.210763",
+                "description": "description",
+                "changeLog": "change log",
+                "buildID": 210763,
+                "majorVersion": 9,
+                "minorVersion": 2,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
+            {
+                "uuid": "10.2.11.210763",
+                "description": "description",
+                "changeLog": "change log",
+                "buildID": 210763,
+                "majorVersion": 10,
+                "minorVersion": 2,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
         ]
 
-        records = version_update_info.run(rest_client)
+        records, record = version_update_info.run(module, rest_client)
 
         assert records == [
-            dict(
-                uuid="9.2.11.210763",
-                description="description",
-                change_log="change log",
-                build_id=210763,
-                major_version=9,
-                minor_version=2,
-                revision=11,
-                timestamp=1676920067,
-            )
+            {
+                "uuid": "9.2.12.210763",
+                "description": "description",
+                "change_log": "change log",
+                "build_id": 210763,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 12,
+                "timestamp": 1676920067,
+            },
+            {
+                "uuid": "9.2.11.210763",
+                "description": "description",
+                "change_log": "change log",
+                "build_id": 210763,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
+            {
+                "uuid": "10.2.11.210763",
+                "description": "description",
+                "change_log": "change log",
+                "build_id": 210763,
+                "major_version": 10,
+                "minor_version": 2,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
         ]
+        assert record == select_record

--- a/tests/unit/plugins/modules/test_version_update_info.py
+++ b/tests/unit/plugins/modules/test_version_update_info.py
@@ -24,109 +24,19 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-class TestSelectNextOrLatest:
-    def test_select(self):
-        list_of_updates = [
+class TestRun:
+    def test_run(self, rest_client):
+        rest_client.list_records.return_value = [
             {
                 "uuid": "9.2.11.210764",
-                "build_id": 210764,
-                "major_version": 9,
-                "minor_version": 2,
+                "description": "description",
+                "changeLog": "change log",
+                "buildID": 210764,
+                "majorVersion": 9,
+                "minorVersion": 2,
                 "revision": 11,
+                "timestamp": 1676920067,
             },
-            {
-                "uuid": "9.2.12.210763",
-                "build_id": 210763,
-                "major_version": 9,
-                "minor_version": 2,
-                "revision": 12,
-            },
-            {
-                "uuid": "9.2.11.210763",
-                "build_id": 210763,
-                "major_version": 9,
-                "minor_version": 2,
-                "revision": 11,
-            },
-            {
-                "uuid": "10.2.11.210763",
-                "build_id": 210763,
-                "major_version": 10,
-                "minor_version": 2,
-                "revision": 11,
-            },
-            {
-                "uuid": "9.3.11.210763",
-                "build_id": 210763,
-                "major_version": 9,
-                "minor_version": 3,
-                "revision": 11,
-            },
-        ]
-        next = version_update_info.select_next_or_latest(list_of_updates, "next")
-        latest = version_update_info.select_next_or_latest(list_of_updates, "latest")
-
-        assert next == {
-            "uuid": "9.2.11.210763",
-            "build_id": 210763,
-            "major_version": 9,
-            "minor_version": 2,
-            "revision": 11,
-        }
-        assert latest == {
-            "uuid": "10.2.11.210763",
-            "build_id": 210763,
-            "major_version": 10,
-            "minor_version": 2,
-            "revision": 11,
-        }
-
-
-class TestRun:
-    @pytest.mark.parametrize(
-        ("select", "select_record"),
-        [
-            (None, None),
-            (
-                "next",
-                {
-                    "uuid": "9.2.11.210763",
-                    "description": "description",
-                    "change_log": "change log",
-                    "build_id": 210763,
-                    "major_version": 9,
-                    "minor_version": 2,
-                    "revision": 11,
-                    "timestamp": 1676920067,
-                },
-            ),
-            (
-                "latest",
-                {
-                    "uuid": "10.2.11.210763",
-                    "description": "description",
-                    "change_log": "change log",
-                    "build_id": 210763,
-                    "major_version": 10,
-                    "minor_version": 2,
-                    "revision": 11,
-                    "timestamp": 1676920067,
-                },
-            ),
-        ],
-    )
-    def test_run(self, rest_client, create_module, select, select_record):
-        module = create_module(
-            params=dict(
-                cluster_instance=dict(
-                    host="https://0.0.0.0",
-                    username=None,
-                    password=None,
-                ),
-                select=select,
-            )
-        )
-        rest_client.list_records.return_value = [
             {
                 "uuid": "9.2.12.210763",
                 "description": "description",
@@ -157,11 +67,41 @@ class TestRun:
                 "revision": 11,
                 "timestamp": 1676920067,
             },
+            {
+                "uuid": "9.3.11.210763",
+                "description": "description",
+                "changeLog": "change log",
+                "buildID": 210763,
+                "majorVersion": 9,
+                "minorVersion": 3,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
         ]
 
-        records, record = version_update_info.run(module, rest_client)
+        records, next, latest = version_update_info.run(rest_client)
 
         assert records == [
+            {
+                "uuid": "9.2.11.210763",
+                "description": "description",
+                "change_log": "change log",
+                "build_id": 210763,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
+            {
+                "uuid": "9.2.11.210764",
+                "description": "description",
+                "change_log": "change log",
+                "build_id": 210764,
+                "major_version": 9,
+                "minor_version": 2,
+                "revision": 11,
+                "timestamp": 1676920067,
+            },
             {
                 "uuid": "9.2.12.210763",
                 "description": "description",
@@ -173,12 +113,12 @@ class TestRun:
                 "timestamp": 1676920067,
             },
             {
-                "uuid": "9.2.11.210763",
+                "uuid": "9.3.11.210763",
                 "description": "description",
                 "change_log": "change log",
                 "build_id": 210763,
                 "major_version": 9,
-                "minor_version": 2,
+                "minor_version": 3,
                 "revision": 11,
                 "timestamp": 1676920067,
             },
@@ -193,4 +133,23 @@ class TestRun:
                 "timestamp": 1676920067,
             },
         ]
-        assert record == select_record
+        assert next == {
+            "uuid": "9.2.11.210763",
+            "description": "description",
+            "change_log": "change log",
+            "build_id": 210763,
+            "major_version": 9,
+            "minor_version": 2,
+            "revision": 11,
+            "timestamp": 1676920067,
+        }
+        assert latest == {
+            "uuid": "10.2.11.210763",
+            "description": "description",
+            "change_log": "change log",
+            "build_id": 210763,
+            "major_version": 10,
+            "minor_version": 2,
+            "revision": 11,
+            "timestamp": 1676920067,
+        }


### PR DESCRIPTION
To be able to choose next (the lowest number) or latest (the highest number) update from the list of available updates, next and latest are added to return value.