### PR TITLE
Ansible lint for examples

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,5 +5,6 @@ exclude_paths:
   - sample_*.yml
   - tests
   - examples/cloud-init-user-data-example.yml
+  - examples/hypercore_inventory.yml
   - .github/workflows
   - changelogs

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -62,6 +62,12 @@ jobs:
       - run: ansible-lint
       - run: flake8 --exclude tests/output/
       - run: ansible-test sanity --local --python 3.10
+      # Running `ansible-lint` will look at examples as being arbitrary yaml files.
+      # It will complain about missing space after hash in "#xy" comment.
+      # Running `ansible-lint examples/*` will interpret files as ansible playbooks.
+      # Here we need also installed collections used in examples.
+      - run: ansible-galaxy collection install community.crypto
+      - run: ansible-lint examples/*
 
   units-test:
     runs-on: [ubuntu-latest]

--- a/examples/api_get_cluster_info.yml
+++ b/examples/api_get_cluster_info.yml
@@ -13,11 +13,11 @@
       register: cluster_result
 
     - name: Show cluster info - complete API response
-      debug:
+      ansible.builtin.debug:
         var: cluster_result.record
 
     - name: Show cluster version
-      debug:
+      ansible.builtin.debug:
         msg:
           - Cluster name is '{{ cluster_result.record[0].clusterName }}'
           - Cluster SW version is '{{ cluster_result.record[0].icosVersion }}'

--- a/examples/certificate_signing_example.yml
+++ b/examples/certificate_signing_example.yml
@@ -9,7 +9,7 @@
   tasks:
     # More info about openssl_privatekey module
     # (https://docs.ansible.com/ansible/latest/collections/community/crypto/openssl_privatekey_module.html)
-    - name: generate private key with openSSL
+    - name: Generate private key with openSSL
       community.crypto.openssl_privatekey:
         path: private_key_example.pem
 
@@ -36,7 +36,7 @@
         privatekey_path: private_key_example.pem
         provider: selfsigned
 
-    - name: upload generated certificate and private_key with certificate module
+    - name: Upload generated certificate and private_key with certificate module
       scale_computing.hypercore.certificate:
         cluster_instance:
         private_key: "{{ lookup('file', 'private_key_example.pem') }}"
@@ -46,5 +46,5 @@
       check_mode: "{{ hypercore_example_check_mode }}"
 
     - name: Show uploaded certificate info
-      debug:
+      ansible.builtin.debug:
         var: certificate_info

--- a/examples/cluster_config.yml
+++ b/examples/cluster_config.yml
@@ -47,7 +47,7 @@
         var: cluster_configuration
 
     - name: Configure HyperCore cluster
-      include_role:
+      ansible.builtin.include_role:
         name: scale_computing.hypercore.cluster_config
       vars:
         scale_computing_hypercore_cluster_config: "{{ cluster_configuration }}"

--- a/examples/dns_config_info.yml
+++ b/examples/dns_config_info.yml
@@ -11,5 +11,5 @@
       register: dns_config_info_results
 
     - name: Show all DNS config entries
-      debug:
+      ansible.builtin.debug:
         var: dns_config_info_results

--- a/examples/email_alert_info.yml
+++ b/examples/email_alert_info.yml
@@ -8,5 +8,7 @@
     - name: List all Email alert recipients
       scale_computing.hypercore.email_alert_info:
       register: info
-    - ansible.builtin.debug:
+
+    - name: Show configured email alert recipients
+      ansible.builtin.debug:
         msg: "{{ info }}"

--- a/examples/iso.yml
+++ b/examples/iso.yml
@@ -14,6 +14,7 @@
       ansible.builtin.get_url:
         url: "{{ iso_url }}"
         dest: /tmp/{{ iso_filename }}
+        mode: 0644
 
     - name: (Optionally) remove existing ISO {{ iso_filename }} from HyperCore
       scale_computing.hypercore.iso:
@@ -36,5 +37,5 @@
       register: iso_results
 
     - name: Show info about {{ iso_filename }} ISO
-      debug:
+      ansible.builtin.debug:
         var: iso_results.records[0]

--- a/examples/iso_info.yml
+++ b/examples/iso_info.yml
@@ -16,7 +16,7 @@
       register: iso_results
 
     - name: Show all ISOs
-      debug:
+      ansible.builtin.debug:
         var: iso_results
 
     # ------------------------------------------------------
@@ -26,7 +26,7 @@
       register: iso_results
 
     - name: Show info about single ISO
-      debug:
+      ansible.builtin.debug:
         var: iso_results
 
     # ------------------------------------------------------
@@ -37,5 +37,5 @@
       register: iso_results
 
     - name: Show info about not present ISO
-      debug:
+      ansible.builtin.debug:
         var: iso_results

--- a/examples/list_vms_with_ide_disk.yml
+++ b/examples/list_vms_with_ide_disk.yml
@@ -54,6 +54,8 @@
     - name: Fail if any VM uses IDE disk
       ansible.builtin.fail:
         msg: Found {{ ide_vm_names | length }} VMs using IDE disk
-      when: ide_vm_names | length > 0
-      # VMs with IDE disks are created while testing. Ignore them if testing.
-      ignore_errors: "{{ hypercore_example_check_mode | default(false) }}"
+      when:
+        - ide_vm_names | length >= 0
+        # VMs with IDE disks are created while testing. Ignore them if CI testing the example -
+        # hypercore_example_check_mode will be True.
+        - not (hypercore_example_check_mode | default(false))

--- a/examples/oidc_config_setup_azure_ad.yml
+++ b/examples/oidc_config_setup_azure_ad.yml
@@ -20,7 +20,7 @@
       register: oidc_config_info_results
 
     - name: Show oidc config entries
-      debug:
+      ansible.builtin.debug:
         var: oidc_config_info_results
 
     - name: Create or update OIDC config
@@ -35,5 +35,5 @@
       register: oidc_config_info_results
 
     - name: Show updated oidc config entries
-      debug:
+      ansible.builtin.debug:
         var: oidc_config_info_results

--- a/examples/smtp.yml
+++ b/examples/smtp.yml
@@ -36,5 +36,6 @@
       scale_computing.hypercore.smtp_info:
       register: smtp_info
 
-    - ansible.builtin.debug:
+    - name: Show SMTP configuration
+      ansible.builtin.debug:
         msg: Final SMTP configuration is "{{ smtp_info }}"

--- a/examples/smtp_info.yml
+++ b/examples/smtp_info.yml
@@ -9,5 +9,6 @@
       scale_computing.hypercore.smtp_info:
       register: smtp_info
 
-    - ansible.builtin.debug:
+    - name: Show SMTP configuration
+      ansible.builtin.debug:
         msg: "{{ smtp_info }}"

--- a/examples/syslog_server.yml
+++ b/examples/syslog_server.yml
@@ -38,5 +38,7 @@
     - name: List all Syslog servers
       scale_computing.hypercore.syslog_server_info:
       register: syslog_info_records
-    - ansible.builtin.debug:
+
+    - name: Show syslog configuration
+      ansible.builtin.debug:
         msg: "{{ syslog_info_records }}"

--- a/examples/time_server_info.yml
+++ b/examples/time_server_info.yml
@@ -8,5 +8,7 @@
     - name: Get current Time Server
       scale_computing.hypercore.time_server_info:
       register: time_server_info
-    - ansible.builtin.debug:
+
+    - name: Show NTP time server configuration
+      ansible.builtin.debug:
         msg: "{{ time_server_info }}"

--- a/examples/time_zone_info.yml
+++ b/examples/time_zone_info.yml
@@ -8,5 +8,7 @@
     - name: Get current Time Zone
       scale_computing.hypercore.time_zone_info:
       register: time_zone_info
-    - ansible.builtin.debug:
+
+    - name: Show time zone configuration
+      ansible.builtin.debug:
         msg: "{{ time_zone_info }}"

--- a/examples/version_update_single_node.yml
+++ b/examples/version_update_single_node.yml
@@ -14,8 +14,9 @@
       scale_computing.hypercore.time_zone_info:
       register: time_zone_info
 
-    - ansible.builtin.assert:
-        fail_message: Time zone is not set on the host
+    - name: Check time zone is configured
+      ansible.builtin.assert:
+        fail_msg: Time zone is not set on the host
         that:
           - time_zone_info.record
 
@@ -27,7 +28,7 @@
         time_interval: 22:00-6:00
 
     - name: Update HyperCore single-node system to a desired version
-      include_role:
+      ansible.builtin.include_role:
         name: scale_computing.hypercore.version_update_single_node
       vars:
         scale_computing_hypercore_desired_version: "{{ desired_version }}"

--- a/examples/version_update_status_info.yml
+++ b/examples/version_update_status_info.yml
@@ -11,5 +11,5 @@
       register: version_update_status_info_result
 
     - name: Show version update status
-      debug:
+      ansible.builtin.debug:
         var: version_update_status_info_result

--- a/examples/virtual_disk.yml
+++ b/examples/virtual_disk.yml
@@ -15,6 +15,7 @@
       ansible.builtin.get_url: # TODO: what if file doesn't download completely?
         url: "{{ image_url }}"
         dest: /tmp/{{ image_filename }}
+        mode: 0644
 
     - name: (Optionally) remove existing Virtual Disk {{ image_filename }} from HyperCore
       when: image_remove_old | bool
@@ -22,7 +23,7 @@
         name: "{{ item }}"
         state: absent
       loop:
-        - "uploading-{{ image_filename }}"
+        - uploading-{{ image_filename }}
         - "{{ image_filename }}"
 
     # ------------------------------------------------------
@@ -39,5 +40,5 @@
       register: result
 
     - name: Show uploaded disk info
-      debug:
+      ansible.builtin.debug:
         var: result.records[0]

--- a/examples/virtual_disk_info.yml
+++ b/examples/virtual_disk_info.yml
@@ -15,7 +15,7 @@
       register: virtual_disk_results
 
     - name: Show all virtual disks
-      debug:
+      ansible.builtin.debug:
         var: virtual_disk_results
 
     # ------------------------------------------------------
@@ -25,7 +25,7 @@
       register: virtual_disk_results
 
     - name: Show info about single virtual disk
-      debug:
+      ansible.builtin.debug:
         var: virtual_disk_results
 
     # ------------------------------------------------------
@@ -35,5 +35,5 @@
       register: virtual_disk_results
 
     - name: Show info about absent virtual disk
-      debug:
+      ansible.builtin.debug:
         var: virtual_disk_results

--- a/examples/vm_info.yml
+++ b/examples/vm_info.yml
@@ -13,5 +13,5 @@
       register: vm_info_result
 
     - name: Show the info about {{ vm_name }} VM
-      debug:
+      ansible.builtin.debug:
         var: vm_info_result

--- a/examples/vm_replication_info.yml
+++ b/examples/vm_replication_info.yml
@@ -13,5 +13,5 @@
       register: replication_info_result
 
     - name: Show the replication info status of {{ vm_name }} VM
-      debug:
+      ansible.builtin.debug:
         var: replication_info_result


### PR DESCRIPTION
CI test in https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4565210170/jobs/8056017663 failed. Problem was `ansible.builtin.assert` `fail_msg` vs. `fail_message`, in `examples/version_update_single_node.yml`.

ansible-lint is now run also on examples, in hope such mistakes will be catched. While ansible-list can complain `namex` is not valid param for `ansible.builtin.include_role`, it still didn't report `fail_message` as invalid param for assert. I still decided it is useful to lint examples, and fix linter errors.