### PR TITLE
Fix roles check_local_time, version_update_single_node

### DIFF
--- a/examples/version_update_info.yml
+++ b/examples/version_update_info.yml
@@ -13,6 +13,6 @@
       ansible.builtin.debug:
         msg: >-
           Host has {{ result.records | length }} updates available.
-          All available updates: {{ result.records | map(attribute='uuid')}}.
+          All available updates: {{ result.records | map(attribute='uuid') }}.
           Lowest update is "{{ result.next.uuid | default('') }}".
           Highest update is "{{ result.latest.uuid | default('') }}".

--- a/examples/version_update_single_node.yml
+++ b/examples/version_update_single_node.yml
@@ -10,6 +10,10 @@
     desired_version: 9.1.23.210897
 
   tasks:
+    - name: Show desired_version
+      ansible.builtin.debug:
+        msg: Desired HyperCore version for host {{ lookup('ansible.builtin.env', 'SC_HOST') }} is {{ desired_version }}.
+
     - name: Get host's time zone
       scale_computing.hypercore.time_zone_info:
       register: time_zone_info

--- a/roles/check_local_time/tasks/main.yml
+++ b/roles/check_local_time/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if local time is in time interval (run check_local_time.py)
   ansible.builtin.script:
-    executable: "{{ discovered_interpreter_python }}"
+    executable: "{{ ansible_python_interpreter }}"
     cmd: check_local_time.py "{{ time_zone }}" "{{ time_interval }}"
   register: local_time_output
 

--- a/roles/check_local_time/tasks/main.yml
+++ b/roles/check_local_time/tasks/main.yml
@@ -1,23 +1,7 @@
 ---
-- name: Is executable python3
-  ansible.builtin.command: which python3
-  register: executable
-  changed_when: false  # to avoid ansible-lint error "no-changed-when: Commands should not change things if nothing needs doing."
-  ignore_errors: true  # if there is no python3, the shell will fail
-
-- name: Is executable python
-  ansible.builtin.command: which python
-  register: executable_python
-  changed_when: false  # to avoid ansible-lint error "no-changed-when: Commands should not change things if nothing needs doing."
-  ignore_errors: true  # if there is no python, the shell will fail
-
-- name: If not python3, then set executable to python
-  ansible.builtin.set_fact: executable="{{ executable_python }}"
-  when: not executable.stdout_lines
-
 - name: Check if local time is in time interval (run check_local_time.py)
   ansible.builtin.script:
-    executable: "{{ executable.stdout_lines[0] }}"
+    executable: "{{ discovered_interpreter_python }}"
     cmd: check_local_time.py "{{ time_zone }}" "{{ time_interval }}"
   register: local_time_output
 

--- a/roles/version_update_single_node/tasks/main.yml
+++ b/roles/version_update_single_node/tasks/main.yml
@@ -87,4 +87,7 @@
       when: update_result.record.uuid != scale_computing_hypercore_desired_version
   when:
     - cluster_info.record.icos_version != scale_computing_hypercore_desired_version
-    - update_status_before_update.record.update_status == "COMPLETED" or update_status_before_update.record.update_status != "IN PROGRESS"
+    - >-
+      update_status_before_update.record == None or
+      update_status_before_update.record.update_status == "COMPLETED" or
+      update_status_before_update.record.update_status != "IN PROGRESS"

--- a/tests/integration/targets/role_check_local_time/tasks/main.yml
+++ b/tests/integration/targets/role_check_local_time/tasks/main.yml
@@ -6,17 +6,25 @@
     SC_TIMEOUT: "{{ sc_timeout }}"
 
   block:
+    - name: Get Timezone 
+      ansible.builtin.uri:
+        url: https://ipapi.co/timezone
+        return_content: true
+      register: respone
+
     - name: Check that local time meets required time interval
       ansible.builtin.include_role:
         name: scale_computing.hypercore.check_local_time
       vars:
-        time_zone: "{{ ansible_date_time.tz }}"
+        time_zone: "{{ respone.content }}" # ansible_date_time.tz returns CEST which is not a valid tz for env var TZ
         time_interval: "{{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59"
     
     # it can fail when run near x:59
     - ansible.builtin.assert:
         that:
-          - "'Local time for time zone {{ ansible_date_time.tz }} is in required time interval {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59' in local_time_msg" 
+          - >-
+            "'Local time for time zone {{ respone.content }} is in required time interval 
+            {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59' in local_time_msg" 
 
     - name: Check that local time doesn't meet required time interval
       ansible.builtin.include_role:
@@ -24,10 +32,12 @@
         apply:
           ignore_errors: True
       vars:
-        time_zone: "{{ ansible_date_time.tz }}"
+        time_zone: "{{ respone.content }}"
         time_interval: "{{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01"
 
     # it can fail when run near x:00
     - ansible.builtin.assert:
         that:
-          - "'Local time for time zone {{ ansible_date_time.tz }} is not in required time interval {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01' in local_time_msg" 
+          - >-
+            "'Local time for time zone {{ respone.content }} is not in required time interval 
+            {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01' in local_time_msg" 

--- a/tests/integration/targets/role_check_local_time/tasks/main.yml
+++ b/tests/integration/targets/role_check_local_time/tasks/main.yml
@@ -10,20 +10,20 @@
       ansible.builtin.uri:
         url: https://ipapi.co/timezone
         return_content: true
-      register: respone
+      register: response
 
     - name: Check that local time meets required time interval
       ansible.builtin.include_role:
         name: scale_computing.hypercore.check_local_time
       vars:
-        time_zone: "{{ respone.content }}" # ansible_date_time.tz returns CEST which is not a valid tz for env var TZ
+        time_zone: "{{ response.content }}" # ansible_date_time.tz returns CEST which is not a valid tz for env var TZ
         time_interval: "{{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59"
     
     # it can fail when run near x:59
     - ansible.builtin.assert:
         that:
           - >-
-            "'Local time for time zone {{ respone.content }} is in required time interval 
+            "'Local time for time zone {{ response.content }} is in required time interval 
             {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59' in local_time_msg" 
 
     - name: Check that local time doesn't meet required time interval
@@ -32,12 +32,12 @@
         apply:
           ignore_errors: True
       vars:
-        time_zone: "{{ respone.content }}"
+        time_zone: "{{ response.content }}"
         time_interval: "{{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01"
 
     # it can fail when run near x:00
     - ansible.builtin.assert:
         that:
           - >-
-            "'Local time for time zone {{ respone.content }} is not in required time interval 
+            "'Local time for time zone {{ response.content }} is not in required time interval 
             {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01' in local_time_msg" 


### PR DESCRIPTION
The job https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4625947983/jobs/8182193452#step:9:55 failed.
The `ansible.builtin.set_fact: executable="{{ executable_python }}"` got executed (I think), and then `executable.stdout_lines` - there is no `stdout_lines` in `executable`.

Whole 3 tasks are just to hard to understand, and also to test.

The PR will switch to use `discovered_interpreter_python`. I think this will just work, even if playbook would be executed over SSH.

The version_update_single_node assumed `version_update_status_info` always returns `record`. But if cluster was never upgraded, then no record is returned. This is fixed now.

The CI job for this example will still fail - we cannot really upgrade any of our test clusters.
And I do not have a good idea how to test that running the example on each test cluster failed in "correct" way.
Maybe I will just exclude that example from CI testing, or add a special CI job with more complicated shell commands.

