### PR TITLE
deprecation for vm and snapshot_schedule return value

### DIFF
--- a/docs/rst/extra/deprecation.rst
+++ b/docs/rst/extra/deprecation.rst
@@ -1,0 +1,169 @@
+.. _scale_computing.hypercore.deprecation:
+
+*****************
+Deprecation Notes
+*****************
+
+Deprecation notes will list deprecated features in different HyperCore Collection releases
+and guide users through migration.
+
+Release 1.0.0
+=============
+
+Initial release, no deprecated features.
+
+Release 1.1.0
+=============
+
+No deprecated features.
+
+Release 1.2.0
+=============
+
+Module `scale_computing.hypercore.iso <../collections/scale_computing/hypercore/iso_module.html>`_
+return value ``results`` is deprecated.
+A new return value ``record`` is added as replacement.
+The old ``results`` return value will remain available until release 3.0.0.
+
+Module `scale_computing.hypercore.vm_nic <../collections/scale_computing/hypercore/vm_nic_module.html>`_
+return value ``records`` is deprecated.
+A new return value ``record`` is added as replacement.
+The old ``records`` return value will remain available until release 3.0.0.
+
+Only playbooks that store output from ``scale_computing.hypercore.iso``
+(or ``scale_computing.hypercore.vm_nic``) module using ``register:`` keyword are affected.
+
+Added deprecation note for modules
+`scale_computing.hypercore.vm <../collections/scale_computing/hypercore/vm_module.html>`_ and
+`scale_computing.hypercore.snapshot_schedule <../collections/scale_computing/hypercore/snapshot_schedule_module.html>`_.
+
+Examples to help with transition to release 1.2.0
+-------------------------------------------------
+
+For ``scale_computing.hypercore.iso`` module:
+
+.. code-block:: yaml
+
+    # Store iso module output
+    - name: Upload ISO {{ iso_filename }} to HyperCore
+      scale_computing.hypercore.iso:
+        name: "{{ iso_filename }}"
+        source: /tmp/{{ iso_filename }}
+        state: present
+      register: uploaded_iso
+
+    # Use iso module output, old syntax, valid until release < 3.0.0
+    - name: Show upload result for ISO {{ iso_filename }} - deprecated syntax
+      ansible.builtin.debug:
+        msg: The uploaded_iso size={{ uploaded_iso.results.0.size }} - deprecated syntax
+
+    # Use iso module output, new syntax, valid after release >= 1.2.0
+    - name: Show upload result for ISO {{ iso_filename }}
+      ansible.builtin.debug:
+        msg: The uploaded_iso size={{ uploaded_iso.record.size }}
+
+
+For ``scale_computing.hypercore.vm_nic`` module:
+
+.. code-block:: yaml
+
+    # Store vm_nic module output
+    - name: Set VLAN for VM {{ vm_name }} 1st NIC
+      scale_computing.hypercore.vm_nic:
+        vm_name: "{{ vm_name }}"
+        items:
+          - vlan: "{{ vlan }}"
+        state: present
+      register: vm_nic_result
+
+    # Use vm_nic module output, old syntax, valid until release < 3.0.0
+    - name: Show VM {{ vm_name }} 1st NIC VLAN - deprecated syntax
+      ansible.builtin.debug:
+        msg: The configured VLAN is {{ vm_nic_result.records.vlan }} - deprecated syntax
+
+    # Use vm_nic module output, new syntax, valid after release >= 1.2.0
+    - name: Show VM {{ vm_name }} 1st NIC VLAN
+      ansible.builtin.debug:
+        msg: The configured VLAN is {{ vm_nic_result.record.vlan }}
+
+
+Release 3.0.0 (not yet released)
+================================
+
+Module `scale_computing.hypercore.vm <../collections/scale_computing/hypercore/vm_module.html>`_
+return value ``record`` content is changed from list with single item to a dict.
+
+Module `scale_computing.hypercore.snapshot_schedule <../collections/scale_computing/hypercore/snapshot_schedule_module.html>`_
+return value ``record`` content is changed from list with single item to a dict.
+
+Only playbooks that store output from ``scale_computing.hypercore.vm``
+(or ``scale_computing.hypercore.snapshot_schedule``) module using ``register:`` keyword are affected.
+
+Examples to help with transition to release 3.0.0
+-------------------------------------------------
+
+For ``scale_computing.hypercore.vm`` module:
+
+.. code-block:: yaml
+
+    - name: Create VM {{ vm_name }}
+      scale_computing.hypercore.vm:
+        vm_name: "{{ vm_name }}"
+        memory: "{{ '1 GB' | human_to_bytes }}"
+        vcpu: 2
+        disks:
+          - type: virtio_disk
+            disk_slot: 0
+            size: "{{ '10 GB' | human_to_bytes }}"
+        nics:
+          - type: virtio
+            vlan: 10
+        state: present
+        operating_system: os_other
+      register: vm_result
+
+    # Use vm module output, syntax valid until release < 3.0.0
+    - name: Show VM {{ vm_name }} vCPU count - syntax valid until release < 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          VM {{ vm_name }} has {{ vm_result.record.0.vcpu }} vCPUs -
+          syntax valid until release < 3.0.0
+
+    # Use vm module output, new syntax, valid after release >= 3.0.0
+    - name: Show VM {{ vm_name }} vCPU count - syntax valid after release >= 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          VM {{ vm_name }} has {{ vm_result.record.vcpu }} vCPUs -
+          syntax valid after release >= 3.0.0
+
+For ``scale_computing.hypercore.snapshot_schedule`` module:
+
+.. code-block:: yaml
+
+    - name: Setup snapshot schedule demo-snap-schedule
+      scale_computing.hypercore.snapshot_schedule:
+        name: demo-snap-schedule
+        state: present
+        recurrences:
+          - name: weekly-tuesday
+            frequency: "FREQ=WEEKLY;INTERVAL=1;BYDAY=TU"  # RFC-2445
+            start: "2010-01-01 00:00:00"
+            local_retention: "{{ 10 * 7*24*60*60 }}"  # 10 days, unit seconds
+            remote_retention:  # optional, None or 0 means same as local_retention.
+      register: demo_snapshot_schedule
+
+    # Use snapshot_schedule module output, syntax valid until release < 3.0.0
+    - name: Show snapshot schedule local retention - syntax valid until release < 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          Snapshot schedule {{ demo_snapshot_schedule.record.0.name }} has local retention
+          {{ demo_snapshot_schedule.record.0.recurrences.0.local_retention }} [sec] -
+          syntax valid until release < 3.0.0
+
+    # Use snapshot_schedule module output, new syntax, valid after release >= 3.0.0
+    - name: Show snapshot schedule local retention - syntax valid after release >= 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          Snapshot schedule {{ demo_snapshot_schedule.record.name }} has local retention
+          {{ demo_snapshot_schedule.record.recurrences.0.local_retention }} [sec] -
+          syntax valid after release >= 3.0.0

--- a/docs/rst/extra/quickstart.rst
+++ b/docs/rst/extra/quickstart.rst
@@ -131,8 +131,8 @@ cluster REST API endpoints. Extensive documentation on our current
 available modules can be found
 `here <https://galaxy.ansible.com/scale_computing/hypercore>`__.
 
-For example: `scale_computing.hypercore.vm <https://scalecomputing.github.io/HyperCoreAnsibleCollection-docs/modules/vm.html>`_ 
-is the module that will allow you to create, update, and delete virtual 
+For example: `scale_computing.hypercore.vm <../collections/scale_computing/hypercore/vm_module.html>`_
+is the module that will allow you to create, update, and delete virtual
 machines. When you begin writing Playbooks, you will reference a specific 
 module when attempting to automate a task associated with that said module 
 is equipped to handle.
@@ -293,7 +293,7 @@ This guide will now demonstrate how to create a Playbook that will create a VM o
 
 .. image:: images/qs_wplaybooks3.png
 
-7. For the purposes of this guide, you can reference the `scale_computing.hypercore.vm <https://scalecomputing.github.io/HyperCoreAnsibleCollection-docs/modules/vm.html>`_ module then copy and paste the example task for creating a VM into your Playbook.
+7. For the purposes of this guide, you can reference the `scale_computing.hypercore.vm <../collections/scale_computing/hypercore/vm_module.html>`_ module then copy and paste the example task for creating a VM into your Playbook.
    A valid `cloud_init user data <https://github.com/ScaleComputing/HyperCoreAnsibleCollection/blob/main/examples/cloud-init-user-data-example.yml>`_ sample file is available.
 
 .. code-block:: yaml

--- a/docs/rst/index.rst
+++ b/docs/rst/index.rst
@@ -22,6 +22,7 @@ All other parameters hold the information related to the resource that we are op
    :caption: Guides:
 
    extra/quickstart.rst
+   extra/deprecation.rst
 
 
 .. toctree::

--- a/examples/iso.yml
+++ b/examples/iso.yml
@@ -28,6 +28,17 @@
         name: "{{ iso_filename }}"
         source: /tmp/{{ iso_filename }}
         state: present
+      register: uploaded_iso
+
+    # Use iso module output, old syntax, valid until release < 3.0.0
+    - name: Show upload result for ISO {{ iso_filename }} - deprecated syntax
+      ansible.builtin.debug:
+        msg: The uploaded_iso size={{ uploaded_iso.results.0.size }} - deprecated syntax
+
+    # Use iso module output, new syntax, valid after release >= 1.2.0
+    - name: Show upload result for ISO {{ iso_filename }}
+      ansible.builtin.debug:
+        msg: The uploaded_iso size={{ uploaded_iso.record.size }}
 
     # ------------------------------------------------------
     - name: Get info about specific ISO image - {{ iso_filename }}

--- a/examples/snapshot_schedule.yml
+++ b/examples/snapshot_schedule.yml
@@ -1,0 +1,38 @@
+- name: Create VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Setup snapshot schedule demo-snap-schedule
+      scale_computing.hypercore.snapshot_schedule:
+        name: demo-snap-schedule
+        state: present
+        recurrences:
+          - name: weekly-tuesday
+            frequency: "FREQ=WEEKLY;INTERVAL=1;BYDAY=TU"  # RFC-2445
+            start: "2010-01-01 00:00:00"
+            local_retention: "{{ 10 * 7*24*60*60 }}"  # 10 days, unit seconds
+            remote_retention:  # optional, None or 0 means same as local_retention.
+      register: demo_snapshot_schedule
+
+    - name: Show snapshot_schedule module output
+      ansible.builtin.debug:
+        var: demo_snapshot_schedule
+
+    # Use snapshot_schedule module output, syntax valid until release < 3.0.0
+    - name: Show snapshot schedule local retention - syntax valid until release < 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          Snapshot schedule {{ demo_snapshot_schedule.record.0.name }} has local retention
+          {{ demo_snapshot_schedule.record.0.recurrences.0.local_retention }} [sec] -
+          syntax valid until release < 3.0.0
+
+    # Use snapshot_schedule module output, new syntax, valid after release >= 3.0.0
+    - name: Show snapshot schedule local retention - syntax valid after release >= 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          Snapshot schedule {{ demo_snapshot_schedule.record.name }} has local retention
+          {{ demo_snapshot_schedule.record.recurrences.0.local_retention }} [sec] -
+          syntax valid after release >= 3.0.0
+      when: false  # 3.0.0 is not yet released

--- a/examples/vm.yml
+++ b/examples/vm.yml
@@ -27,3 +27,18 @@
     - name: Show the info about {{ vm_name }} VM
       debug:
         var: vm_result
+
+    # Use vm module output, syntax valid until release < 3.0.0
+    - name: Show VM {{ vm_name }} vCPU count - syntax valid until release < 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          VM {{ vm_name }} has {{ vm_result.record.0.vcpu }} vCPUs -
+          syntax valid until release < 3.0.0
+
+    # Use vm module output, new syntax, valid after release >= 3.0.0
+    - name: Show VM {{ vm_name }} vCPU count - syntax valid after release >= 3.0.0
+      ansible.builtin.debug:
+        msg: >-
+          VM {{ vm_name }} has {{ vm_result.record.vcpu }} vCPUs -
+          syntax valid after release >= 3.0.0
+      when: false  # 3.0.0 is not yet released

--- a/examples/vm.yml
+++ b/examples/vm.yml
@@ -1,0 +1,29 @@
+---
+- name: Create VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: demo-vm
+
+  tasks:
+    - name: Create VM {{ vm_name }}
+      scale_computing.hypercore.vm:
+        vm_name: "{{ vm_name }}"
+        memory: "{{ '1 GB' | human_to_bytes }}"
+        vcpu: 2
+        disks:
+          - type: virtio_disk
+            disk_slot: 0
+            size: "{{ '10 GB' | human_to_bytes }}"
+        nics:
+          - type: virtio
+            vlan: 10
+        state: present
+        # os_other or os_windows_server_2012
+        operating_system: os_other
+      register: vm_result
+
+    - name: Show the info about {{ vm_name }} VM
+      debug:
+        var: vm_result

--- a/examples/vm_nic.yml
+++ b/examples/vm_nic.yml
@@ -1,0 +1,31 @@
+---
+- name: Change VLAN for 1st NIC of a specific VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: demo-vm
+    vlan: 10
+
+  tasks:
+    - name: Set VLAN for VM {{ vm_name }} 1st NIC
+      scale_computing.hypercore.vm_nic:
+        vm_name: "{{ vm_name }}"
+        items:
+          - vlan: "{{ vlan }}"
+        state: present
+      register: vm_nic_result
+
+    - name: Show the VM {{ vm_name }} new NIC state
+      debug:
+        var: vm_nic_result.record
+
+    # Use vm_nic module output, old syntax, valid until release < 3.0.0
+    - name: Show VM {{ vm_name }} 1st NIC VLAN - deprecated syntax
+      ansible.builtin.debug:
+        msg: The configured VLAN is {{ vm_nic_result.records.vlan }} - deprecated syntax
+
+    # Use vm_nic module output, new syntax, valid after release >= 1.2.0
+    - name: Show VM {{ vm_name }} 1st NIC VLAN
+      ansible.builtin.debug:
+        msg: The configured VLAN is {{ vm_nic_result.record.vlan }}

--- a/plugins/modules/iso.py
+++ b/plugins/modules/iso.py
@@ -52,6 +52,8 @@ notes:
   - C(check_mode) is not supported.
   - Return value C(record) is added in version 1.2.0, and deprecates return value C(results).
     Return value C(results) will be removed in future release.
+    R(List of deprecation changes, scale_computing.hypercore.deprecation)
+    includes examples to help with transition.
 """
 
 

--- a/plugins/modules/iso.py
+++ b/plugins/modules/iso.py
@@ -256,8 +256,8 @@ def main():
     )
 
     module.deprecate(
-        "The 'results' return value is being renamed to 'record' and changed from list to dict."
-        "Please use 'record' since 'results' will be removed in future release."
+        "The 'results' return value is being renamed to 'record' and changed from list to dict. "
+        "Please use 'record' since 'results' will be removed in future release. "
         "But for now both values are being returned to allow users to migrate their automation.",
         version="3.0.0",
         collection_name="scale_computing.hypercore",

--- a/plugins/modules/snapshot_schedule.py
+++ b/plugins/modules/snapshot_schedule.py
@@ -73,6 +73,12 @@ options:
           - If either not set or set to either C(0) or C(None), remote_retention will be assigned
             I(local_retention)'s value.
 notes:
+  - The C(record) return value will be changed from list (containing a single item) to dict.
+    There will be no release where both old and new variant work at the same time.
+    To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release
+    will be changing the C(record) return value.
+    Affected modules are M(scale_computing.hypercore.vm) and M(scale_computing.hypercore.snapshot_schedule).
+    The change will happen with release 3.0.0.
   - C(check_mode) is not supported.
 """
 
@@ -226,6 +232,16 @@ def main():
             ),
         ),
         required_if=[("state", "present", ("recurrences",))],
+    )
+
+    module.deprecate(
+        "The 'record' return value will be changed from list (containing a single item) to dict. "
+        "There will be no release where both old and new variant work at the same time. "
+        "To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release "
+        "will be changing the 'record' return value. "
+        "Affected modules are vm and snapshot_schedule.",
+        version="3.0.0",
+        collection_name="scale_computing.hypercore",
     )
 
     try:

--- a/plugins/modules/snapshot_schedule.py
+++ b/plugins/modules/snapshot_schedule.py
@@ -75,10 +75,11 @@ options:
 notes:
   - The C(record) return value will be changed from list (containing a single item) to dict.
     There will be no release where both old and new variant work at the same time.
+    The change will happen with release 3.0.0.
     To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release
     will be changing the C(record) return value.
-    Affected modules are M(scale_computing.hypercore.vm) and M(scale_computing.hypercore.snapshot_schedule).
-    The change will happen with release 3.0.0.
+    R(List of deprecation changes, scale_computing.hypercore.deprecation)
+    includes examples to help with transition.
   - C(check_mode) is not supported.
 """
 

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -214,6 +214,12 @@ options:
     choices: [ BIOS, UEFI, vTPM+UEFI ]
     version_added: 1.1.0
 notes:
+  - The C(record) return value will be changed from list (containing a single item) to dict.
+    There will be no release where both old and new variant work at the same time.
+    To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release
+    will be changing the C(record) return value.
+    Affected modules are M(scale_computing.hypercore.vm) and M(scale_computing.hypercore.snapshot_schedule).
+    The change will happen with release 3.0.0.
   - C(check_mode) is not supported.
 """
 
@@ -648,6 +654,16 @@ def main():
                 False,
             ),
         ],
+    )
+
+    module.deprecate(
+        "The 'record' return value will be changed from list (containing a single item) to dict. "
+        "There will be no release where both old and new variant work at the same time. "
+        "To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release "
+        "will be changing the 'record' return value. "
+        "Affected modules are vm and snapshot_schedule.",
+        version="3.0.0",
+        collection_name="scale_computing.hypercore",
     )
 
     try:

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -216,10 +216,11 @@ options:
 notes:
   - The C(record) return value will be changed from list (containing a single item) to dict.
     There will be no release where both old and new variant work at the same time.
+    The change will happen with release 3.0.0.
     To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release
     will be changing the C(record) return value.
-    Affected modules are M(scale_computing.hypercore.vm) and M(scale_computing.hypercore.snapshot_schedule).
-    The change will happen with release 3.0.0.
+    R(List of deprecation changes, scale_computing.hypercore.deprecation)
+    includes examples to help with transition.
   - C(check_mode) is not supported.
 """
 

--- a/plugins/modules/vm_nic.py
+++ b/plugins/modules/vm_nic.py
@@ -71,6 +71,8 @@ notes:
   - C(check_mode) is not supported.
   - Return value C(record) is added in version 1.2.0, and deprecates return value C(records).
     Return value C(records) will be removed in future release.
+    R(List of deprecation changes, scale_computing.hypercore.deprecation)
+    includes examples to help with transition.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vm_nic.py
+++ b/plugins/modules/vm_nic.py
@@ -332,8 +332,8 @@ def main():
     )
 
     module.deprecate(
-        "The 'records' return value is being renamed to 'record'."
-        "Please use 'record' since 'records' will be removed in future release."
+        "The 'records' return value is being renamed to 'record'. "
+        "Please use 'record' since 'records' will be removed in future release. "
         "But for now both values are being returned to allow users to migrate their automation.",
         version="3.0.0",
         collection_name="scale_computing.hypercore",


### PR DESCRIPTION
Running `ansible-playbook examples/vm.yml` shows 

```
TASK [Create VM demo-vm] ******************************************************************************
[DEPRECATION WARNING]: The 'record' return value will be changed from list (containing a single item) to dict. There will be no release where both old and 
new variant work at the same time. To ease migration, the only change between last 1.x or 2.x release and 3.0.0 release will be changing the 'record' 
return value. Affected modules are vm and snapshot_schedule. This feature will be removed from scale_computing.hypercore in version 3.0.0. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [localhost]
```

Examples for `vm` and `snapshot_schedule` modules were added.
Examples for `vm`, `snapshot_schedule`, `iso` and `vm_nic` contain example task for old and new syntax.

The same example tasks are show in `deprecation.rst`, a document that is support to help users migrate their playbooks.

Space for existing deprecation messages are fixed.

Relative links are used in `deprecation.rst`, so we can render documentation locally, and link will guide to locally rendered modules. Relative links were added to `quickstart.rst` too.

After merge to milestone-1-done branch (e.g. will be in release 1.2.0), I will cherry-pick this for main branch too.