### PR TITLE
Use github pages action

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,51 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the specified branch
+  push:
+    branches: ["gh-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    container: quay.io/justinc1_github/scale_ci_integ:3
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Build Ansible collection docs
+        run: |
+          /bin/rm -fr /tmp/scale-ansible-collection
+          mkdir -p /tmp/scale-ansible-collection/ansible_collections/scale_computing/
+          cp -a . /tmp/scale-ansible-collection/ansible_collections/scale_computing/hypercore
+          export ANSIBLE_COLLECTIONS_PATH=/tmp/scale-ansible-collection
+          apt update && apt install -y rsync
+          make docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'docs/build/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
The PR adds github action to deploy documentation when:
- when new code is pushed to gh-pages branch.
- we manually run corresponding action. In this case source branch/tag can be selected.

Example manually run action - https://github.com/justinc1/HyperCoreAnsibleCollection/actions/runs/4667144279.
Rendered documentation is at https://justinc1.github.io/HyperCoreAnsibleCollection/

We will need to protect gh-pages branch (no force push).

After merge to main, I will cherry-pick this for release 1.2.0 too.
