### PR TITLE
CI try to fix check_local_time integ test

### DIFF
--- a/tests/integration/targets/role_check_local_time/tasks/main.yml
+++ b/tests/integration/targets/role_check_local_time/tasks/main.yml
@@ -12,20 +12,48 @@
         return_content: true
       register: response
 
+    - name: Show Timezone
+      ansible.builtin.debug:
+        msg: Timezone is {{ response.content }}
+
+    # ansible_date_time is incremented for a few second for each next task.
+    # Store value, so we have a stable value.
+    - name: Store current time
+      ansible.builtin.set_fact:
+        current_date_time: "{{ ansible_date_time }}"
+
+    - name: Show current time
+      ansible.builtin.debug:
+        msg: current_date_time={{ current_date_time }} TZ={{ current_date_time.tz }} hour={{ current_date_time.hour }}
+
+    # The scheduled integration tests run near 3.00 UTC (5:00 CEST).
+    # ansible_date_time.hour is reported in local timezone.
+    # It should be safe to add/subtract 1 hour to prevent occasional test failures,
+    # if scheduled test is run near x:59:59.
+
+    # Manual testing - can be run at arbitrary time, can always be a problem. So extra assert
+    - name: Check "current_date_time.hour +/- 1" is still a valid hour
+      ansible.builtin.assert:
+        that:
+          - 1 <= (current_date_time.hour | int)
+          - (current_date_time.hour | int) <= 22
+
+    # ------------------------------------------------------------------------------
     - name: Check that local time meets required time interval
       ansible.builtin.include_role:
         name: scale_computing.hypercore.check_local_time
       vars:
         time_zone: "{{ response.content }}" # ansible_date_time.tz returns CEST which is not a valid tz for env var TZ
-        time_interval: "{{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59"
+        time_interval: "{{ (current_date_time.hour | int) - 1 }}:00-{{ (current_date_time.hour | int) + 1 }}:59"
     
-    # it can fail when run near x:59
-    - ansible.builtin.assert:
+    - name: Check local_time_msg for passed case
+      ansible.builtin.assert:
         that:
           - >-
-            "'Local time for time zone {{ response.content }} is in required time interval 
-            {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:59' in local_time_msg" 
+            'Local time for time zone {{ response.content }} is in required time interval
+            {{ (current_date_time.hour | int) - 1 }}:00-{{ (current_date_time.hour | int) + 1 }}:59' in local_time_msg
 
+    # ------------------------------------------------------------------------------
     - name: Check that local time doesn't meet required time interval
       ansible.builtin.include_role:
         name: scale_computing.hypercore.check_local_time
@@ -33,11 +61,11 @@
           ignore_errors: True
       vars:
         time_zone: "{{ response.content }}"
-        time_interval: "{{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01"
+        time_interval: "{{ (current_date_time.hour | int) - 1 }}:00-{{ (current_date_time.hour | int) - 1 }}:01"
 
-    # it can fail when run near x:00
-    - ansible.builtin.assert:
+    - name: Check local_time_msg for failed case
+      ansible.builtin.assert:
         that:
           - >-
-            "'Local time for time zone {{ response.content }} is not in required time interval 
-            {{ ansible_date_time.hour }}:00-{{ ansible_date_time.hour }}:01' in local_time_msg" 
+            'Local time for time zone {{ response.content }} is not in required time interval
+            {{ (current_date_time.hour | int) - 1 }}:00-{{ (current_date_time.hour | int) - 1 }}:01' in local_time_msg


### PR DESCRIPTION
Jobs
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4675127388/jobs/8279941573#step:8:52 and
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4675127388/jobs/8279941761#step:8:52 failed

Extra debug print added. It is not clear what were input values, and what went wrong.

Tested interval is also changed, this should make test more reliable.

Downside is test cannot work 2 hours in a day - there is extra assert just to fail early when this happens. It should not happen during scheduled CI jobs.

Removed the extra "" in asserts. We were checking string is not empty, but we need to let assert evaluate string.