### PR TITLE
CI expect latest new GA release 9.1.24

### DIFF
--- a/examples/version_update_single_node.yml
+++ b/examples/version_update_single_node.yml
@@ -7,7 +7,7 @@
   check_mode: true
 
   vars:
-    desired_version: 9.1.23.210897
+    desired_version: 9.1.24.211326
 
   tasks:
     - name: Show desired_version

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -126,8 +126,8 @@ sc_config:
     features:
       version_update:
         current_version: "9.1.14.208456"
-        next_version: "9.1.23.210897"
-        latest_version: "9.1.23.210897"
+        next_version: "9.1.24.211326"
+        latest_version: "9.1.24.211326"
         can_be_applied: False
         # We can try update, update will fail, and status.json will be present.
         old_update_status_present: True

--- a/tests/integration/targets/role_version_update_single_node/tasks/main.yml
+++ b/tests/integration/targets/role_version_update_single_node/tasks/main.yml
@@ -6,14 +6,16 @@
     SC_TIMEOUT: "{{ sc_timeout }}"
 
   vars:
-    desired_version_new: 9.1.23.210897
-    desired_version_current: 9.1.18.209840
+    # Update to .next_version or .latest_version
+    desired_version_new: "{{ sc_config[sc_host].features.version_update.next_version }}"
+    desired_version_current: "{{ sc_config[sc_host].features.version_update.current_version }}"
 
   block:
     - name: Get available updates
       scale_computing.hypercore.version_update_info:
       register: updates
-    - ansible.builtin.debug:
+    - name: Show available updates
+      ansible.builtin.debug:
         var: updates
 
     - name: Test role version_update_single_node - no updates available

--- a/tests/integration/targets/version_update_info/tasks/main.yml
+++ b/tests/integration/targets/version_update_info/tasks/main.yml
@@ -10,6 +10,14 @@
       scale_computing.hypercore.version_update_info:
       register: updates
 
+    - name: Show available updates
+      ansible.builtin.debug:
+        var: updates
+
+    - name: Show expected updates
+      ansible.builtin.debug:
+        var: sc_config[sc_host].features.version_update
+
     - name: Check returned update list - updates available
       ansible.builtin.assert:
         that:


### PR DESCRIPTION
Job
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4675127388/jobs/8279938549 failed.
New SW version 9.1.24.211326 was released.