### PR TITLE
Fix version update role

### DIFF
--- a/tests/integration/targets/version_update/tasks/main.yml
+++ b/tests/integration/targets/version_update/tasks/main.yml
@@ -24,9 +24,13 @@
     - name: Get status of the latest update applied
       scale_computing.hypercore.version_update_status_info:
       register: update_status
+    # Fail early if update is in progress
     - ansible.builtin.assert:
         that:
-          - update_status.record.update_status == "COMPLETE" or update_status.record.update_status == "TERMINATING" # Fail early if update in progress
+          - >-
+            update_status.record == None or
+            update_status.record.update_status == "COMPLETE" or
+            update_status.record.update_status == "TERMINATING"
 
     - name: Update to the same hc version
       scale_computing.hypercore.version_update:
@@ -53,7 +57,9 @@
     - name: Get status of the latest update applied
       scale_computing.hypercore.version_update_status_info:
       register: update_status
-      until:  update_status.record.update_status == "EXECUTING"
+      # It takes a while (2 minutes) for update_status.json to appear.
+      # We get update_status.record=None on first invocation.
+      until:  update_status.record != None and update_status.record.update_status == "EXECUTING"
       retries: 100
       delay: 5
     - ansible.builtin.assert:

--- a/tests/integration/targets/version_update/tasks/main.yml
+++ b/tests/integration/targets/version_update/tasks/main.yml
@@ -25,10 +25,22 @@
       scale_computing.hypercore.version_update_status_info:
       register: update_status
     # Fail early if update is in progress
+    # In some cases update fails and we get record.update_status == None
+    # Example from https://172.31.6.11/update/update_status.json
+    # {
+    #    "prepareStatus": "",
+    #    "updateStatus": {
+    #        "percent": "0",
+    #        "status": {
+    #            "usernotes": "Failed to open update tunnel"
+    #        }
+    #    }
+    #}
     - ansible.builtin.assert:
         that:
           - >-
             update_status.record == None or
+            update_status.record.update_status == None or
             update_status.record.update_status == "COMPLETE" or
             update_status.record.update_status == "TERMINATING"
 
@@ -54,11 +66,12 @@
           - update.diff.before.icos_version == cluster_initial.record.icos_version
           - update.diff.after.icos_version == updates.records[0].uuid
 
-    - name: Get status of the latest update applied
+    - name: Wait on update to move into EXECUTING state
       scale_computing.hypercore.version_update_status_info:
       register: update_status
       # It takes a while (2 minutes) for update_status.json to appear.
       # We get update_status.record=None on first invocation.
+      # Should we quit waiting if update_status.record.update_status == None ? It could be transient state.
       until:  update_status.record != None and update_status.record.update_status == "EXECUTING"
       retries: 100
       delay: 5


### PR DESCRIPTION
Two corner cases fixed.

1st if cluster was never upgrade before, the `version_update_status_info` module will return `record=None`. 

2nd, after one upgrade failed (upgrade was initiated, after a while is stopped with "Failed to open update tunnel") the `version_update_status_info` module does return  `record.update_status=None`. 
 