### PR TITLE
Fix python interpreter for check_local_time.py script

### DIFF
--- a/roles/check_local_time/tasks/main.yml
+++ b/roles/check_local_time/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if local time is in time interval (run check_local_time.py)
   ansible.builtin.script:
-    executable: "{{ ansible_python_interpreter }}"
+    executable: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
     cmd: check_local_time.py "{{ time_zone }}" "{{ time_interval }}"
   register: local_time_output
 


### PR DESCRIPTION
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4686722374/jobs/8305135195#step:9:48 Here ansible_python_interpreter was not defined.

See also https://github.com/ansible/ansible/issues/21311 and https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html I missed before that ansible_python_interpreter is not always defined.

We do not want to force user to tell us some valid python interpreter. Also, it would be possible that the only availble python is in venv or in /usr/local/bin (python docker images).

ansible_playbook_python looks like a suitable fallback. It is interpreter on the controller node. Our script will always run there - we never ssh to HyperCore controller.