### PR TITLE
Cluster shutdown module exception handling update

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -134,6 +134,7 @@ class Client:
             return Response(e.code, e.read(), e.headers)
         except URLError as e:
             # TODO: Add other errors here; we need to handle them in modules.
+            # TimeoutError is handled in the rest_client
             if (
                 e.args
                 and isinstance(e.args, tuple)

--- a/plugins/module_utils/cluster.py
+++ b/plugins/module_utils/cluster.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 from time import sleep
 from ..module_utils.utils import PayloadMapper
 from ..module_utils.rest_client import RestClient
-from ..module_utils.errors import ScaleComputingError, ScaleTimeoutError
+from ..module_utils.errors import ScaleTimeoutError
 from ..module_utils.typed_classes import TypedClusterToAnsible, TypedTaskTag
 from typing import Any
 

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -105,3 +105,9 @@ class ApiResponseNotJson(ScaleComputingError):
     def __init__(self, data: Union[str, Exception]):
         self.message = f"From API expected json got {data}."
         super(ApiResponseNotJson, self).__init__(self.message)
+
+
+class ScaleTimeoutError(ScaleComputingError):
+    def __init__(self, data: Union[str, Exception]):
+        self.message = f"Request timed out: {data}."
+        super(ScaleTimeoutError, self).__init__(self.message)

--- a/plugins/module_utils/rest_client.py
+++ b/plugins/module_utils/rest_client.py
@@ -39,7 +39,7 @@ class RestClient:
         try:
             records = self.client.get(path=endpoint, timeout=timeout).json
         except TimeoutError as e:
-            raise errors.ScaleComputingError(f"Request timed out: {e}")
+            raise errors.ScaleTimeoutError(e)
         return utils.filter_results(records, query)
 
     def get_record(
@@ -78,7 +78,7 @@ class RestClient:
                 endpoint, payload, query=_query(), timeout=timeout
             ).json
         except TimeoutError as e:
-            raise errors.ScaleComputingError(f"Request timed out: {e}")
+            raise errors.ScaleTimeoutError(e)
         return response
 
     def update_record(
@@ -96,7 +96,7 @@ class RestClient:
                 endpoint, payload, query=_query(), timeout=timeout
             ).json
         except TimeoutError as e:
-            raise errors.ScaleComputingError(f"Request timed out: {e}")
+            raise errors.ScaleTimeoutError(e)
         return response
 
     def delete_record(
@@ -108,7 +108,7 @@ class RestClient:
         try:
             response: TypedTaskTag = self.client.delete(endpoint, timeout=timeout).json
         except TimeoutError as e:
-            raise errors.ScaleComputingError(f"Request timed out: {e}")
+            raise errors.ScaleTimeoutError(e)
         return response
 
     def put_record(
@@ -133,7 +133,7 @@ class RestClient:
                 headers=headers,
             ).json
         except TimeoutError as e:
-            raise errors.ScaleComputingError(f"Request timed out: {e}")
+            raise errors.ScaleTimeoutError(e)
         except (json.JSONDecodeError, json.decoder.JSONDecodeError) as e:
             raise json.JSONDecodeError(e.msg, e.doc, e.pos)
         return response
@@ -159,7 +159,7 @@ class CachedRestClient(RestClient):
             try:
                 records = self.client.get(path=endpoint, timeout=timeout).json
             except TimeoutError as e:
-                raise errors.ScaleComputingError(f"Request timed out: {e}")
+                raise errors.ScaleTimeoutError(e)
             self.cache[endpoint] = records
 
         return utils.filter_results(records, query)

--- a/tests/unit/plugins/module_utils/test_cluster.py
+++ b/tests/unit/plugins/module_utils/test_cluster.py
@@ -9,6 +9,9 @@ import pytest
 from ansible_collections.scale_computing.hypercore.plugins.module_utils.cluster import (
     Cluster,
 )
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.errors import (
+    ScaleTimeoutError,
+)
 from ansible_collections.scale_computing.hypercore.plugins.module_utils.utils import (
     MIN_PYTHON_VERSION,
 )
@@ -111,6 +114,8 @@ class TestCluster:
 
     def test_cluster_shutdown(self, rest_client):
         force_shutdown = True
+        rest_client.create_record.side_effect = ScaleTimeoutError("Timeout error")
+        rest_client.get_record.side_effect = ConnectionRefusedError
 
         Cluster.shutdown(rest_client, force_shutdown)
 
@@ -121,6 +126,9 @@ class TestCluster:
         )
 
     def test_cluster_shutdown_default_force_shutdown(self, rest_client):
+        rest_client.create_record.side_effect = ScaleTimeoutError("Timeout error")
+        rest_client.get_record.side_effect = ConnectionRefusedError
+
         Cluster.shutdown(rest_client)
 
         rest_client.create_record.assert_called_with(


### PR DESCRIPTION
Use ConnectionRefusedError in cluster shutdown instead of error description comparison

Closes #137 