### PR TITLE
Log username for support-tunnel open/close

### DIFF
--- a/plugins/module_utils/support_tunnel.py
+++ b/plugins/module_utils/support_tunnel.py
@@ -69,8 +69,15 @@ class SupportTunnel(PayloadMapper):
 
     @staticmethod
     def open_tunnel(module: AnsibleModule, client: Client) -> None:
-        client.get("/support-api/open", query={"code": module.params["code"]})
+        query = {
+            "code": module.params["code"],
+            "user": client.username,
+        }
+        client.get("/support-api/open", query=query)
 
     @staticmethod
     def close_tunnel(client: Client) -> None:
-        client.get("/support-api/close")
+        query = {
+            "user": client.username,
+        }
+        client.get("/support-api/close", query=query)

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -34,7 +34,9 @@ from ansible_collections.scale_computing.hypercore.plugins.module_utils.task_tag
 
 @pytest.fixture
 def client(mocker):
-    return mocker.Mock(spec=Client)
+    mock_client = mocker.Mock(spec=Client)
+    mock_client.username = "mock_username"
+    return mock_client
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/test_support_tunnel.py
+++ b/tests/unit/plugins/module_utils/test_support_tunnel.py
@@ -107,10 +107,14 @@ class TestSupportTunnel:
 
         SupportTunnel.open_tunnel(module, client)
 
-        client.get.assert_called_with("/support-api/open", query={"code": 4422})
+        client.get.assert_called_with(
+            "/support-api/open", query={"code": 4422, "user": "mock_username"}
+        )
 
     def test_close_tunnel(self, client):
         client.get.return_value = Response(status=200, data="")
         SupportTunnel.close_tunnel(client)
 
-        client.get.assert_called_with("/support-api/close")
+        client.get.assert_called_with(
+            "/support-api/close", query={"user": "mock_username"}
+        )


### PR DESCRIPTION
Each support tunnel open/close will include a username in the log. Printscreen:
![image](https://user-images.githubusercontent.com/587971/234192723-940d127a-5234-4c34-8ace-66475e47f7e1.png)

Fixes #205
