### PR TITLE
Shutdown tagged vms

### DIFF
--- a/examples/shutdown_restart_tagged_vms.yml
+++ b/examples/shutdown_restart_tagged_vms.yml
@@ -1,0 +1,81 @@
+---
+# Example invocation:
+# ansible-playbook -e '{"vm_shutdown_tags": ["gpu-passthrough", "usb-passthrough"]}' examples/shutdown_restart_tagged_vms.yml
+- name: Shut down and start back HyperCore VMs with specific tags
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    vm_shutdown_tags:
+      - gpu-passthrough
+      - usb-passthrough
+
+  tasks:
+    # ------------------------------------------------------
+    - name: Store initial/desired VMs state
+      scale_computing.hypercore.vm_info:
+      register: vm_desired_state
+
+    # ------------------------------------------------------
+    - name: List tagged VMs power-state before shutdown
+      block: &list-tagged-vms
+        - name: List all VMs
+          scale_computing.hypercore.vm_info:
+          register: vm_info_result
+
+        - name: Find VMs with matching tag
+          ansible.builtin.shell: |
+            #!/usr/bin/env python
+            import json
+            import sys
+            data_str = sys.stdin.read()
+            data = json.loads(data_str)
+            all_vms = data["all_vms"]
+            vm_shutdown_tags = data["vm_shutdown_tags"]
+            tagged_vms = []
+            for vm in all_vms:
+                for tag in vm["tags"]:
+                    if tag in vm_shutdown_tags:
+                        tagged_vms.append(vm)
+                        break
+            print(json.dumps(tagged_vms))
+          args:
+            # /usr/bin/python3 - fedora
+            # /usr/local/bin/python - python:3.10-slim-buster docker image
+            executable: python3
+            stdin: "{{ stdin_data | to_json }}"
+          vars:
+            stdin_data:
+              all_vms: "{{ vm_info_result.records }}"
+              vm_shutdown_tags: "{{ vm_shutdown_tags }}"
+          changed_when: false
+          register: tagged_vms_result
+
+        - name: Show tagged VMs
+          ansible.builtin.debug:
+            msg: |
+              vm_names={{ tagged_vms_result.stdout | from_json | map(attribute='vm_name') }}
+              power_state={{ tagged_vms_result.stdout | from_json | map(attribute='power_state') }}
+
+    # ------------------------------------------------------
+    - name: Shutdown running VMs with specific tags
+      ansible.builtin.include_role:
+        name: scale_computing.hypercore.version_update_single_node
+        tasks_from: shutdown_vms
+      vars:
+        scale_computing_hypercore_shutdown_vms: "{{ vm_desired_state }}"
+        scale_computing_hypercore_shutdown_tags: "{{ vm_shutdown_tags }}"
+
+    - name: List tagged VMs power-state after shutdown
+      block: *list-tagged-vms
+
+    # ------------------------------------------------------
+    - name: Start back VMs with specific tags
+      ansible.builtin.include_role:
+        name: scale_computing.hypercore.version_update_single_node
+        tasks_from: restart_vms.yml
+      vars:
+        scale_computing_hypercore_restart_vms: "{{ vm_desired_state }}"
+
+    - name: List tagged VMs power-state after restart
+      block: *list-tagged-vms

--- a/roles/version_update_single_node/defaults/main.yml
+++ b/roles/version_update_single_node/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+scale_computing_hypercore_shutdown_wait_time: 300

--- a/roles/version_update_single_node/defaults/main.yml
+++ b/roles/version_update_single_node/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 scale_computing_hypercore_shutdown_wait_time: 300
+scale_computing_hypercore_shutdown_tags: []

--- a/roles/version_update_single_node/meta/argument_specs.yml
+++ b/roles/version_update_single_node/meta/argument_specs.yml
@@ -33,6 +33,14 @@ argument_specs:
           - VM list as returned by M(scale_computing.hypercore.vm_info) module.
         required: true
         type: dict
+      scale_computing_hypercore_shutdown_tags:
+        description:
+          - VM will be shutdown only if it has assigned (at least one) tag from this list.
+          - If tag list is empty, than every running VM from the VM list is shutdown.
+        required: false
+        type: list
+        elements: str
+        default: []
 
   restart_vms:
     short_description: Start VMs that were running before upgrade

--- a/roles/version_update_single_node/meta/argument_specs.yml
+++ b/roles/version_update_single_node/meta/argument_specs.yml
@@ -13,3 +13,9 @@ argument_specs:
           - If multi-node system was detected, no update will be applied.
         required: true
         type: str
+      scale_computing_hypercore_shutdown_wait_time:
+        description:
+          - How much time (in seconds) VMs have to gracefully shutdown.
+          - After wait time expires a force shutdown is issued. Force shutdown can corrupt VM disk data.
+        default: 300
+        type: int

--- a/roles/version_update_single_node/meta/argument_specs.yml
+++ b/roles/version_update_single_node/meta/argument_specs.yml
@@ -13,9 +13,36 @@ argument_specs:
           - If multi-node system was detected, no update will be applied.
         required: true
         type: str
-      scale_computing_hypercore_shutdown_wait_time:
+      scale_computing_hypercore_shutdown_wait_time: &scale_computing_hypercore_shutdown_wait_time
         description:
           - How much time (in seconds) VMs have to gracefully shutdown.
           - After wait time expires a force shutdown is issued. Force shutdown can corrupt VM disk data.
         default: 300
         type: int
+
+  shutdown_vms:
+    short_description: Shutdown running VMs before upgrade
+    description:
+      - Taskfile shutdown_vms is used to shutdown running VMs.
+      - Input is a list of VMs, as returned by M(scale_computing.hypercore.vm_info) module.
+        The VMs listed as `running` in the list are then shutdown.
+    options:
+      scale_computing_hypercore_shutdown_wait_time: *scale_computing_hypercore_shutdown_wait_time
+      scale_computing_hypercore_shutdown_vms:
+        description:
+          - VM list as returned by M(scale_computing.hypercore.vm_info) module.
+        required: true
+        type: dict
+
+  restart_vms:
+    short_description: Start VMs that were running before upgrade
+    description:
+      - Taskfile restart_vms is used start VMs that were running before upgrade.
+      - Input is a list of VMs, as returned by M(scale_computing.hypercore.vm_info) module.
+        The VMs listed as `running` in the list are then started.
+    options:
+      scale_computing_hypercore_restart_vms:
+        description:
+          - VM list as returned by M(scale_computing.hypercore.vm_info) module.
+        required: true
+        type: dict

--- a/roles/version_update_single_node/tasks/main.yml
+++ b/roles/version_update_single_node/tasks/main.yml
@@ -56,7 +56,7 @@
     - name: Shutdown all running VMs
       include_tasks: shutdown_vms.yml
       vars:
-        vms: "{{ vm_info }}"
+        scale_computing_hypercore_shutdown_vms: "{{ vm_info }}"
       when: vms.records != []
 
     # ----------------- UPDATE --------------------
@@ -78,7 +78,7 @@
     - name: Restart previously running VMs
       include_tasks: restart_vms.yml
       vars:
-        vms: "{{ vm_info }}"
+        scale_computing_hypercore_restart_vms: "{{ vm_info }}"
       when: vms.records != []
 
     - name: Check if updating to desired version failed

--- a/roles/version_update_single_node/tasks/restart_vms.yml
+++ b/roles/version_update_single_node/tasks/restart_vms.yml
@@ -4,7 +4,7 @@
     vm_name: "{{ item.vm_name }}"
     power_state: start
   when: item.power_state == 'started'
-  loop: "{{ vms.records }}"
+  loop: "{{ scale_computing_hypercore_restart_vms.records }}"
   register: vm_start_result
 
 - name: Show restart results

--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -3,7 +3,7 @@
   ansible.builtin.debug:
     msg: "{{ item.vm_name }}"
   when: item.power_state == 'started'
-  loop: "{{ vms.records }}"
+  loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
   register: running_vms
 
 - name: Shutdown running VMs
@@ -11,7 +11,7 @@
     vm_name: "{{ item.vm_name }}"
     power_state: shutdown
   when: item.power_state == 'started'
-  loop: "{{ vms.records }}"
+  loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
   register: vm_shutdown_result
   ignore_errors: true # if VMs fail to shut down without force, error will occur, so we skip and try on to shut down with force
 

--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -17,11 +17,15 @@
   register: vm_shutdown_result
   ignore_errors: true # if VMs fail to shut down without force, error will occur, so we skip and try on to shut down with force
 
+- name: Set fact version_update_all_vms_stopped to initial false
+  ansible.builtin.set_fact:
+    version_update_all_vms_stopped: false
+
 # Wait up to 300 sec (30*10)
 - name: Wait until VMs shutdown
   include_tasks: wait_vm_shutdown.yml
   loop: "{{ range(0, (scale_computing_hypercore_shutdown_wait_time / 10.0) | round(0, 'ceil') | int) | list }}"
-  when: version_update_all_vms_stopped | default(true)
+  when: not version_update_all_vms_stopped
 
 - name: Show shutdown results
   ansible.builtin.debug:

--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -18,7 +18,7 @@
 # Wait up to 300 sec (30*10)
 - name: Wait until VMs shutdown
   include_tasks: wait_vm_shutdown.yml
-  loop: "{{ range(0, 30) | list }}"
+  loop: "{{ range(0, (scale_computing_hypercore_shutdown_wait_time / 10.0) | round(0, 'ceil') | int) | list }}"
   when: version_update_all_vms_stopped | default(true)
 
 - name: Show shutdown results

--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -10,7 +10,9 @@
   scale_computing.hypercore.vm_params:
     vm_name: "{{ item.vm_name }}"
     power_state: shutdown
-  when: item.power_state == 'started'
+  when:
+    - item.power_state == 'started'
+    - (scale_computing_hypercore_shutdown_tags == []) or (scale_computing_hypercore_shutdown_tags | intersect(item.tags))
   loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
   register: vm_shutdown_result
   ignore_errors: true # if VMs fail to shut down without force, error will occur, so we skip and try on to shut down with force
@@ -29,7 +31,9 @@
   scale_computing.hypercore.vm_params:
     vm_name: "{{ item.item.vm_name }}"
     power_state: stop
-  when: item.item.power_state == 'started'
+  when:
+    - item.item.power_state == 'started'
+    - (scale_computing_hypercore_shutdown_tags == []) or (scale_computing_hypercore_shutdown_tags | intersect(item.item.tags))
   loop: "{{ vm_shutdown_result.results }}"
   register: vm_stop_result
 

--- a/roles/version_update_single_node/tasks/wait_vm_shutdown.yml
+++ b/roles/version_update_single_node/tasks/wait_vm_shutdown.yml
@@ -25,15 +25,19 @@
     #    CRASHED="crashed",
     # Do not include 'shutdown' - it means "shutting_down"
     # States paused, blocked  - might be safe to include, might not. Do not include yet.
-    - name: Set fact version_update_all_vms_stopped
+    - name: Set fact version_update_all_vms_stopped to initial true
       ansible.builtin.set_fact:
-        version_update_all_vms_stopped: |
-          {{
-            (
-              version_update_vms.records | map(attribute='power_state') | unique) |
-              ansible.builtin.difference(['stopped', 'crashed']
-            ) == []
-          }}
+        version_update_all_vms_stopped: true
+
+    # We wait for VMs to shutdown, but only if they are included in the scale_computing_hypercore_shutdown_vms list.
+    - name: Reset version_update_all_vms_stopped if any VM is still running
+      ansible.builtin.set_fact:
+        version_update_all_vms_stopped: false
+      when:
+        - (version_update_vms.records | selectattr("vm_name", "equalto", item.vm_name) | list).0.power_state not in ['stopped', 'crashed']
+        - (scale_computing_hypercore_shutdown_tags == []) or (scale_computing_hypercore_shutdown_tags | intersect(item.tags))
+      loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
+      register: vm_shutdown_result
 
     - name: Are all VMs stopped?
       ansible.builtin.debug:

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -60,8 +60,9 @@ sc_config:
       config_url_test: https://login.microsoftonline.com/76d4c62a-a9ca-4dc2-9187-e2cc4d9abe7f/v2.0/.well-known/openid-configuration
     cluster_shutdown:
       magic_allow_string: "oh-no-no"  # use "allow-cluster-shutdown-test" to allow this integration test
-    version_update:
-      magic_allow_string: "oh-no-no"  # use "allow-version-update-test" to allow this integration test
+    # version_update:
+    #   magic_allow_string: "oh-no-no"  # use "allow-version-update-test" to allow this integration test
+    #   vm_shutdown_restart_allow_string: "oh-no-no"  # use "allow-vm-shutdown-restart-test" to test VM shutdown/restart
     syslog_server:
       host: 10.5.11.222
 
@@ -84,6 +85,9 @@ sc_config:
     smtp:
       <<: *base_smtp
       from_address: PUB5@scalecomputing.com
+    version_update:
+      magic_allow_string: "oh-no-no"
+      vm_shutdown_restart_allow_string: "oh-no-no"
     # Under features are described properties that affect expected integration test output.
     features:
       version_update:
@@ -123,6 +127,9 @@ sc_config:
     smtp:
       <<: *base_smtp
       from_address: VSNS200@scalecomputing.com
+    version_update:
+      magic_allow_string: "oh-no-no"
+      vm_shutdown_restart_allow_string: "allow-vm-shutdown-restart-test"
     syslog_server:
       host: 10.5.11.222
     features:
@@ -154,6 +161,9 @@ sc_config:
     smtp:
       <<: *base_smtp
       from_address: VSNS201@scalecomputing.com
+    version_update:
+      magic_allow_string: "oh-no-no"
+      vm_shutdown_restart_allow_string: "allow-vm-shutdown-restart-test"
     syslog_server:
       host: 10.5.11.222
     features:

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/01_shutdown_all.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/01_shutdown_all.yml
@@ -31,7 +31,7 @@
     name: scale_computing.hypercore.version_update_single_node
     tasks_from: shutdown_vms.yml
   vars:
-    vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_shutdown_vms: "{{ vm_info_a }}"
 
 # ------------------------------------------------------------------------------------------------------------------
 # after shutdown
@@ -55,7 +55,7 @@
     name: scale_computing.hypercore.version_update_single_node
     tasks_from: restart_vms.yml
   vars:
-    vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_restart_vms: "{{ vm_info_a }}"
 
 # ------------------------------------------------------------------------------------------------------------------
 # after restart

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/01_shutdown_all.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/01_shutdown_all.yml
@@ -1,0 +1,86 @@
+# version_update/shutdown_vms.yml default behaviour - shutdown all running VMs
+
+# ------------------------------------------------------------------------------------------------------------------
+# before shutdown
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state before shutdown
+  ansible.builtin.debug:
+    var: vm_info_results.results | map(attribute='records.0.power_state')
+
+- name: Check VMs were initially running
+  ansible.builtin.assert:
+    that:
+      - vm_info_results.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results.results | map(attribute="records.0.power_state") == ["started", "started", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_a
+
+- name: Shutdown all running VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: shutdown_vms.yml
+  vars:
+    vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_b
+
+- name: Show power_state after shutdown
+  ansible.builtin.debug:
+    var: vm_info_b.records | map(attribute="power_state")
+
+- name: Check all VMs are shutdown
+  ansible.builtin.assert:
+    that:
+      - vm_info_b.records | map(attribute="power_state") | difference(["stopped"]) == []
+
+# ------------------------------------------------------------------------------------------------------------------
+# do restart
+- name: Restart VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: restart_vms.yml
+  vars:
+    vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after restart
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_c
+
+- name: Show power_state after restart - all VMs
+  ansible.builtin.debug:
+    var: vm_info_c.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after restart - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs are running again
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "started", "started"]

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/02_shutdown_none.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/02_shutdown_none.yml
@@ -38,7 +38,7 @@
     name: scale_computing.hypercore.version_update_single_node
     tasks_from: shutdown_vms.yml
   vars:
-    vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_shutdown_vms: "{{ vm_info_a }}"
 
 
 # ------------------------------------------------------------------------------------------------------------------
@@ -76,7 +76,7 @@
     name: scale_computing.hypercore.version_update_single_node
     tasks_from: restart_vms.yml
   vars:
-    vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_restart_vms: "{{ vm_info_a }}"
 
 # ------------------------------------------------------------------------------------------------------------------
 # after restart

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/02_shutdown_none.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/02_shutdown_none.yml
@@ -1,0 +1,107 @@
+# version_update/shutdown_vms.yml corner case - shutdown no running VMs
+# The input VM list will contain no running VMs.
+
+# ------------------------------------------------------------------------------------------------------------------
+# before shutdown
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state before shutdown
+  ansible.builtin.debug:
+    var: vm_info_results.results | map(attribute='records.0.power_state')
+
+- name: Check VMs were initially running
+  ansible.builtin.assert:
+    that:
+      - vm_info_results.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results.results | map(attribute="records.0.power_state") == ["started", "started", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do shutdown
+- name: List all/no VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: no-such-vm-29bao3we7a
+  register: vm_info_a
+
+- name: Check no VMs were listed
+  ansible.builtin.assert:
+    that:
+      - vm_info_a.records == []
+
+- name: Shutdown no running VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: shutdown_vms.yml
+  vars:
+    vms: "{{ vm_info_a }}"
+
+
+# ------------------------------------------------------------------------------------------------------------------
+# after shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_b
+
+- name: Show power_state after shutdown
+  ansible.builtin.debug:
+    var: vm_info_b.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after shutdown - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs are still running
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "started", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do restart
+- name: Restart VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: restart_vms.yml
+  vars:
+    vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after restart
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_c
+
+- name: Show power_state after restart - all VMs
+  ansible.builtin.debug:
+    var: vm_info_c.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after restart - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs are running again
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "started", "started"]

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/03_shutdown_some.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/03_shutdown_some.yml
@@ -38,7 +38,7 @@
     name: scale_computing.hypercore.version_update_single_node
     tasks_from: shutdown_vms.yml
   vars:
-    vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_shutdown_vms: "{{ vm_info_a }}"
 
 # ------------------------------------------------------------------------------------------------------------------
 # after shutdown
@@ -62,7 +62,7 @@
     name: scale_computing.hypercore.version_update_single_node
     tasks_from: restart_vms.yml
   vars:
-    vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_restart_vms: "{{ vm_info_a }}"
 
 # ------------------------------------------------------------------------------------------------------------------
 # after restart

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/03_shutdown_some.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/03_shutdown_some.yml
@@ -1,0 +1,100 @@
+# version_update/shutdown_vms.yml - shutdown/restart a mix of running and shutdown VMs.
+# vm_name_a and vm_name_c will be running, vm_name_b will be shutoff.
+# We want to check shutoff VM is not restarted.
+
+# ------------------------------------------------------------------------------------------------------------------
+# before shutdown
+- name: Force-shutdown VM {{ vm_name_b }}
+  scale_computing.hypercore.vm_params:
+    vm_name: "{{ vm_name_b }}"
+    power_state: stop
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state before shutdown
+  ansible.builtin.debug:
+    var: vm_info_results.results | map(attribute='records.0.power_state')
+
+- name: Check VMs were initially running
+  ansible.builtin.assert:
+    that:
+      - vm_info_results.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results.results | map(attribute="records.0.power_state") == ["started", "stopped", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_a
+
+- name: Shutdown all running VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: shutdown_vms.yml
+  vars:
+    vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_b
+
+- name: Show power_state after shutdown
+  ansible.builtin.debug:
+    var: vm_info_b.records | map(attribute="power_state")
+
+- name: Check all VMs are shutdown
+  ansible.builtin.assert:
+    that:
+      - vm_info_b.records | map(attribute="power_state") | difference(["stopped"]) == []
+
+# ------------------------------------------------------------------------------------------------------------------
+# do restart
+- name: Restart VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: restart_vms.yml
+  vars:
+    vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after restart
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_c
+
+- name: Show power_state after restart - all VMs
+  ansible.builtin.debug:
+    var: vm_info_c.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after restart - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs are running again
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "stopped", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+- name: Start VM {{ vm_name_b }}
+  scale_computing.hypercore.vm_params:
+    vm_name: "{{ vm_name_b }}"
+    power_state: start

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/04_shutdown_tagged_a.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/04_shutdown_tagged_a.yml
@@ -1,0 +1,101 @@
+# Shutdown running VMs, but only if they are tagged with specific tag/tags.
+
+# ------------------------------------------------------------------------------------------------------------------
+# before shutdown
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state before shutdown
+  ansible.builtin.debug:
+    var: vm_info_results.results | map(attribute='records.0.power_state')
+
+- name: Check VMs were initially running
+  ansible.builtin.assert:
+    that:
+      - vm_info_results.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results.results | map(attribute="records.0.power_state") == ["started", "started", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_a
+
+- name: Shutdown running VMs with specific tags
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: shutdown_vms.yml
+  vars:
+    scale_computing_hypercore_shutdown_vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_shutdown_tags:
+      - ci_live_migrate__no_a
+
+# ------------------------------------------------------------------------------------------------------------------
+# after shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_b
+
+- name: Show power_state after shutdown
+  ansible.builtin.debug:
+    var: vm_info_b.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after shutdown - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs power state
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["stopped", "started", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do restart
+- name: Restart VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: restart_vms.yml
+  vars:
+    scale_computing_hypercore_restart_vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after restart
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_c
+
+- name: Show power_state after restart - all VMs
+  ansible.builtin.debug:
+    var: vm_info_c.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after restart - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs are running again
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "started", "started"]

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/04_shutdown_tagged_a.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/04_shutdown_tagged_a.yml
@@ -37,6 +37,13 @@
 
 # ------------------------------------------------------------------------------------------------------------------
 # after shutdown
+# vm_name_a has ACPI, it should shutdown nicely.
+# Check shutdown_vms.yml does not wait.
+- name: Check VM force shutdown was not needed
+  ansible.builtin.assert:
+    that:
+      - version_update_all_vms_stopped is true
+
 - name: List all VMs
   scale_computing.hypercore.vm_info:
   register: vm_info_b

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/05_shutdown_tagged_bc.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/05_shutdown_tagged_bc.yml
@@ -1,0 +1,103 @@
+# Shutdown running VMs, but only if they are tagged with specific tag/tags.
+
+# ------------------------------------------------------------------------------------------------------------------
+# before shutdown
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state before shutdown
+  ansible.builtin.debug:
+    var: vm_info_results.results | map(attribute='records.0.power_state')
+
+- name: Check VMs were initially running
+  ansible.builtin.assert:
+    that:
+      - vm_info_results.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results.results | map(attribute="records.0.power_state") == ["started", "started", "started"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_a
+
+- name: Shutdown running VMs with specific tags
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: shutdown_vms.yml
+  vars:
+    scale_computing_hypercore_shutdown_vms: "{{ vm_info_a }}"
+    scale_computing_hypercore_shutdown_tags:
+      - ci_live_migrate__no_b
+      - ci_live_migrate__yes_c
+
+
+# ------------------------------------------------------------------------------------------------------------------
+# after shutdown
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_b
+
+- name: Show power_state after shutdown
+  ansible.builtin.debug:
+    var: vm_info_b.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after shutdown - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs power state
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "stopped", "stopped"]
+
+# ------------------------------------------------------------------------------------------------------------------
+# do restart
+- name: Restart VMs
+  ansible.builtin.include_role:
+    name: scale_computing.hypercore.version_update_single_node
+    tasks_from: restart_vms.yml
+  vars:
+    scale_computing_hypercore_restart_vms: "{{ vm_info_a }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# after restart
+- name: List all VMs
+  scale_computing.hypercore.vm_info:
+  register: vm_info_c
+
+- name: Show power_state after restart - all VMs
+  ansible.builtin.debug:
+    var: vm_info_c.records | map(attribute="power_state")
+
+- name: Check current power state for test VMs
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info_results_b
+  loop: "{{ vm_names }}"
+  loop_control:
+    loop_var: vm_name
+
+- name: Show power_state after restart - test VMs
+  ansible.builtin.debug:
+    var: vm_info_results_b.results | map(attribute="records.0.power_state")
+
+- name: Check test VMs are running again
+  ansible.builtin.assert:
+    that:
+      - vm_info_results_b.results | map(attribute="records.0.vm_name") == vm_names
+      - vm_info_results_b.results | map(attribute="records.0.power_state") == ["started", "started", "started"]

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/05_shutdown_tagged_bc.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/05_shutdown_tagged_bc.yml
@@ -39,6 +39,13 @@
 
 # ------------------------------------------------------------------------------------------------------------------
 # after shutdown
+# vm_name_b does not have ACPI, it should require force-shutdown.
+# Check shutdown_vms.yml did wait.
+- name: Check VM force shutdown was needed
+  ansible.builtin.assert:
+    that:
+      - version_update_all_vms_stopped is false
+
 - name: List all VMs
   scale_computing.hypercore.vm_info:
   register: vm_info_b

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/helper_create_vms.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/helper_create_vms.yml
@@ -1,0 +1,118 @@
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+#- name: Delete the VM with name {{ vm_name_a }}
+#  scale_computing.hypercore.vm: &delete-vm-a
+#    vm_name: "{{ vm_name_a }}"
+#    state: absent
+#  register: result
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prerequisites
+# integration-test.iso must be already present, we have prepare.yml task
+- name: Get ISO {{ iso_name_with_acpi }} info
+  scale_computing.hypercore.iso_info:
+    name: "{{ iso_name_with_acpi }}"
+  register: uploaded_iso_info
+- ansible.builtin.assert:
+    that:
+      - uploaded_iso_info.records | length == 1
+
+- name: Get ISO {{ iso_name_no_acpi }} info
+  scale_computing.hypercore.iso_info:
+    name: "{{ iso_name_no_acpi }}"
+  register: uploaded_iso_info
+- ansible.builtin.assert:
+    that:
+      - uploaded_iso_info.records | length == 1
+
+# ------------------------------------------------------------------------------------------------------------------
+# Create test VMs
+- name: Create test VM a
+  scale_computing.hypercore.vm:
+    vm_name: "{{ vm_name_a }}"
+    description: "{{ vm_name_a }}"
+    state: present
+    tags:
+      - Xlab
+      - ci_live_migrate__no_a
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: false
+    power_state: start
+    disks:
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: "{{ iso_name_with_acpi }}"
+    nics:
+      - vlan: 1
+        type: virtio
+    boot_devices:
+      - type: ide_cdrom
+        disk_slot: 0
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.boot_devices | length == 1
+      - vm_created.record.0.boot_devices.0.type == "ide_cdrom"
+
+- name: Create test VM b
+  scale_computing.hypercore.vm:
+    vm_name: "{{ vm_name_b }}"
+    description: "{{ vm_name_b }}"
+    state: present
+    tags:
+      - Xlab
+      - ci_live_migrate__no_b
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: false
+    power_state: start
+    disks:
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: "{{ iso_name_no_acpi }}"
+    nics:
+      - vlan: 1
+        type: virtio
+    boot_devices:
+      - type: ide_cdrom
+        disk_slot: 0
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.boot_devices | length == 1
+      - vm_created.record.0.boot_devices.0.type == "ide_cdrom"
+
+- name: Create test VM c
+  scale_computing.hypercore.vm:
+    vm_name: "{{ vm_name_c }}"
+    description: "{{ vm_name_c }}"
+    state: present
+    tags:
+      - Xlab
+      - ci_live_migrate__yes_c
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 2
+    attach_guest_tools_iso: false
+    power_state: start
+    disks:
+      - type: ide_cdrom
+        disk_slot: 0
+        iso_name: "{{ iso_name_with_acpi }}"
+    nics:
+      - vlan: 1
+        type: virtio
+    boot_devices:
+      - type: ide_cdrom
+        disk_slot: 0
+    machine_type: BIOS
+  register: vm_created
+- ansible.builtin.assert:
+    that:
+      - vm_created.record.0.power_state == "started"
+      - vm_created.record.0.boot_devices | length == 1
+      - vm_created.record.0.boot_devices.0.type == "ide_cdrom"

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
@@ -22,6 +22,7 @@
       - "{{ vm_name_a }}"
       - "{{ vm_name_b }}"
       - "{{ vm_name_c }}"
+    scale_computing_hypercore_shutdown_wait_time: 30
 
   block:
     - name: Check vm_shutdown_restart_allow_string value

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
@@ -34,3 +34,5 @@
     - include_tasks: 01_shutdown_all.yml
     - include_tasks: 02_shutdown_none.yml
     - include_tasks: 03_shutdown_some.yml
+    - include_tasks: 04_shutdown_tagged_a.yml
+    - include_tasks: 05_shutdown_tagged_bc.yml

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# Test the role version_update, tasks shutdown_vms.yml and restart_vms.yml
+# VM tags:
+#   ci_live_migrate__no_a - has ACPI shutdown
+#   ci_live_migrate__no_b - no ACPI shutdown
+#   ci_live_migrate__yes_c - has ACPI shutdown
+# Test VMs are not removed. They are left present, hopefully this will speedup testing.
+
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+  vars:
+    # cluster_update_config: "{{ sc_config[sc_host].version_update }}"
+    iso_name_with_acpi: "Porteus-XFCE-v5.0-x86_64.iso"
+    iso_name_no_acpi: "integration-test.iso"
+    vm_name_a: "ci-version-update-shutdown-a"
+    vm_name_b: "ci-version-update-shutdown-b"
+    vm_name_c: "ci-version-update-shutdown-c"
+    vm_names:
+      - "{{ vm_name_a }}"
+      - "{{ vm_name_b }}"
+      - "{{ vm_name_c }}"
+
+  block:
+    - name: Check vm_shutdown_restart_allow_string value
+      ansible.builtin.assert:
+        that:
+          - sc_config[sc_host].version_update.vm_shutdown_restart_allow_string == "allow-vm-shutdown-restart-test"
+
+    - include_tasks: helper_create_vms.yml
+    - include_tasks: 01_shutdown_all.yml
+    - include_tasks: 02_shutdown_none.yml
+    - include_tasks: 03_shutdown_some.yml

--- a/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
+++ b/tests/integration/targets/version_update__shutdown_restart_vms/tasks/main.yml
@@ -35,4 +35,8 @@
     - include_tasks: 02_shutdown_none.yml
     - include_tasks: 03_shutdown_some.yml
     - include_tasks: 04_shutdown_tagged_a.yml
+      vars:
+        # Porteus VM needs about 20 sec to shut down.
+        # Use longer wait time, we want to check VM did shut down, without exceeding the wait time.
+        scale_computing_hypercore_shutdown_wait_time: 300
     - include_tasks: 05_shutdown_tagged_bc.yml


### PR DESCRIPTION
We already had a role with taskfile `shutdown_vms` to shutdown all VMs. This is used to shutdown all VMs in a single node cluster before version upgrade, and to start them back after upgrade.

The PR extended `shutdown_vms` with option to shutdown only some VMs. VM tag is used to decide if VM needs to be shutdown. This will be used during multinode cluster version upgrade to shutdown VMs than should not be live-migrated to another node. See also #198.

Integration test in https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/4799944517