### PR TITLE
Fix update status check

### DIFF
--- a/roles/version_update_single_node/tasks/update_status_check.yml
+++ b/roles/version_update_single_node/tasks/update_status_check.yml
@@ -5,12 +5,6 @@
       ansible.builtin.set_fact:
         retry_count: "{{ 0 if retry_count is undefined else retry_count | int + 1 }}"
 
-    # We might be able to remove this task
-    - name: Pause before checking update status - checks will report FAILED-RETRYING until update COMPLETE/TERMINATED
-      ansible.builtin.wait_for:
-        timeout: 60
-      delegate_to: localhost
-
     - name: Check update status - will report FAILED-RETRYING until update COMPLETE/TERMINATED
       scale_computing.hypercore.version_update_status_info:
       register: update_status

--- a/roles/version_update_single_node/tasks/update_status_check.yml
+++ b/roles/version_update_single_node/tasks/update_status_check.yml
@@ -14,7 +14,12 @@
     - name: Check update status - will report FAILED-RETRYING until update COMPLETE/TERMINATED
       scale_computing.hypercore.version_update_status_info:
       register: update_status
-      until: update_status.record.update_status == "COMPLETE" | default(omit) or update_status.record.update_status == "TERMINATING" | default(omit)
+      until: >-
+        update_status.record != None and
+        (
+          update_status.record.update_status == "COMPLETE" or
+          update_status.record.update_status == "TERMINATING"
+        )
       retries: 100
       delay: 30
       ignore_unreachable: true


### PR DESCRIPTION
We had a race condition. Sometimes a magic 60 sec delay was not enough to get update/update_status.json API endpoint work. The version_update_status_info now (it didn't initially) returns None in this case, so we can use that.