### PR TITLE
Cleanup unneeded condition

### DIFF
--- a/roles/version_update_single_node/tasks/main.yml
+++ b/roles/version_update_single_node/tasks/main.yml
@@ -89,5 +89,4 @@
     - cluster_info.record.icos_version != scale_computing_hypercore_desired_version
     - >-
       update_status_before_update.record == None or
-      update_status_before_update.record.update_status == "COMPLETED" or
       update_status_before_update.record.update_status != "IN PROGRESS"


### PR DESCRIPTION
The version_update_status_info uses undocumented API endpoint, it is hard to know what is returned. I believe we wanted to have `==COMPLETE`, not `==COMPLETED`.

I believe whole condition is there only to prevent starting second upgrade before the first one is finished -
`.update_status != "IN PROGRESS"` is sufficient.

A corner case would be if `.update_status == SOME_ERROR` or similar. In this case `!= "IN PROGRESS"` would still allow starting an upgrade. The `==COMPLETE` is again not needed - better to remove it, it just adds to confusion.