### PR TITLE
Fix version_update_single_node to send shutdown request multiple times.

### DIFF
--- a/roles/version_update_single_node/tasks/main.yml
+++ b/roles/version_update_single_node/tasks/main.yml
@@ -57,6 +57,7 @@
       include_tasks: shutdown_vms.yml
       vars:
         scale_computing_hypercore_shutdown_vms: "{{ vm_info }}"
+      loop: "{{ range(0, (scale_computing_hypercore_shutdown_wait_time / 10.0) | round(0, 'ceil') | int) | list }}"
       when: vms.records != []
 
     # ----------------- UPDATE --------------------

--- a/roles/version_update_single_node/tasks/main.yml
+++ b/roles/version_update_single_node/tasks/main.yml
@@ -57,8 +57,7 @@
       include_tasks: shutdown_vms.yml
       vars:
         scale_computing_hypercore_shutdown_vms: "{{ vm_info }}"
-      loop: "{{ range(0, (scale_computing_hypercore_shutdown_wait_time / 10.0) | round(0, 'ceil') | int) | list }}"
-      when: vms.records != []
+      when: scale_computing_hypercore_shutdown_vms.records != []
 
     # ----------------- UPDATE --------------------
 
@@ -80,7 +79,7 @@
       include_tasks: restart_vms.yml
       vars:
         scale_computing_hypercore_restart_vms: "{{ vm_info }}"
-      when: vms.records != []
+      when: scale_computing_hypercore_restart_vms.records != []
 
     - name: Check if updating to desired version failed
       ansible.builtin.fail:

--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -6,17 +6,6 @@
   loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
   register: running_vms
 
-- name: Shutdown running VMs
-  scale_computing.hypercore.vm_params:
-    vm_name: "{{ item.vm_name }}"
-    power_state: shutdown
-  when:
-    - item.power_state == 'started'
-    - (scale_computing_hypercore_shutdown_tags == []) or (scale_computing_hypercore_shutdown_tags | intersect(item.tags))
-  loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
-  register: vm_shutdown_result
-  ignore_errors: true # if VMs fail to shut down without force, error will occur, so we skip and try on to shut down with force
-
 - name: Set fact version_update_all_vms_stopped to initial false
   ansible.builtin.set_fact:
     version_update_all_vms_stopped: false
@@ -26,10 +15,6 @@
   include_tasks: wait_vm_shutdown.yml
   loop: "{{ range(0, (scale_computing_hypercore_shutdown_wait_time / 10.0) | round(0, 'ceil') | int) | list }}"
   when: not version_update_all_vms_stopped
-
-- name: Show shutdown results
-  ansible.builtin.debug:
-    var: vm_shutdown_result
 
 - name: Force shutdown the remaining running VMs
   scale_computing.hypercore.vm_params:

--- a/roles/version_update_single_node/tasks/wait_vm_shutdown.yml
+++ b/roles/version_update_single_node/tasks/wait_vm_shutdown.yml
@@ -1,6 +1,23 @@
 ---
 - name: Wait on VMs to shutdown
   block:
+    - name: Shutdown running VMs
+      scale_computing.hypercore.vm_params:
+        vm_name: "{{ single_vm.vm_name }}"
+        power_state: shutdown
+      when:
+        - single_vm.power_state == 'started'
+        - (scale_computing_hypercore_shutdown_tags == []) or (scale_computing_hypercore_shutdown_tags | intersect(single_vm.tags))
+      loop: "{{ scale_computing_hypercore_shutdown_vms.records }}"
+      loop_control:
+        loop_var: single_vm
+      register: vm_shutdown_result
+      ignore_errors: true # if VMs fail to shut down without force, error will occur, so we skip and try on to shut down with force
+
+    - name: Show shutdown results
+      ansible.builtin.debug:
+        var: vm_shutdown_result
+
     - name: Get all available running VMs
       scale_computing.hypercore.vm_info:
       register: version_update_vms

--- a/tests/integration/targets/role_version_update_single_node/tasks/main.yml
+++ b/tests/integration/targets/role_version_update_single_node/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - environment:
     SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_username_50 }}"
-    SC_PASSWORD: "{{ sc_password_50 }}"
+    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
     SC_TIMEOUT: "{{ sc_timeout }}"
 
   vars:

--- a/tests/integration/targets/role_version_update_single_node/tasks/main.yml
+++ b/tests/integration/targets/role_version_update_single_node/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - environment:
     SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_USERNAME: "{{ sc_username_50 }}"
+    SC_PASSWORD: "{{ sc_password_50 }}"
     SC_TIMEOUT: "{{ sc_timeout }}"
 
   vars:


### PR DESCRIPTION
Some VMs didn't want to receive a shutdown request, so ``version_update_single_node`` was updated so that the shutdown request is sent multiple times - in a loop.