### PR TITLE
Add README.md to roles directory

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -1,0 +1,8 @@
+# Roles
+
+Some features are implemented a Ansible roles.
+Please check README.md in subdirectory of each individual role.
+
+Complete [roles list](https://scalecomputing.github.io/HyperCoreAnsibleCollection/collections/index_role.html)
+in latest released Ansible Collection for Scale Computing HyperCore
+is also available.


### PR DESCRIPTION
import to automatin hub for v1.2.0 reported warning Could not get role description, no role metadata found

Per https://github.com/kubernetes-sigs/kubespray/issues/9048#issuecomment-1221334912 adding roles/README.md should help.

Please do not merge the PR. I prefer rebase, I might need to cherry-pick this PR/commit for v1.2.x.