### PR TITLE
Add README.md to version_update_single_node role

### DIFF
--- a/roles/version_update_single_node/README.md
+++ b/roles/version_update_single_node/README.md
@@ -1,0 +1,32 @@
+# cluster_config
+
+Role version_update_single_node can be used to:
+- update version on Scale Computing HyperCore cluster ([main.yml](tasks/main.yml)).
+- shutdown all running VMs or only a running VMs with specific tag/tags ([shutdown_vms.yml](tasks/shutdown_vms.yml) ).
+- start previously running VMs ([restart_vms.yml](tasks/restart_vms.yml)).
+
+## Requirements
+
+- Role can be used on a single node cluster only.
+
+## Role Variables
+
+See [argument_specs.yml](../../roles/version_update_single_node/meta/argument_specs.yml).
+
+## Limitations
+
+- NA
+
+## Dependencies
+
+- NA
+
+## Example Playbook
+
+See [version_update_single_node.yml](../../examples/version_update_single_node.yml).
+
+## License
+
+GNU General Public License v3.0 or later
+
+See [LICENSE](../../LICENSE) to see the full text.

--- a/roles/version_update_single_node/meta/argument_specs.yml
+++ b/roles/version_update_single_node/meta/argument_specs.yml
@@ -4,6 +4,10 @@ argument_specs:
     short_description: Update single-node systems
     description:
       - Role version_update_single_node can be use to to update a single-node HyperCore system to a desired HyperCore version.
+      - Role performs following steps during version update -
+          shutdown all running VMs,
+          upgrade cluster,
+          start back VMs that were running before upgrade.
     options:
       scale_computing_hypercore_desired_version:
         description:


### PR DESCRIPTION
The role  version_update_single_node was missing a Readme.md file. PR does add it, and also shortly describes steps performed by the role.