### PR TITLE
Create config.yml - ignore Python sanity tests for unsupported Python

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+  python_requires: '>=3.8'


### PR DESCRIPTION
Ignore unsupported Python sanity tests (compile-2.7, compile-3.5, compile-3.6) by using the tests/config.yml file. 

By specifying `python_requires: '>=3.8'`, the `ansible-test sanity` tests will skip python-specific tests for any lower version than 3.8. 

This will create a clean import log in Automation Hub for the next certified release (assuming no other errors). 