### PR TITLE
Inventory - sc_timeout changed to int

### DIFF
--- a/changelogs/fragments/hypercore_inventory_bugfix.yml
+++ b/changelogs/fragments/hypercore_inventory_bugfix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - This fix now converts value read from SC_TIMEOUT to int, thus resolving inventory parse error when SC_TIMEOUT was defined. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/231)

--- a/changelogs/fragments/hypercore_inventory_bugfix.yml
+++ b/changelogs/fragments/hypercore_inventory_bugfix.yml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
-  - This fix now converts value read from SC_TIMEOUT to int, thus resolving inventory parse error when SC_TIMEOUT was defined. (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/231)
+  - Convert SC_TIMEOUT environ variable to float, thus resolving inventory parse error when SC_TIMEOUT was defined.
+    (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/231)

--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -218,19 +218,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path)
         cfg = self.read_config_data(path, os.environ)
 
-        # Try getting variables from env
-        try:
-            host = os.getenv("SC_HOST")
-            username = os.getenv("SC_USERNAME")
-            password = os.getenv("SC_PASSWORD")
-            timeout = os.getenv("SC_TIMEOUT")
-        except KeyError:
+        # get variables from env
+        host = os.getenv("SC_HOST")
+        username = os.getenv("SC_USERNAME")
+        password = os.getenv("SC_PASSWORD")
+        timeout = os.getenv("SC_TIMEOUT")
+        if timeout:
+            timeout = int(timeout)
+        if host is None or username is None or password is None:
             raise errors.ScaleComputingError(
-                "Missing parameters: sc_host, sc_username, sc_password."
+                "Missing one or more parameters: sc_host, sc_username, sc_password."
             )
         client = Client(host, username, password, timeout)
         rest_client = RestClient(client)
-
         vms = rest_client.list_records("/rest/v1/VirDomain")
 
         for vm in vms:

--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -224,7 +224,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         password = os.getenv("SC_PASSWORD")
         timeout = os.getenv("SC_TIMEOUT")
         if timeout:
-            timeout = int(timeout)
+            try:
+                timeout = float(timeout)
+            except ValueError:  # "could not convert string to float"
+                raise errors.ScaleComputingError(
+                    f'Environ variable "SC_TIMEOUT" has invalid value {timeout}. The value cannot be converted to number'
+                )
         if host is None or username is None or password is None:
             raise errors.ScaleComputingError(
                 "Missing one or more parameters: sc_host, sc_username, sc_password."

--- a/tests/integration/targets/inventory/cleanup.yml
+++ b/tests/integration/targets/inventory/cleanup.yml
@@ -2,10 +2,6 @@
 - name: Cleanup test environment
   hosts: localhost
   gather_facts: False
-  environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
 
   tasks:
     - name: List all VMs
@@ -26,7 +22,7 @@
       ansible.builtin.set_fact:
         vms_to_remove: "{{ vms_to_remove + [vm] }}"
 
-    - name: Show vms_to_remove
+    - name: Show VMs to remove
       loop: "{{ vms_to_remove }}"
       loop_control:
         loop_var: vm

--- a/tests/integration/targets/inventory/prepare.yml
+++ b/tests/integration/targets/inventory/prepare.yml
@@ -3,10 +3,6 @@
 - name: Prepare test environment
   hosts: localhost
   gather_facts: False
-  environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
 
   vars:
     vm_data_doms:
@@ -48,7 +44,7 @@
 
   tasks:
     # ===============================================================================
-    - name: Create VM {{ vm_data_dom.name }}
+    - name: Create VMs
       loop: "{{ vm_data_doms }}"
       loop_control:
         loop_var: vm_data_dom

--- a/tests/integration/targets/inventory/run_ansible_both_false_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_both_false_tests.yml
@@ -6,6 +6,7 @@
     SC_HOST: "{{ sc_host }}"
     SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
     SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_both_false_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_both_false_tests.yml
@@ -2,11 +2,6 @@
 - name: Run HyperCore inventory tests
   hosts: localhost
   gather_facts: False
-  environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
-    SC_TIMEOUT: "{{ sc_timeout }}"
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_both_true_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_both_true_tests.yml
@@ -6,6 +6,7 @@
     SC_HOST: "{{ sc_host }}"
     SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
     SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_both_true_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_both_true_tests.yml
@@ -2,11 +2,6 @@
 - name: Run HyperCore inventory tests
   hosts: localhost
   gather_facts: False
-  environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
-    SC_TIMEOUT: "{{ sc_timeout }}"
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_disable_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_disable_tests.yml
@@ -6,6 +6,7 @@
     SC_HOST: "{{ sc_host }}"
     SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
     SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_disable_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_disable_tests.yml
@@ -2,11 +2,6 @@
 - name: Run HyperCore inventory tests
   hosts: localhost
   gather_facts: False
-  environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
-    SC_TIMEOUT: "{{ sc_timeout }}"
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_enable_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_enable_tests.yml
@@ -2,12 +2,6 @@
 - name: Run HyperCore inventory ansible_enable tests
   hosts: localhost
   gather_facts: False
-  environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
-    SC_TIMEOUT: "{{ sc_timeout }}"
-    
 
   tasks:
     - block:

--- a/tests/integration/targets/inventory/run_ansible_enable_tests.yml
+++ b/tests/integration/targets/inventory/run_ansible_enable_tests.yml
@@ -6,6 +6,7 @@
     SC_HOST: "{{ sc_host }}"
     SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
     SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
     
 
   tasks:

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -10,6 +10,7 @@ sc_host=data["sc_host"]
 print("export SC_HOST='{}'".format(sc_host))
 print("export SC_USERNAME='{}'".format(data["sc_config"][sc_host]["sc_username"]))
 print("export SC_PASSWORD='{}'".format(data["sc_config"][sc_host]["sc_password"]))
+print("export SC_TIMEOUT='{}'".format(sc_timeout))
 EOF
 )"
 

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -7,10 +7,11 @@ import yaml
 with open("$vars_file") as fd:
     data = yaml.safe_load(fd)
 sc_host=data["sc_host"]
+sc_timeout=data["sc_timeout"]
 print("export SC_HOST='{}'".format(sc_host))
+print("export SC_TIMEOUT='{}'".format(sc_timeout))
 print("export SC_USERNAME='{}'".format(data["sc_config"][sc_host]["sc_username"]))
 print("export SC_PASSWORD='{}'".format(data["sc_config"][sc_host]["sc_password"]))
-print("export SC_TIMEOUT='{}'".format(sc_timeout))
 EOF
 )"
 

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -38,12 +38,15 @@ function cleanup {
 trap 'cleanup "$@"' EXIT
 
 
-ansible-playbook -e "@$vars_file" cleanup.yml
-ansible-playbook -e "@$vars_file" prepare.yml
+ansible-playbook cleanup.yml
+ansible-playbook prepare.yml
 
-ansible-playbook -i localhost, -i hypercore_inventory_ansible_enable.yml -e "@$vars_file" run_ansible_enable_tests.yml
-ansible-playbook -i localhost, -i hypercore_inventory_ansible_disable.yml -e "@$vars_file" run_ansible_disable_tests.yml
-ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_true.yml -e "@$vars_file" run_ansible_both_true_tests.yml
-ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml -e "@$vars_file" run_ansible_both_false_tests.yml
+ansible-playbook -i localhost, -i hypercore_inventory_ansible_enable.yml run_ansible_enable_tests.yml
+ansible-playbook -i localhost, -i hypercore_inventory_ansible_disable.yml run_ansible_disable_tests.yml
+ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_true.yml run_ansible_both_true_tests.yml
 
-ansible-playbook -e "@$vars_file" cleanup.yml
+unset SC_TIMEOUT  # do one test without SC_TIMEOUT
+
+ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml run_ansible_both_false_tests.yml
+
+ansible-playbook cleanup.yml


### PR DESCRIPTION
When reading timeout from env variable SC_TIMEOUT (which is string) it needs to be changed to int to avoid inventory parse error (specifically error in "/usr/lib/python3.10/socket.py", line 830, in create_connection sock.settimeout(timeout)). 
Also try-except was removed since KeyError is not raised in case if env variable doesn't exist.