### PR TITLE
Fix cloud-init meta-data/user-data content being mixed

### DIFF
--- a/docs/rst/extra/quickstart.rst
+++ b/docs/rst/extra/quickstart.rst
@@ -329,12 +329,9 @@ This guide will now demonstrate how to create a Playbook that will create a VM o
           - type: nic
             nic_vlan: 0
         cloud_init:
-          user_data: |
-            #cloud-config
-            valid:
-            - yaml: 1
-            - expression: 2
-          meta_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+          user_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+          meta_data: |
+            # Content for cloud-init meta-data (or user-data) can be inline too.
     register: result
 
 8. After copying and pasting the task into your editor of choice you only need to make a few changes to run the Playbook.
@@ -349,12 +346,9 @@ b. Second, delete the following section entirely:
 .. code-block:: yaml
 
    cloud_init:
-     user_data:
-       #cloud-config
-	  valid:
-      - yaml: 1
-      - expression: 2
-    meta_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+     user_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+     meta_data: |
+       # Content for cloud-init meta-data (or user-data) can be inline too.
 
 c. This portion of the task facilitates passing configuration information to a cloud image for automatic in-guest customization via cloud-init, which is out of the scope of this guide. 
 

--- a/examples/cloud-init-user-data-example.yml
+++ b/examples/cloud-init-user-data-example.yml
@@ -1,9 +1,12 @@
 #cloud-config
+# NOTE: The cloud-init user-data MUST begin with be "#cloud-config" string!
+#
 # Tested with Ubuntu 20.04.4 LTS server ISO image
 # https://releases.ubuntu.com/20.04.4/ubuntu-20.04.4-live-server-amd64.iso
-# cp cloud-init-user-data.ubuntu-2004.yml /tmp/user-data
-# echo -n '' > /tmp/meta-data
-# sudo cloud-localds /var/lib/libvirt/boot/cloud-init-min.iso /tmp/user-data /tmp/meta-data
+# To manually test cloud-init ISO image, create one with commands:
+#   cp cloud-init-user-data-example.yml /tmp/user-data
+#   echo -n '' > /tmp/meta-data
+#   sudo cloud-localds /var/lib/libvirt/boot/cloud-init-min.iso /tmp/user-data /tmp/meta-data
 autoinstall:
     version: 1
     locale: en_US

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -263,12 +263,9 @@ EXAMPLES = r"""
       - type: nic
         nic_vlan: 0
     cloud_init:
-      user_data: |
-        #cloud-config
-        valid:
-        - yaml: 1
-        - expression: 2
-      meta_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+      user_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+      meta_data: |
+        # Content for cloud-init meta-data (or user-data) can be inline too.
   register: result
 
 - name: Delete the VM

--- a/plugins/modules/vm_clone.py
+++ b/plugins/modules/vm_clone.py
@@ -66,10 +66,7 @@ EXAMPLES = r"""
     cloud_init:
       user_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
       meta_data: |
-        #cloud-config
-        valid:
-          yaml: 3
-          expression: 4
+        # Content for cloud-init meta-data (or user-data) can be inline too.
     tags:
       - test
       - tag

--- a/plugins/modules/vm_import.py
+++ b/plugins/modules/vm_import.py
@@ -99,12 +99,9 @@ EXAMPLES = r"""
       password: pass
       file_name: my_file.xml
     cloud_init:
-      user_data: |
-        #cloud-config
-        valid:
-        - yaml: 1
-        - expression: 2
-      meta_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+      user_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+      meta_data: |
+        # Content for cloud-init meta-data (or user-data) can be inline too.
   register: output
 
 - name: import VM from URI
@@ -122,12 +119,9 @@ EXAMPLES = r"""
       path: 'http://some-address-where-file-is-located'
       file_name: actual_file_name.xml
     cloud_init:
-      user_data: |
-        #cloud-config
-        valid:
-        - yaml: 1
-        - expression: 2
-      meta_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+      user_data: "{{ lookup('file', 'cloud-init-user-data-example.yml') }}"
+      meta_data: |
+        # Content for cloud-init meta-data (or user-data) can be inline too.
   register: output
 """
 


### PR DESCRIPTION
A number of examples were including user-data content into meta-data section, and user-data section containing a bogus meta-data content.

Change this, examples should be close to valid and runnuble example.

Also add extra note to user-data example file that the file must begin with magic comment. This is always very easy to miss.