### PR TITLE
Add shutdown destination VM functionallity before attaching a disk from a source snapshot.

### DIFF
--- a/plugins/module_utils/vm_snapshot.py
+++ b/plugins/module_utils/vm_snapshot.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 
 from copy import copy
 
-from ansible.module_utils.basic import AnsibleModule
 from .rest_client import RestClient
 
 from ..module_utils.utils import PayloadMapper
@@ -372,38 +371,3 @@ class VMSnapshot(PayloadMapper):
             return None
 
         return vm_hypercore_dict["uuid"]
-
-    @classmethod
-    # This method is meant to be called before the attaching was done on a destination VM
-    #   - first get vm object before attaching was done
-    #   - then try to normally shut down the vm
-    #       - if this fails, then force shut down the vm
-    def power_off_vm(cls, module: AnsibleModule, rest_client: RestClient) -> None:
-        vm = VM.get_by_name(module.params, rest_client, must_exist=True)
-
-        # Make sure we don't try to shut down an already non-running VM
-        if vm.power_state not in ('stopped', 'crashed'):
-            if not module.params["force_reboot"]:  # force_reboot == False
-                # First try a normal shutdown
-                try:
-                    module.params["force_reboot"] = False  # must be "False" to be able to normally shut down
-                    vm.do_shutdown_steps(module, rest_client)
-
-                # If normal shutdown failed, then try a force shutdown
-                except errors.ScaleComputingError as normal_shutdown_error:
-                    module.params["force_reboot"] = True  # must be "True" to be able to forcibly shut down
-                    vm.vm_shutdown_forced(module, rest_client)
-                    module.params["force_reboot"] = False  # set it back to what it was initially
-            else:
-                vm.vm_shutdown_forced(module, rest_client)
-
-    @classmethod
-    # This method is meant to be called after the attaching was done on a destination VM
-    #   - first get vm object after attaching was done
-    #   - then start that vm
-    def power_up_vm(cls, module: AnsibleModule, rest_client: RestClient) -> None:
-        # If a VM is stopped or crashed, then start it up
-        if module.params["reboot_destination_vm"]:
-            vm = VM.get_by_name(module.params, rest_client, must_exist=True)
-            if vm.power_state in ('stopped', 'crashed'):
-                vm.update_vm_power_state(module, rest_client, "start")

--- a/plugins/modules/vm_snapshot_attach_disk.py
+++ b/plugins/modules/vm_snapshot_attach_disk.py
@@ -39,6 +39,8 @@ options:
     type: int
     description:
       - Specify a disk slot from a vm to identify destination disk.
+      - Note that this MUST be a next free slot or an already used slot for the given disk_type.
+        Otherwise VM might not boot.
     required: True
   source_snapshot_uuid:
     type: str

--- a/plugins/modules/vm_snapshot_attach_disk.py
+++ b/plugins/modules/vm_snapshot_attach_disk.py
@@ -114,9 +114,6 @@ from ..module_utils.typed_classes import TypedDiff
 from typing import Tuple, Dict, Any, Optional
 
 
-# ++++++++++++
-# Must be reviewed - not sure if that's how this should work
-# ++++++++++++
 def attach_disk(
     module: AnsibleModule, rest_client: RestClient
 ) -> Tuple[bool, Optional[Dict[Any, Any]], TypedDiff]:

--- a/plugins/modules/vm_snapshot_attach_disk.py
+++ b/plugins/modules/vm_snapshot_attach_disk.py
@@ -59,6 +59,7 @@ options:
     required: True
 notes:
   - C(check_mode) is not supported
+  - The VM will be rebooted if it is running.
 """
 
 

--- a/plugins/modules/vm_snapshot_attach_disk.py
+++ b/plugins/modules/vm_snapshot_attach_disk.py
@@ -57,7 +57,6 @@ options:
     required: True
 notes:
   - C(check_mode) is not supported
-  - The VM to which the user is trying to attach the snapshot disk, B(must not) be running.
 """
 
 

--- a/tests/integration/targets/vm_snapshot/tasks/01_vm_snapshot_info.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/01_vm_snapshot_info.yml
@@ -20,12 +20,6 @@
         - snap-2
         - not-unique
   block:
-    - include_tasks: helper_api_vm_snapshot_create.yml
-      vars:
-        vms_number: "{{ test_vms_number }}"
-
-    # --------------------------------------------------------
-
     - name: List all VM snapshots - API
       scale_computing.hypercore.api:
         action: get
@@ -185,10 +179,3 @@
     - ansible.builtin.debug:
         var: vm_snapshots.records
     - ansible.builtin.assert: *assert-nonexistent
-
-# ------------- Cleanup --------------
-
-    - name: Remove all created VMs for this test
-      include_tasks: helper_api_vm_snapshot_delete_all.yml
-      vars:
-        vms_number: "{{ number_of_snapshot_testing_vms }}"

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -16,11 +16,30 @@
 
   block:
     - name: Create a stopped VM "{{ vm_2 }}"
-      include_tasks: helper_api_vm_snapshot_create.yml
-      vars:
-        vms_number: 1
-        label: "{{ vm_2_label }}"
-        vm_init_state: stop
+      scale_computing.hypercore.vm:
+        vm_name: "{{ vm_2 }}"
+        description: Snapshot testing
+        state: present
+        tags:
+          - Xlab_snapshot_testing
+        memory: "{{ '512 MB' | human_to_bytes }}"
+        vcpu: 2
+        attach_guest_tools_iso: false
+        power_state: stop
+        disks:
+          - type: virtio_disk
+            disk_slot: 0
+            size: "{{ '10.1 GB' | human_to_bytes }}"
+          - type: virtio_disk
+            disk_slot: 1
+            size: "{{ '10.2 GB' | human_to_bytes }}"
+        nics: []
+        boot_devices:
+          - type: virtio_disk
+            disk_slot: 0
+          - type: ide_cdrom
+            disk_slot: 0
+        machine_type: BIOS
 
     # --------------------------------------------------------
 

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -7,8 +7,9 @@
     vm_2_label: "-attach"
     vm_2: "snapshot-test-vm-1{{ vm_2_label }}"
 
-    slot_a: 42
-    slot_b: 0
+    # We must use next free slot on bus if we want VM to be bootable!
+    slot_a: 3  # virtio_disk
+    slot_b: 0  # ide_disk
 
     force_reboot: true  # allow forced vm shutdown
 

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -1,8 +1,4 @@
 ---
-# ==============================
-# The VM to which we are trying to attach the
-# snapshot disk to MUST NOT be running!
-# ==============================
 - name: Test vm_snapshot_attach_disk
 
   vars:

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -11,7 +11,7 @@
     vm_1: snapshot-test-vm-1
     vm_2: snapshot-test-vm-3
     slot_a: 42
-    slot_b: 43
+    slot_b: 0
 
   block:
     - include_tasks: helper_api_vm_snapshot_create.yml

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -8,8 +8,9 @@
     vm_2: "snapshot-test-vm-1{{ vm_2_label }}"
 
     # We must use next free slot on bus if we want VM to be bootable!
-    slot_a: 3  # virtio_disk
-    slot_b: 0  # ide_disk
+    slot_vm_1_virtio: 2
+    slot_a: 3  # vm_2, virtio_disk
+    slot_b: 0  # vm_2, ide_disk
 
     force_reboot: true  # allow forced vm shutdown
 
@@ -171,7 +172,7 @@
       scale_computing.hypercore.vm_snapshot_attach_disk:
         vm_name: "{{ vm_1 }}"
         vm_disk_type: virtio_disk
-        vm_disk_slot: "{{ slot_a }}"
+        vm_disk_slot: "{{ slot_vm_1_virtio }}"
         source_snapshot_uuid:
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
@@ -190,7 +191,7 @@
     - ansible.builtin.assert: &test-virtio-2
         that:
           - result.record.type == "virtio_disk"
-          - result.record.disk_slot == slot_a
+          - result.record.disk_slot == slot_vm_1_virtio
           - result.record.vm_uuid == vm_1_info.records[0].uuid
 
     - name: >-
@@ -199,7 +200,7 @@
       scale_computing.hypercore.vm_snapshot_attach_disk:
         vm_name: "{{ vm_1 }}"
         vm_disk_type: virtio_disk
-        vm_disk_slot: "{{ slot_a }}"
+        vm_disk_slot: "{{ slot_vm_1_virtio }}"
         source_snapshot_uuid:
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -119,6 +119,7 @@
         source_disk_type: virtio_disk
         source_disk_slot: 1
         force_reboot: "{{ force_reboot }}"
+        shutdown_timeout: 10  # For faster testing. VM has no OS, so it cannot react to ACPI shutdown.
       register: result
     - ansible.builtin.debug:
         var: result

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -161,6 +161,9 @@
     - ansible.builtin.assert: *test-not-virtio
 
     # ++++++++++++ Test attach snapshot disk from a VM to itself +++++++++++++
+    # This does change vm_1 (snapshot-test-vm-1), because of this whole 03_vm_snapshot_attach_disk.yml
+    # requires snapshot-test-vm-1 to be deleted and recreated each time.
+    # Refactor test if you do not like this.
 
     - name: >-
         Attach "snap-0" from VM "{{ vm_1 }}"

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -6,17 +6,23 @@
 - name: Test vm_snapshot_attach_disk
 
   vars:
-    vm_1_snapshot_label_0: ana-snap
     vm_1_snapshot_label: snap-0
     vm_1: snapshot-test-vm-1
-    vm_2: snapshot-test-vm-3
+    vm_2_label: "-attach"
+    vm_2: "snapshot-test-vm-1{{ vm_2_label }}"
+
     slot_a: 42
     slot_b: 0
 
+    force_reboot: true  # allow forced vm shutdown
+
   block:
-    - include_tasks: helper_api_vm_snapshot_create.yml
+    - name: Create a stopped VM "{{ vm_2 }}"
+      include_tasks: helper_api_vm_snapshot_create.yml
       vars:
-        vms_number: "{{ test_vms_number }}"
+        vms_number: 1
+        label: "{{ vm_2_label }}"
+        vm_init_state: stop
 
     # --------------------------------------------------------
 
@@ -42,6 +48,7 @@
     # ++++++++++++ Test attach snapshot disk from one VM to another +++++++++++
     # --------- Test VIRTIO_DISK to VIRTIO_DISK ---------
 
+    # Test attach when vm_2 is stopped
     - name: >-
         Attach "snap-0" from VM "{{ vm_1 }}" to VM "{{ vm_2 }}" - as VIRTIO_DISK
       scale_computing.hypercore.vm_snapshot_attach_disk:
@@ -52,18 +59,29 @@
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
         source_disk_slot: 1
+        force_reboot: "{{ force_reboot }}"
       register: result
     - ansible.builtin.debug:
         var: result
     - ansible.builtin.assert:
         that:
           - result is changed
+    - include_tasks: helper_check_vm_state.yml
+      vars:
+        vm_name: "{{ vm_2 }}"
+        expected_state: stopped
     - ansible.builtin.assert: &test-virtio
         that:
           - result.record.type == "virtio_disk"
           - result.record.disk_slot == slot_a
           - result.record.vm_uuid == vm_2_info.records[0].uuid
 
+    - name: Start VM "{{ vm_2 }}"
+      scale_computing.hypercore.vm_params:
+        vm_name: "{{ vm_2 }}"
+        power_state: start
+
+    # Test attach when vm_2 is running
     - name: >-
         IDEMPOTENCE - Attach "snap-0" from VM "{{ vm_1 }}"
         to VM "{{ vm_2 }}" - as VIRTIO_DISK
@@ -75,15 +93,23 @@
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
         source_disk_slot: 1
+        force_reboot: "{{ force_reboot }}"
       register: result
     - ansible.builtin.debug:
         var: result
     - ansible.builtin.assert:
         that:
           - result is not changed
+    - include_tasks: helper_check_vm_state.yml
+      vars:
+        vm_name: "{{ vm_2 }}"
+        expected_state: started
     - ansible.builtin.assert: *test-virtio
 
-#    # --------- Test VIRTIO_DISK to SOME_OTHER_TYPE_OF_DISK ---------
+    # >>>>>>>>>>>>>>>>>>>>
+    # The rest of the tests are attaching on a running vm_2/vm_1
+    # >>>>>>>>>>>>>>>>>>>>
+    # --------- Test VIRTIO_DISK to SOME_OTHER_TYPE_OF_DISK ---------
     - name: >-
         Attach "snap-0" from VM "{{ vm_1 }}" to
         VM "{{ vm_2 }}" - as NOT VIRTIO_DISK
@@ -95,12 +121,17 @@
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
         source_disk_slot: 1
+        force_reboot: "{{ force_reboot }}"
       register: result
     - ansible.builtin.debug:
         var: result
     - ansible.builtin.assert:
         that:
           - result is changed
+    - include_tasks: helper_check_vm_state.yml
+      vars:
+        vm_name: "{{ vm_2 }}"
+        expected_state: started
     - ansible.builtin.assert: &test-not-virtio
         that:
           - result.record.type == "ide_disk"
@@ -118,12 +149,17 @@
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
         source_disk_slot: 1
+        force_reboot: "{{ force_reboot }}"
       register: result
     - ansible.builtin.debug:
         var: result
     - ansible.builtin.assert:
         that:
           - result is not changed
+    - include_tasks: helper_check_vm_state.yml
+      vars:
+        vm_name: "{{ vm_2 }}"
+        expected_state: started
     - ansible.builtin.assert: *test-not-virtio
 
     # ++++++++++++ Test attach snapshot disk from a VM to itself +++++++++++++
@@ -139,12 +175,17 @@
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
         source_disk_slot: 1
+        force_reboot: "{{ force_reboot }}"
       register: result
     - ansible.builtin.debug:
         var: result
     - ansible.builtin.assert:
         that:
           - result is changed
+    - include_tasks: helper_check_vm_state.yml
+      vars:
+        vm_name: "{{ vm_1 }}"
+        expected_state: started
     - ansible.builtin.assert: &test-virtio-2
         that:
           - result.record.type == "virtio_disk"
@@ -162,10 +203,22 @@
           "{{ vm_1_snapshot_info.records[0].snapshot_uuid }}"
         source_disk_type: virtio_disk
         source_disk_slot: 1
+        force_reboot: "{{ force_reboot }}"
       register: result
     - ansible.builtin.debug:
         var: result
+    - include_tasks: helper_check_vm_state.yml
+      vars:
+        vm_name: "{{ vm_1 }}"
+        expected_state: started
     - ansible.builtin.assert:
         that:
           - result is not changed
     - ansible.builtin.assert: *test-virtio-2
+
+# ---------- Cleanup ------------
+  always:
+    - name: Remove snapshot attach testing VM "{{ vm_2 }}"
+      scale_computing.hypercore.vm:
+        vm_name: "{{ vm_2 }}"
+        state: absent

--- a/tests/integration/targets/vm_snapshot/tasks/helper_api_vm_snapshot_create.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/helper_api_vm_snapshot_create.yml
@@ -4,7 +4,7 @@
 # ++++++++++++++++++++++++++++++
 - name: Create test VMs
   scale_computing.hypercore.vm:
-    vm_name: "snapshot-test-vm-{{ item }}{{ label | default('') }}"
+    vm_name: "snapshot-test-vm-{{ item }}"
     description: Snapshot testing
     state: present
     tags:
@@ -12,14 +12,14 @@
     memory: "{{ '512 MB' | human_to_bytes }}"
     vcpu: 2
     attach_guest_tools_iso: false
-    power_state: "{{ vm_init_state | default('start') }}"
+    power_state: start
     disks:
       - type: virtio_disk
         disk_slot: 0
-        size: "{{ '1.1 GB' | human_to_bytes }}"
+        size: "{{ '0.1 GB' | human_to_bytes }}"
       - type: virtio_disk
         disk_slot: 1
-        size: "{{ '1.2 GB' | human_to_bytes }}"
+        size: "{{ '0.2 GB' | human_to_bytes }}"
     nics:
       - vlan: 1
         type: RTL8139
@@ -43,63 +43,61 @@
 
 # ----------- Create/POST USER SNAPSHOTS -------------
 
-- block:
-  - name: Create 3 snapshots with "unique" label for "snapshot-test-vm-1"
-    scale_computing.hypercore.api:
-      action: post
-      endpoint: /rest/v1/VirDomainSnapshot
-      data:
-        domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
-        label: "snap-{{ item }}"
-    with_sequence: start=0 end=2
-    register: unique_labeled_snapshots
+- name: Create 3 snapshots with "unique" label for "snapshot-test-vm-1"
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/VirDomainSnapshot
+    data:
+      domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
+      label: "snap-{{ item }}"
+  with_sequence: start=0 end=2
+  register: unique_labeled_snapshots
 
-  - name: Show created snapshots with "unique" label on "snapshot-test-vm-1"
-    ansible.builtin.debug:
-      var: unique_labeled_snapshots
+- name: Show created snapshots with "unique" label on "snapshot-test-vm-1"
+  ansible.builtin.debug:
+    var: unique_labeled_snapshots
 
-  - name: Create 3 snapshots with "unique" label for "snapshot-test-vm-2"
-    scale_computing.hypercore.api:
-      action: post
-      endpoint: /rest/v1/VirDomainSnapshot
-      data:
-        domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
-        label: "snap-{{ item }}"
-    with_sequence: start=0 end=2
-    register: unique_labeled_snapshots
+- name: Create 3 snapshots with "unique" label for "snapshot-test-vm-2"
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/VirDomainSnapshot
+    data:
+      domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
+      label: "snap-{{ item }}"
+  with_sequence: start=0 end=2
+  register: unique_labeled_snapshots
 
-  - name: Show created snapshots with "unique" label on "snapshot-test-vm-2"
-    ansible.builtin.debug:
-      var: unique_labeled_snapshots
+- name: Show created snapshots with "unique" label on "snapshot-test-vm-2"
+  ansible.builtin.debug:
+    var: unique_labeled_snapshots
 
-  - name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-1"
-    scale_computing.hypercore.api:
-      action: post
-      endpoint: /rest/v1/VirDomainSnapshot
-      data:
-        domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
-        label: "not-unique"
-    with_sequence: start=0 end=2
-    register: non_unique_labeled_snapshots
+- name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-1"
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/VirDomainSnapshot
+    data:
+      domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
+      label: "not-unique"
+  with_sequence: start=0 end=2
+  register: non_unique_labeled_snapshots
 
-  - name: Show created snapshots with "non-unique" label on "snapshot-test-vm-1"
-    ansible.builtin.debug:
-      var: non_unique_labeled_snapshots
+- name: Show created snapshots with "non-unique" label on "snapshot-test-vm-1"
+  ansible.builtin.debug:
+    var: non_unique_labeled_snapshots
 
-  - name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-2"
-    scale_computing.hypercore.api:
-      action: post
-      endpoint: /rest/v1/VirDomainSnapshot
-      data:
-        domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
-        label: "not-unique"
-    with_sequence: start=0 end=2
-    register: non_unique_labeled_snapshots
+- name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-2"
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/VirDomainSnapshot
+    data:
+      domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
+      label: "not-unique"
+  with_sequence: start=0 end=2
+  register: non_unique_labeled_snapshots
 
-  - name: Show created snapshots with "non-unique" label on "snapshot-test-vm-2"
-    ansible.builtin.debug:
-      var: non_unique_labeled_snapshots
-  when: label is undefined
+- name: Show created snapshots with "non-unique" label on "snapshot-test-vm-2"
+  ansible.builtin.debug:
+    var: non_unique_labeled_snapshots
 
 # These snapshot serials are always the same, everytime they are freshly created
 # ++++++++++++++++++++++++++

--- a/tests/integration/targets/vm_snapshot/tasks/helper_api_vm_snapshot_create.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/helper_api_vm_snapshot_create.yml
@@ -12,7 +12,7 @@
     memory: "{{ '512 MB' | human_to_bytes }}"
     vcpu: 2
     attach_guest_tools_iso: false
-    power_state: stop
+    power_state: start
     disks:
       - type: virtio_disk
         disk_slot: 0

--- a/tests/integration/targets/vm_snapshot/tasks/helper_api_vm_snapshot_create.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/helper_api_vm_snapshot_create.yml
@@ -4,7 +4,7 @@
 # ++++++++++++++++++++++++++++++
 - name: Create test VMs
   scale_computing.hypercore.vm:
-    vm_name: "snapshot-test-vm-{{ item }}"
+    vm_name: "snapshot-test-vm-{{ item }}{{ label | default('') }}"
     description: Snapshot testing
     state: present
     tags:
@@ -12,14 +12,14 @@
     memory: "{{ '512 MB' | human_to_bytes }}"
     vcpu: 2
     attach_guest_tools_iso: false
-    power_state: start
+    power_state: "{{ vm_init_state | default('start') }}"
     disks:
       - type: virtio_disk
         disk_slot: 0
-        size: "{{ '0.1 GB' | human_to_bytes }}"
+        size: "{{ '1.1 GB' | human_to_bytes }}"
       - type: virtio_disk
         disk_slot: 1
-        size: "{{ '0.2 GB' | human_to_bytes }}"
+        size: "{{ '1.2 GB' | human_to_bytes }}"
     nics:
       - vlan: 1
         type: RTL8139
@@ -43,61 +43,63 @@
 
 # ----------- Create/POST USER SNAPSHOTS -------------
 
-- name: Create 3 snapshots with "unique" label for "snapshot-test-vm-1"
-  scale_computing.hypercore.api:
-    action: post
-    endpoint: /rest/v1/VirDomainSnapshot
-    data:
-      domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
-      label: "snap-{{ item }}"
-  with_sequence: start=0 end=2
-  register: unique_labeled_snapshots
+- block:
+  - name: Create 3 snapshots with "unique" label for "snapshot-test-vm-1"
+    scale_computing.hypercore.api:
+      action: post
+      endpoint: /rest/v1/VirDomainSnapshot
+      data:
+        domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
+        label: "snap-{{ item }}"
+    with_sequence: start=0 end=2
+    register: unique_labeled_snapshots
 
-- name: Show created snapshots with "unique" label on "snapshot-test-vm-1"
-  ansible.builtin.debug:
-    var: unique_labeled_snapshots
+  - name: Show created snapshots with "unique" label on "snapshot-test-vm-1"
+    ansible.builtin.debug:
+      var: unique_labeled_snapshots
 
-- name: Create 3 snapshots with "unique" label for "snapshot-test-vm-2"
-  scale_computing.hypercore.api:
-    action: post
-    endpoint: /rest/v1/VirDomainSnapshot
-    data:
-      domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
-      label: "snap-{{ item }}"
-  with_sequence: start=0 end=2
-  register: unique_labeled_snapshots
+  - name: Create 3 snapshots with "unique" label for "snapshot-test-vm-2"
+    scale_computing.hypercore.api:
+      action: post
+      endpoint: /rest/v1/VirDomainSnapshot
+      data:
+        domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
+        label: "snap-{{ item }}"
+    with_sequence: start=0 end=2
+    register: unique_labeled_snapshots
 
-- name: Show created snapshots with "unique" label on "snapshot-test-vm-2"
-  ansible.builtin.debug:
-    var: unique_labeled_snapshots
+  - name: Show created snapshots with "unique" label on "snapshot-test-vm-2"
+    ansible.builtin.debug:
+      var: unique_labeled_snapshots
 
-- name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-1"
-  scale_computing.hypercore.api:
-    action: post
-    endpoint: /rest/v1/VirDomainSnapshot
-    data:
-      domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
-      label: "not-unique"
-  with_sequence: start=0 end=2
-  register: non_unique_labeled_snapshots
+  - name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-1"
+    scale_computing.hypercore.api:
+      action: post
+      endpoint: /rest/v1/VirDomainSnapshot
+      data:
+        domainUUID: "{{ vms_created.results.0.record.0.uuid }}"
+        label: "not-unique"
+    with_sequence: start=0 end=2
+    register: non_unique_labeled_snapshots
 
-- name: Show created snapshots with "non-unique" label on "snapshot-test-vm-1"
-  ansible.builtin.debug:
-    var: non_unique_labeled_snapshots
+  - name: Show created snapshots with "non-unique" label on "snapshot-test-vm-1"
+    ansible.builtin.debug:
+      var: non_unique_labeled_snapshots
 
-- name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-2"
-  scale_computing.hypercore.api:
-    action: post
-    endpoint: /rest/v1/VirDomainSnapshot
-    data:
-      domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
-      label: "not-unique"
-  with_sequence: start=0 end=2
-  register: non_unique_labeled_snapshots
+  - name: Create 3 snapshots with "non-unique" label for "snapshot-test-vm-2"
+    scale_computing.hypercore.api:
+      action: post
+      endpoint: /rest/v1/VirDomainSnapshot
+      data:
+        domainUUID: "{{ vms_created.results.1.record.0.uuid }}"
+        label: "not-unique"
+    with_sequence: start=0 end=2
+    register: non_unique_labeled_snapshots
 
-- name: Show created snapshots with "non-unique" label on "snapshot-test-vm-2"
-  ansible.builtin.debug:
-    var: non_unique_labeled_snapshots
+  - name: Show created snapshots with "non-unique" label on "snapshot-test-vm-2"
+    ansible.builtin.debug:
+      var: non_unique_labeled_snapshots
+  when: label is undefined
 
 # These snapshot serials are always the same, everytime they are freshly created
 # ++++++++++++++++++++++++++

--- a/tests/integration/targets/vm_snapshot/tasks/helper_check_vm_state.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/helper_check_vm_state.yml
@@ -1,0 +1,10 @@
+---
+- name: Get VM "{{ vm_name }}" info
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name }}"
+  register: vm_info
+
+- name: Is VM "{{ vm_name }}" power_state == "{{ expected_state }}" ?
+  ansible.builtin.assert:
+    that:
+      - vm_info.records[0].power_state == expected_state

--- a/tests/integration/targets/vm_snapshot/tasks/main.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/main.yml
@@ -6,7 +6,7 @@
     SC_TIMEOUT: "{{ sc_timeout }}"
 
   vars:
-    number_of_snapshot_testing_vms: 3
+    number_of_snapshot_testing_vms: 2
     non_unique_snapshot_label: not_unique
     # unique snapshot labels are strings like:
     # snap-x, where x is an iterative number
@@ -14,6 +14,11 @@
     #    greater than 0, is a newer snapshot
 
   block:
+    - name: Create VMs
+      include_tasks: helper_api_vm_snapshot_create.yml
+      vars:
+        vms_number: "{{ number_of_snapshot_testing_vms }}"
+
     - include_tasks: 01_vm_snapshot_info.yml
       vars:
         test_vms_number: "{{ number_of_snapshot_testing_vms }}"


### PR DESCRIPTION
This PR makes sure that the VM we are trying to attach a snapshot disk to shuts down before attaching; tasks fail if we are trying to attach to a running VM.

**How it works (steps)**:
1. if the destination VM is running, shut it down (first normally, and if that fails, then forcibly) - this step is skipped if the VM is already shut down.
2. attach the desired snapshot disk
3. restart the destination VM.