### PR TITLE
Update return of vm_snapshot_attach_disk module.

### DIFF
--- a/plugins/modules/vm_snapshot_attach_disk.py
+++ b/plugins/modules/vm_snapshot_attach_disk.py
@@ -215,14 +215,7 @@ def attach_disk(
     )
 
     # Restart the previously running VM (destination)
-    vm_state_before = vm_object.power_state
     vm_object.vm_power_up(module, rest_client)  # type: ignore
-    vm_state_after = vm_object.power_state
-
-    # This is True if the destination VM was indeed rebooted
-    vm_destination_reboot = \
-        (vm_state_before != vm_state_after) and \
-        vm_state_before in ("stop", "stopped", "shutdown")
 
     # return changed, after, diff
     return (
@@ -232,7 +225,7 @@ def attach_disk(
         dict(
             before=None, after=created_disk
         ),  # before, we ofcourse, didn't have that new block device, and after we should have it
-        vm_destination_reboot,
+        vm_object.reboot,
     )
 
 

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -83,6 +83,7 @@
     - ansible.builtin.assert:
         that:
           - result is changed
+          - result.vm_rebooted is false
     - include_tasks: helper_check_vm_state.yml
       vars:
         vm_name: "{{ vm_2 }}"
@@ -117,6 +118,7 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
+          - result.vm_rebooted is false
     - include_tasks: helper_check_vm_state.yml
       vars:
         vm_name: "{{ vm_2 }}"
@@ -146,6 +148,7 @@
     - ansible.builtin.assert:
         that:
           - result is changed
+          - result.vm_rebooted is true
     - include_tasks: helper_check_vm_state.yml
       vars:
         vm_name: "{{ vm_2 }}"
@@ -174,6 +177,7 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
+          - result.vm_rebooted is false
     - include_tasks: helper_check_vm_state.yml
       vars:
         vm_name: "{{ vm_2 }}"
@@ -203,6 +207,7 @@
     - ansible.builtin.assert:
         that:
           - result is changed
+          - result.vm_rebooted is true
     - include_tasks: helper_check_vm_state.yml
       vars:
         vm_name: "{{ vm_1 }}"
@@ -235,6 +240,7 @@
     - ansible.builtin.assert:
         that:
           - result is not changed
+          - result.vm_rebooted is false
     - ansible.builtin.assert: *test-virtio-2
 
 # ---------- Cleanup ------------

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -102,6 +102,13 @@
           - result.record.type == "virtio_disk"
           - result.record.uuid | length == 36
           - result.record.vm_uuid == vm_2_info.records[0].uuid
+          # Test returned record is consistent with data from vm_info
+          - vm_info.records[0].disks | length == 3
+          - vm_info.records[0].disks[2].disk_slot  == slot_a
+          - vm_info.records[0].disks[2].size  == size_0_2_GB
+          - vm_info.records[0].disks[2].type  == "virtio_disk"
+          - vm_info.records[0].disks[2].uuid == result.record.uuid
+          - vm_info.records[0].disks[2].vm_uuid == vm_2_info.records[0].uuid
 
     - name: Start VM "{{ vm_2 }}"
       scale_computing.hypercore.vm_params:
@@ -170,6 +177,17 @@
           - result.record.type == "ide_disk"
           - result.record.uuid | length == 36
           - result.record.vm_uuid == vm_2_info.records[0].uuid
+          - vm_info.records[0].disks | length == 4
+          - vm_info.records[0].disks[2].disk_slot  == slot_a
+          - vm_info.records[0].disks[2].size  == size_0_2_GB
+          - vm_info.records[0].disks[2].type  == "virtio_disk"
+          # - vm_info.records[0].disks[2].uuid == result.record.uuid
+          - vm_info.records[0].disks[2].vm_uuid == vm_2_info.records[0].uuid
+          - vm_info.records[0].disks[3].disk_slot  == slot_b
+          - vm_info.records[0].disks[3].size  == size_0_2_GB
+          - vm_info.records[0].disks[3].type  == "ide_disk"
+          - vm_info.records[0].disks[3].uuid == result.record.uuid
+          - vm_info.records[0].disks[3].vm_uuid == vm_2_info.records[0].uuid
 
     - name: >-
         IDEMPOTENCE - Attach "snap-0" from VM "{{ vm_1 }}"
@@ -232,6 +250,13 @@
           - result.record.type == "virtio_disk"
           - result.record.uuid | length == 36
           - result.record.vm_uuid == vm_1_info.records[0].uuid
+          - vm_info.records[0].disks | length == 3
+          - vm_info.records[0].disks[2].disk_slot  == slot_vm_1_virtio
+          - vm_info.records[0].disks[2].size  == size_0_2_GB
+          - vm_info.records[0].disks[2].type  == "virtio_disk"
+          - vm_info.records[0].disks[2].uuid == result.record.uuid
+          - vm_info.records[0].disks[2].vm_uuid == vm_1_info.records[0].uuid
+
 
     - name: >-
         IDEMPOTENCE - Attach "snap-0" from VM "{{ vm_1 }}"

--- a/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
+++ b/tests/integration/targets/vm_snapshot/tasks/03_vm_snapshot_attach_disk.yml
@@ -14,6 +14,12 @@
 
     force_reboot: true  # allow forced vm shutdown
 
+    # disk size gets rounded by HC3:
+    #   0.1 GB to 107374182 B
+    #   0.2 GB to 214958080 B
+    size_0_1_GB: 107374182
+    size_0_2_GB: 214958080
+
   block:
     - name: Create a stopped VM "{{ vm_2 }}"
       scale_computing.hypercore.vm:
@@ -90,8 +96,11 @@
         expected_state: stopped
     - ansible.builtin.assert: &test-virtio
         that:
-          - result.record.type == "virtio_disk"
+          - "result.record.keys() | sort == ['disk_slot', 'size', 'type', 'uuid', 'vm_uuid']"
           - result.record.disk_slot == slot_a
+          - result.record.size == size_0_2_GB
+          - result.record.type == "virtio_disk"
+          - result.record.uuid | length == 36
           - result.record.vm_uuid == vm_2_info.records[0].uuid
 
     - name: Start VM "{{ vm_2 }}"
@@ -155,8 +164,11 @@
         expected_state: started
     - ansible.builtin.assert: &test-not-virtio
         that:
-          - result.record.type == "ide_disk"
+          - "result.record.keys() | sort == ['disk_slot', 'size', 'type', 'uuid', 'vm_uuid']"
           - result.record.disk_slot == slot_b
+          - result.record.size == size_0_2_GB
+          - result.record.type == "ide_disk"
+          - result.record.uuid | length == 36
           - result.record.vm_uuid == vm_2_info.records[0].uuid
 
     - name: >-
@@ -214,8 +226,11 @@
         expected_state: started
     - ansible.builtin.assert: &test-virtio-2
         that:
-          - result.record.type == "virtio_disk"
+          - "result.record.keys() | sort == ['disk_slot', 'size', 'type', 'uuid', 'vm_uuid']"
           - result.record.disk_slot == slot_vm_1_virtio
+          - result.record.size == size_0_2_GB
+          - result.record.type == "virtio_disk"
+          - result.record.uuid | length == 36
           - result.record.vm_uuid == vm_1_info.records[0].uuid
 
     - name: >-

--- a/tests/unit/plugins/modules/test_vm_snapshot_attach_disk.py
+++ b/tests/unit/plugins/modules/test_vm_snapshot_attach_disk.py
@@ -155,10 +155,10 @@ class TestAttachDisk:
     @pytest.mark.parametrize(
         ("destination_vm_disk_info", "expected_return"),
         [
-            (None, (True, BLOCK_DEVICE, dict(before=None, after=BLOCK_DEVICE))),
+            (None, (True, BLOCK_DEVICE, dict(before=None, after=BLOCK_DEVICE), True)),
             (
                 BLOCK_DEVICE,
-                (False, BLOCK_DEVICE, dict(before=BLOCK_DEVICE, after=None)),
+                (False, BLOCK_DEVICE, dict(before=BLOCK_DEVICE, after=None), False),
             ),
         ],
     )
@@ -222,7 +222,7 @@ class TestAttachDisk:
             check_mode=False,
         )
 
-        changed, record, diff = vm_snapshot_attach_disk.attach_disk(module, rest_client)
+        changed, record, diff, vm_rebooted = vm_snapshot_attach_disk.attach_disk(module, rest_client)
 
         if destination_vm_disk_info is None:
             rest_client.create_record.assert_any_call(**called_with_dict)
@@ -235,15 +235,16 @@ class TestAttachDisk:
         assert changed == expected_return[0]
         assert record == expected_return[1]
         assert diff == expected_return[2]
+        assert vm_rebooted == expected_return[3]
 
 
 class TestMain:
-    def test_fail(self, run_main):
-        success, result = run_main(vm_snapshot_attach_disk)
+    def test_fail(self, run_main_with_reboot):
+        success, result = run_main_with_reboot(vm_snapshot_attach_disk)
 
         assert success is False
         assert "missing required arguments" in result["msg"]
 
-    def test_params(self, run_main):
-        success, result = run_main(vm_snapshot_attach_disk, PARAMS)
+    def test_params(self, run_main_with_reboot):
+        success, result = run_main_with_reboot(vm_snapshot_attach_disk, PARAMS)
         assert success is True

--- a/tests/unit/plugins/modules/test_vm_snapshot_attach_disk.py
+++ b/tests/unit/plugins/modules/test_vm_snapshot_attach_disk.py
@@ -222,7 +222,9 @@ class TestAttachDisk:
             check_mode=False,
         )
 
-        changed, record, diff, vm_rebooted = vm_snapshot_attach_disk.attach_disk(module, rest_client)
+        changed, record, diff, vm_rebooted = vm_snapshot_attach_disk.attach_disk(
+            module, rest_client
+        )
 
         if destination_vm_disk_info is None:
             rest_client.create_record.assert_any_call(**called_with_dict)


### PR DESCRIPTION
A small change to ``vm_snapshot_attach_disk`` was made as requested in #233.
- add ``vm_rebooted`` status to return --> info if reboot of the destination VM was performed.