### PR TITLE
Make examples testing job run after integration tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,9 +21,8 @@ jobs:
       - run: echo GITHUB_WORKSPACE=$GITHUB_WORKSPACE
       - run: echo WORKDIR=$WORKDIR
       - run: echo PWD=$PWD
-      - run: echo "MYPY job" && exit 0
-#      - name: Run mypy
-#        run: mypy -p plugins
+      - name: Run mypy
+        run: mypy -p plugins
 
   docs:
     runs-on: [ubuntu-latest]
@@ -40,12 +39,11 @@ jobs:
       - run: make docs
         env:
           ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
-      - run: echo "DOCS job" && exit 0
-#      - run: ls -al docs/build/html
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          name: docs-html
-#          path: work-dir/ansible_collections/scale_computing/hypercore/docs/build/html
+      - run: ls -al docs/build/html
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs-html
+          path: work-dir/ansible_collections/scale_computing/hypercore/docs/build/html
 
   sanity-test:
     runs-on: [ubuntu-latest]
@@ -58,19 +56,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - run: echo "SANITY-TEST job" && exit 0
-#        # Same as "make sanity"
-#        # TODO reuse Makefile
-#      - run: black -t py38 --check --diff --color plugins tests/unit
-#      - run: ansible-lint
-#      - run: flake8 --exclude tests/output/
-#      - run: ansible-test sanity --local --python 3.10
-#      # Running `ansible-lint` will look at examples as being arbitrary yaml files.
-#      # It will complain about missing space after hash in "#xy" comment.
-#      # Running `ansible-lint examples/*` will interpret files as ansible playbooks.
-#      # Here we need also installed collections used in examples.
-#      - run: ansible-galaxy collection install community.crypto
-#      - run: ansible-lint examples/*
+        # Same as "make sanity"
+        # TODO reuse Makefile
+      - run: black -t py38 --check --diff --color plugins tests/unit
+      - run: ansible-lint
+      - run: flake8 --exclude tests/output/
+      - run: ansible-test sanity --local --python 3.10
+      # Running `ansible-lint` will look at examples as being arbitrary yaml files.
+      # It will complain about missing space after hash in "#xy" comment.
+      # Running `ansible-lint examples/*` will interpret files as ansible playbooks.
+      # Here we need also installed collections used in examples.
+      - run: ansible-galaxy collection install community.crypto
+      - run: ansible-lint examples/*
 
   units-test:
     runs-on: [ubuntu-latest]
@@ -83,9 +80,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - run: echo "UNITS-TEST job" && exit 0
-#        # Same as "make units"
-#        # TODO reuse Makefile
-#      - run: ansible-test units --local --python 3.10 --coverage
-#      - run: ansible-test coverage html --requirements
-#      - run: ansible-test coverage report --omit 'tests/*' --show-missing
+        # Same as "make units"
+        # TODO reuse Makefile
+      - run: ansible-test units --local --python 3.10 --coverage
+      - run: ansible-test coverage html --requirements
+      - run: ansible-test coverage report --omit 'tests/*' --show-missing

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,8 +21,9 @@ jobs:
       - run: echo GITHUB_WORKSPACE=$GITHUB_WORKSPACE
       - run: echo WORKDIR=$WORKDIR
       - run: echo PWD=$PWD
-      - name: Run mypy
-        run: mypy -p plugins
+      - run: echo "MYPY job" && exit 0
+#      - name: Run mypy
+#        run: mypy -p plugins
 
   docs:
     runs-on: [ubuntu-latest]
@@ -39,11 +40,12 @@ jobs:
       - run: make docs
         env:
           ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
-      - run: ls -al docs/build/html
-      - uses: actions/upload-artifact@v3
-        with:
-          name: docs-html
-          path: work-dir/ansible_collections/scale_computing/hypercore/docs/build/html
+      - run: echo "DOCS job" && exit 0
+#      - run: ls -al docs/build/html
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: docs-html
+#          path: work-dir/ansible_collections/scale_computing/hypercore/docs/build/html
 
   sanity-test:
     runs-on: [ubuntu-latest]
@@ -56,18 +58,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-        # Same as "make sanity"
-        # TODO reuse Makefile
-      - run: black -t py38 --check --diff --color plugins tests/unit
-      - run: ansible-lint
-      - run: flake8 --exclude tests/output/
-      - run: ansible-test sanity --local --python 3.10
-      # Running `ansible-lint` will look at examples as being arbitrary yaml files.
-      # It will complain about missing space after hash in "#xy" comment.
-      # Running `ansible-lint examples/*` will interpret files as ansible playbooks.
-      # Here we need also installed collections used in examples.
-      - run: ansible-galaxy collection install community.crypto
-      - run: ansible-lint examples/*
+      - run: echo "SANITY-TEST job" && exit 0
+#        # Same as "make sanity"
+#        # TODO reuse Makefile
+#      - run: black -t py38 --check --diff --color plugins tests/unit
+#      - run: ansible-lint
+#      - run: flake8 --exclude tests/output/
+#      - run: ansible-test sanity --local --python 3.10
+#      # Running `ansible-lint` will look at examples as being arbitrary yaml files.
+#      # It will complain about missing space after hash in "#xy" comment.
+#      # Running `ansible-lint examples/*` will interpret files as ansible playbooks.
+#      # Here we need also installed collections used in examples.
+#      - run: ansible-galaxy collection install community.crypto
+#      - run: ansible-lint examples/*
 
   units-test:
     runs-on: [ubuntu-latest]
@@ -80,8 +83,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-        # Same as "make units"
-        # TODO reuse Makefile
-      - run: ansible-test units --local --python 3.10 --coverage
-      - run: ansible-test coverage html --requirements
-      - run: ansible-test coverage report --omit 'tests/*' --show-missing
+      - run: echo "UNITS-TEST job" && exit 0
+#        # Same as "make units"
+#        # TODO reuse Makefile
+#      - run: ansible-test units --local --python 3.10 --coverage
+#      - run: ansible-test coverage html --requirements
+#      - run: ansible-test coverage report --omit 'tests/*' --show-missing

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -142,6 +142,54 @@ jobs:
           )" >> $GITHUB_OUTPUT
     if: "${{ github.event.inputs || github.event.schedule }}"
 
+  examples-run:
+    needs:
+      - examples-matrix
+      # run examples after integ - they will both try to modify say syslog_server etc
+      - integ
+    if: "always() && (needs.examples-matrix.result=='success')"
+    runs-on: [ self-hosted2 ]
+    container: quay.io/justinc1_github/scale_ci_integ:3
+    env:
+      ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
+      DEBIAN_FRONTEND: noninteractive
+    defaults:
+      run:
+        working-directory: ${{ env.WORKDIR }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible: [ 2.13.0 ]
+        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.WORKDIR }}
+      - run: pip install ansible-core~=${{ matrix.ansible }}
+      - run: ansible-galaxy collection install community.crypto community.general
+      - run: ansible-galaxy collection list
+
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          sc_host: https://10.5.11.201
+          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          working_directory: ${{ env.WORKDIR }}
+      - run: |
+          pwd
+          ls -al tests/integration/integration_config.yml
+          head tests/integration/integration_config.yml
+
+      - run: |
+          eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
+          eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_username')
+          eval export SC_PASSWORD=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_password')
+          eval export SC_TIMEOUT=$(cat tests/integration/integration_config.yml | yq '.sc_timeout')
+          ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
+
   integ:
     needs:
       - integ-matrix
@@ -210,53 +258,6 @@ jobs:
           working_directory: ${{ env.WORKDIR }}
       - run: ansible-test integration --local ${{ matrix.test_name }}
 
-  examples-run:
-    needs:
-      - examples-matrix
-      # run examples after integ - they will both try to modify say syslog_server etc
-      - integ
-    if: "always() && (needs.examples-matrix.result=='success')"
-    runs-on: [ self-hosted2 ]
-    container: quay.io/justinc1_github/scale_ci_integ:3
-    env:
-      ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
-      DEBIAN_FRONTEND: noninteractive
-    defaults:
-      run:
-        working-directory: ${{ env.WORKDIR }}
-    strategy:
-      fail-fast: false
-      matrix:
-        ansible: [ 2.13.0 ]
-        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: ${{ env.WORKDIR }}
-      - run: pip install ansible-core~=${{ matrix.ansible }}
-      - run: ansible-galaxy collection install community.crypto community.general
-      - run: ansible-galaxy collection list
-
-      # ${{ env.WORKDIR }} cannot be used
-      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
-        with:
-          sc_host: https://10.5.11.201
-          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
-          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
-          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
-          working_directory: ${{ env.WORKDIR }}
-      - run: |
-          pwd
-          ls -al tests/integration/integration_config.yml
-          head tests/integration/integration_config.yml
-
-      - run: |
-          eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
-          eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_username')
-          eval export SC_PASSWORD=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_password')
-          eval export SC_TIMEOUT=$(cat tests/integration/integration_config.yml | yq '.sc_timeout')
-          ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
 
   replica_cleanup:
     needs:

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -146,8 +146,8 @@ jobs:
     needs:
       - examples-matrix
       # run examples after integ - they will both try to modify say syslog_server etc
-      - integ
-    if: "always() && (needs.examples-matrix.outputs.job_status=='success')"
+      # - integ
+    # if: "always() && (needs.examples-matrix.outputs.job_status=='success')"
     runs-on: [ self-hosted2 ]
     container: quay.io/justinc1_github/scale_ci_integ:3
     env:
@@ -162,6 +162,8 @@ jobs:
         ansible: [ 2.13.0 ]
         example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
     steps:
+      - name: Print examples-run time
+        run: echo $(date + "%T")
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -238,26 +240,27 @@ jobs:
           - sc_host: https://10.5.11.201
             test_name: support_tunnel
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: ${{ env.WORKDIR }}
-      - run: pip install ansible-core~=2.13.0
-      # We have ansible.cfg "for testing" in git repo
-      # (it is excluded in galaxy.yml, so it is not part of collection artifact)
-      # But it does affect ansible-galaxy and ansible-test commands.
-      - run: ansible-galaxy collection install community.crypto
-      - run: ansible-galaxy collection list
-      # ${{ env.WORKDIR }} cannot be used
-      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
-        with:
-          sc_host: ${{ matrix.sc_host }}
-          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
-          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
-          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
-          working_directory: ${{ env.WORKDIR }}
-      - run: ansible-test integration --local ${{ matrix.test_name }}
-
+      - name: Print integ time
+        run: echo $(date + "%T") && exit 1
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          path: ${{ env.WORKDIR }}
+#      - run: pip install ansible-core~=2.13.0
+#      # We have ansible.cfg "for testing" in git repo
+#      # (it is excluded in galaxy.yml, so it is not part of collection artifact)
+#      # But it does affect ansible-galaxy and ansible-test commands.
+#      - run: ansible-galaxy collection install community.crypto
+#      - run: ansible-galaxy collection list
+#      # ${{ env.WORKDIR }} cannot be used
+#      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+#        with:
+#          sc_host: ${{ matrix.sc_host }}
+#          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+#          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+#          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+#          working_directory: ${{ env.WORKDIR }}
+#      - run: ansible-test integration --local ${{ matrix.test_name }}
 
   replica_cleanup:
     needs:

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           path: ${{ env.WORKDIR }}
       - name: Print integ time
-        run: echo "Integ time -> $(date +%T)" && exit 0
+        run: echo "Integ time -> $(date +%T)" && exit 1
 #      - run: pip install ansible-core~=2.13.0
 #      # We have ansible.cfg "for testing" in git repo
 #      # (it is excluded in galaxy.yml, so it is not part of collection artifact)

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           path: ${{ env.WORKDIR }}
       - name: Print integ time
-        run: echo "Integ time -> $(date +%T)" && exit 1
+        run: echo "Integ time -> $(date +%T)" && exit 0
 #      - run: pip install ansible-core~=2.13.0
 #      # We have ansible.cfg "for testing" in git repo
 #      # (it is excluded in galaxy.yml, so it is not part of collection artifact)

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -142,56 +142,6 @@ jobs:
           )" >> $GITHUB_OUTPUT
     if: "${{ github.event.inputs || github.event.schedule }}"
 
-  examples-run:
-    needs:
-      - examples-matrix
-      # run examples after integ - they will both try to modify say syslog_server etc
-      # - integ
-    # if: "always() && (needs.examples-matrix.outputs.job_status=='success')"
-    runs-on: [ self-hosted2 ]
-    container: quay.io/justinc1_github/scale_ci_integ:3
-    env:
-      ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
-      DEBIAN_FRONTEND: noninteractive
-    defaults:
-      run:
-        working-directory: ${{ env.WORKDIR }}
-    strategy:
-      fail-fast: false
-      matrix:
-        ansible: [ 2.13.0 ]
-        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
-    steps:
-      - name: Print examples-run time
-        run: echo $(date + "%T")
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: ${{ env.WORKDIR }}
-      - run: pip install ansible-core~=${{ matrix.ansible }}
-      - run: ansible-galaxy collection install community.crypto community.general
-      - run: ansible-galaxy collection list
-
-      # ${{ env.WORKDIR }} cannot be used
-      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
-        with:
-          sc_host: https://10.5.11.201
-          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
-          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
-          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
-          working_directory: ${{ env.WORKDIR }}
-      - run: |
-          pwd
-          ls -al tests/integration/integration_config.yml
-          head tests/integration/integration_config.yml
-
-      - run: |
-          eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
-          eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_username')
-          eval export SC_PASSWORD=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_password')
-          eval export SC_TIMEOUT=$(cat tests/integration/integration_config.yml | yq '.sc_timeout')
-          ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
-
   integ:
     needs:
       - integ-matrix
@@ -240,12 +190,12 @@ jobs:
           - sc_host: https://10.5.11.201
             test_name: support_tunnel
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.WORKDIR }}
       - name: Print integ time
-        run: echo $(date + "%T") && exit 1
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#        with:
-#          path: ${{ env.WORKDIR }}
+        run: echo "Integ time -> $(date +%T)" && exit 1
 #      - run: pip install ansible-core~=2.13.0
 #      # We have ansible.cfg "for testing" in git repo
 #      # (it is excluded in galaxy.yml, so it is not part of collection artifact)
@@ -261,6 +211,56 @@ jobs:
 #          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
 #          working_directory: ${{ env.WORKDIR }}
 #      - run: ansible-test integration --local ${{ matrix.test_name }}
+
+  examples-run:
+    needs:
+      - examples-matrix
+      # run examples after integ - they will both try to modify say syslog_server etc
+      - integ
+    if: "always() && (needs.examples-matrix.result=='success')"
+    runs-on: [ self-hosted2 ]
+    container: quay.io/justinc1_github/scale_ci_integ:3
+    env:
+      ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
+      DEBIAN_FRONTEND: noninteractive
+    defaults:
+      run:
+        working-directory: ${{ env.WORKDIR }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible: [ 2.13.0 ]
+        example_name: ${{ fromJson(needs.examples-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.WORKDIR }}
+      - name: Print examples-run time
+        run: echo "Integ time -> $(date +%T)"
+#      - run: pip install ansible-core~=${{ matrix.ansible }}
+#      - run: ansible-galaxy collection install community.crypto community.general
+#      - run: ansible-galaxy collection list
+#
+#      # ${{ env.WORKDIR }} cannot be used
+#      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+#        with:
+#          sc_host: https://10.5.11.201
+#          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+#          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+#          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+#          working_directory: ${{ env.WORKDIR }}
+#      - run: |
+#          pwd
+#          ls -al tests/integration/integration_config.yml
+#          head tests/integration/integration_config.yml
+#
+#      - run: |
+#          eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
+#          eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_username')
+#          eval export SC_PASSWORD=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_password')
+#          eval export SC_TIMEOUT=$(cat tests/integration/integration_config.yml | yq '.sc_timeout')
+#          ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
 
   replica_cleanup:
     needs:

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -194,23 +194,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - name: Print integ time
-        run: echo "Integ time -> $(date +%T)" && exit 1
-#      - run: pip install ansible-core~=2.13.0
-#      # We have ansible.cfg "for testing" in git repo
-#      # (it is excluded in galaxy.yml, so it is not part of collection artifact)
-#      # But it does affect ansible-galaxy and ansible-test commands.
-#      - run: ansible-galaxy collection install community.crypto
-#      - run: ansible-galaxy collection list
-#      # ${{ env.WORKDIR }} cannot be used
-#      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
-#        with:
-#          sc_host: ${{ matrix.sc_host }}
-#          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
-#          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
-#          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
-#          working_directory: ${{ env.WORKDIR }}
-#      - run: ansible-test integration --local ${{ matrix.test_name }}
+      - run: pip install ansible-core~=2.13.0
+      # We have ansible.cfg "for testing" in git repo
+      # (it is excluded in galaxy.yml, so it is not part of collection artifact)
+      # But it does affect ansible-galaxy and ansible-test commands.
+      - run: ansible-galaxy collection install community.crypto
+      - run: ansible-galaxy collection list
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          sc_host: ${{ matrix.sc_host }}
+          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          working_directory: ${{ env.WORKDIR }}
+      - run: ansible-test integration --local ${{ matrix.test_name }}
 
   examples-run:
     needs:
@@ -236,31 +234,29 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - name: Print examples-run time
-        run: echo "Integ time -> $(date +%T)"
-#      - run: pip install ansible-core~=${{ matrix.ansible }}
-#      - run: ansible-galaxy collection install community.crypto community.general
-#      - run: ansible-galaxy collection list
-#
-#      # ${{ env.WORKDIR }} cannot be used
-#      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
-#        with:
-#          sc_host: https://10.5.11.201
-#          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
-#          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
-#          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
-#          working_directory: ${{ env.WORKDIR }}
-#      - run: |
-#          pwd
-#          ls -al tests/integration/integration_config.yml
-#          head tests/integration/integration_config.yml
-#
-#      - run: |
-#          eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
-#          eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_username')
-#          eval export SC_PASSWORD=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_password')
-#          eval export SC_TIMEOUT=$(cat tests/integration/integration_config.yml | yq '.sc_timeout')
-#          ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
+      - run: pip install ansible-core~=${{ matrix.ansible }}
+      - run: ansible-galaxy collection install community.crypto community.general
+      - run: ansible-galaxy collection list
+
+      # ${{ env.WORKDIR }} cannot be used
+      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
+        with:
+          sc_host: https://10.5.11.201
+          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
+          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
+          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          working_directory: ${{ env.WORKDIR }}
+      - run: |
+          pwd
+          ls -al tests/integration/integration_config.yml
+          head tests/integration/integration_config.yml
+
+      - run: |
+          eval export SC_HOST=$(cat tests/integration/integration_config.yml | yq '.sc_host')
+          eval export SC_USERNAME=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_username')
+          eval export SC_PASSWORD=$(cat tests/integration/integration_config.yml | yq '.sc_config."https://10.5.11.200".sc_password')
+          eval export SC_TIMEOUT=$(cat tests/integration/integration_config.yml | yq '.sc_timeout')
+          ansible-playbook -i localhost, -e hypercore_example_check_mode=true examples/${{ matrix.example_name }}
 
   replica_cleanup:
     needs:


### PR DESCRIPTION
Examples testing job was always run before the integration testing job which made waiting for integration tests to finish even longer then it was supposed to. This pull request fixes this problem by updating the ``examples-run`` job to make it run after the ``integ`` job finishes regardless of the status.

Jobs ``examples-run`` and ``integ`` can be found in ``.github/workflows/integ-test.yml``.

### Tests:
#### 1. Test if ``examples-run`` is run after ``integ`` job succeeds:
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/5003937671
Timestamp of the last integration test to succeed ([here](https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/5003937671/jobs/8965837295)):
```
Run echo "Integ time -> $(date +%T)" && exit 0
Integ time -> 13:44:08
```

Timestamp of the first example test to run ([here](https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/5003937671/jobs/8965900254)):
```
Run echo "Integ time -> $(date +%T)"
Integ time -> 13:44:30
```
#### 2. Test if ``examples-run`` is run after ``integ`` job fails:
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/5004006697
Timestamp of the last integration test to fail ([here](https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/5004006697/jobs/8966010113)):
```
Run echo "Integ time -> $(date +%T)" && exit 1
Integ time -> 13:51:26
Error: Process completed with exit code 1.
```

Timestamp of the first example test to run ([here](https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/5004006697/jobs/8966072007)):
```
Run echo "Integ time -> $(date +%T)"
Integ time -> 13:51:44
```