### PR TITLE
OIDC login

### DIFF
--- a/.github/actions/make-integ-config/action.yml
+++ b/.github/actions/make-integ-config/action.yml
@@ -19,6 +19,9 @@ inputs:
   oidc_client_secret:
     description: 'oidc_client_secret'
     required: true
+  oidc_users_0_password:
+    description: 'oidc_users_0_password'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -35,6 +38,8 @@ runs:
         smb_share: /cidata
         oidc_client_id: d2298ec0-0596-49d2-9554-840a2fe20603
         oidc_client_secret: ${{ inputs.oidc_client_secret }}
+        oidc_users_0_username: xlabciuser@scalemsdnscalecomputing.onmicrosoft.com
+        oidc_users_0_password: ${{ inputs.oidc_users_0_password }}
         EOF
         cat integ_config_vars.yml | jinja2 --strict tests/integration/integration_config.yml.j2 > tests/integration/integration_config.yml
         echo "sc_host: ${{ inputs.sc_host }}" >> tests/integration/integration_config.yml

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -221,8 +221,12 @@ jobs:
             test_name: support_tunnel
           - sc_host: https://10.5.11.50
             test_name: vm_clone__replicated
+          # test oidc login
           - sc_host: https://10.5.11.50
             test_name: utils_login
+          # test inventory plugin with oidc login
+          - sc_host: https://10.5.11.50
+            test_name: inventory
         exclude:
           # The VSNS were not configured with remote replication cluster.
           - sc_host: https://10.5.11.200

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -74,6 +74,7 @@ jobs:
           sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          oidc_users_0_password: ${{ secrets.OIDC_USERS_0_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
       - run: ansible-playbook tests/integration/prepare/prepare_iso.yml
       - run: ansible-playbook tests/integration/prepare/prepare_vm.yml
@@ -178,6 +179,7 @@ jobs:
           sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          oidc_users_0_password: ${{ secrets.OIDC_USERS_0_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
       - run: |
           pwd
@@ -262,6 +264,7 @@ jobs:
           sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          oidc_users_0_password: ${{ secrets.OIDC_USERS_0_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
       - run: ansible-test integration --local ${{ matrix.test_name }}
 
@@ -289,6 +292,7 @@ jobs:
           sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          oidc_users_0_password: ${{ secrets.OIDC_USERS_0_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
       - run: ansible-galaxy collection install community.general
       - run: ansible-playbook tests/integration/cleanup/ci_replica_cleanup.yml
@@ -313,6 +317,7 @@ jobs:
           sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
+          oidc_users_0_password: ${{ secrets.OIDC_USERS_0_PASSWORD }}
           working_directory: ${{ env.WORKDIR }}
       - run: |
           cd tests/integration/cleanup && ./smb_cleanup.sh \

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -14,6 +14,7 @@ on:
       # dns_config|time_server - NTP cannot be reconfigured if DNS is invalid
       # git_issues - slow, do not run on each push. TODO - run them only once a day
       # oidc_config - during reconfiguration API returns 500/502 errors for other requests
+      # utils_login - it uses OIDC user to login
       # smtp - email_alert test requires a configured SMTP
       # role_cluster_config - role cluster_config reconfigures DNS, SMTP, OIDC. And it is slow.
       # version_update_single_node - role would change version, VSNS system cannot be updated.
@@ -23,7 +24,7 @@ on:
           List integration tests to exclude.
           Use "*" to exclude all tests.
           Use regex like 'node|^git_issue|^dns_config$' to exclude only a subset.
-        default: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$"
+        default: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^utils_login$"
       examples_tests_include:
         type: string
         description: |-
@@ -32,7 +33,7 @@ on:
         default: "iso_info"
 env:
   INTEG_TESTS_INCLUDE_SCHEDULE: "*"
-  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$"
+  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^utils_login$"
   EXAMPLES_TESTS_INCLUDE_SCHEDULE: "*"
   # ansible-test needs special directory structure.
   # WORKDIR is a subdir of GITHUB_WORKSPACE
@@ -220,6 +221,8 @@ jobs:
             test_name: support_tunnel
           - sc_host: https://10.5.11.50
             test_name: vm_clone__replicated
+          - sc_host: https://10.5.11.50
+            test_name: utils_login
         exclude:
           # The VSNS were not configured with remote replication cluster.
           - sc_host: https://10.5.11.200

--- a/plugins/doc_fragments/cluster_instance.py
+++ b/plugins/doc_fragments/cluster_instance.py
@@ -50,13 +50,11 @@ options:
       auth_method:
         description:
           - Select login method.
-          - If not set, the value of the C(SC_AUTH_METHOD) environment
+            If not set, the value of the C(SC_AUTH_METHOD) environment
             variable will be used.
           - Value I(local) - username/password is verified by the HyperCore server (the local users).
           - Value I(oidc) - username/password is verified by the configured OIDC provider.
         default: local
-        choices:
-          - local
-          - oidc
+        choices: [local, oidc]
         type: str
 """

--- a/plugins/doc_fragments/cluster_instance.py
+++ b/plugins/doc_fragments/cluster_instance.py
@@ -47,4 +47,16 @@ options:
             variable will be used.
         required: false
         type: float
+      auth_method:
+        description:
+          - Select login method.
+          - If not set, the value of the C(SC_AUTH_METHOD) environment
+            variable will be used.
+          - Value I(local) - username/password is verified by the HyperCore server (the local users).
+          - Value I(oidc) - username/password is verified by the configured OIDC provider.
+        default: local
+        choices:
+          - local
+          - oidc
+        type: str
 """

--- a/plugins/inventory/hypercore.py
+++ b/plugins/inventory/hypercore.py
@@ -223,6 +223,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         username = os.getenv("SC_USERNAME")
         password = os.getenv("SC_PASSWORD")
         timeout = os.getenv("SC_TIMEOUT")
+        auth_method = os.getenv("SC_AUTH_METHOD")
         if timeout:
             try:
                 timeout = float(timeout)
@@ -234,7 +235,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             raise errors.ScaleComputingError(
                 "Missing one or more parameters: sc_host, sc_username, sc_password."
             )
-        client = Client(host, username, password, timeout)
+        client = Client(host, username, password, timeout, auth_method)
         rest_client = RestClient(client)
         vms = rest_client.list_records("/rest/v1/VirDomain")
 

--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -10,6 +10,7 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import env_fallback
 from typing import Any
+from ..module_utils.client import AuthMethod
 
 # TODO - env from /etc/environment is loaded
 # But when env is set in bash session, env seems to be lost on ssh connection to localhost.
@@ -41,6 +42,12 @@ SHARED_SPECS = dict(
                 type="float",
                 required=False,
                 fallback=(env_fallback, ["SC_TIMEOUT"]),
+            ),
+            auth_method=dict(
+                type="str",
+                default=AuthMethod.local,
+                choices=[am.value for am in AuthMethod],
+                fallback=(env_fallback, ["SC_AUTH_METHOD"]),
             ),
         ),
         required_together=[("username", "password")],

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -84,7 +84,7 @@ class Client:
         self.timeout = timeout
         self.auth_method = auth_method
 
-        self._auth_header: Optional[dict[str, bytes]] = None
+        self._auth_header: Optional[dict[str, str]] = None
         self._client = Request()
 
     @classmethod
@@ -98,15 +98,15 @@ class Client:
         )
 
     @property
-    def auth_header(self) -> dict[str, bytes]:
+    def auth_header(self) -> dict[str, str]:
         if not self._auth_header:
             self._auth_header = self._login()
         return self._auth_header
 
-    def _login(self) -> dict[str, bytes]:
+    def _login(self) -> dict[str, str]:
         return self._login_username_password()
 
-    def _login_username_password(self) -> dict[str, bytes]:
+    def _login_username_password(self) -> dict[str, str]:
         headers = {
             "Accept": "application/json",
             "Content-type": "application/json",

--- a/plugins/module_utils/typed_classes.py
+++ b/plugins/module_utils/typed_classes.py
@@ -21,6 +21,7 @@ class TypedClusterInstance(TypedDict):
     username: str
     password: str
     timeout: float
+    auth_method: str
 
 
 # Registration to ansible return dict.

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -55,6 +55,10 @@ sc_config:
       shared_secret_default: "{{ oidc_client_secret }}"
       config_url_default: https://login.microsoftonline.com/76d4c62a-a9ca-4dc2-9187-e2cc4d9abe7f/v2.0/.well-known/openid-configuration
       scopes: "openid+profile"
+      # Users that can login when config_url_default is configured as OIDC provider
+      users:
+        - username: "{{ oidc_users_0_username }}"
+          password: "{{ oidc_users_0_password }}"
       client_id_test: ci-client-id
       shared_secret_test: ci-client-secret
       config_url_test: https://login.microsoftonline.com/76d4c62a-a9ca-4dc2-9187-e2cc4d9abe7f/v2.0/.well-known/openid-configuration

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -54,23 +54,23 @@ export SC_AUTH_METHOD=local
 ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml run_ansible_both_false_tests.yml
 
 # test with OIDC user
-eval "$(cat <<EOF | python
-import yaml
-with open("$vars_file") as fd:
-    data = yaml.safe_load(fd)
-sc_host=data["sc_host"]
-sc_timeout=data["sc_timeout"]
-print("export SC_HOST='{}'".format(sc_host))
-print("export SC_TIMEOUT='{}'".format(sc_timeout))
-print("export SC_USERNAME='{}'".format(data["sc_config"][sc_host]["oidc"]["users"][0]["username"]))
-print("export SC_PASSWORD='{}'".format(data["sc_config"][sc_host]["oidc"]["users"][0]["password"]))
-print("export SC_AUTH_METHOD=oidc")
-EOF
-)"
 if [[ "$SC_HOST" == "https://10.5.11.50" ]]
 then
     # We can do this only if OIDC login is configured.
     echo "Testing inventory plugin with OIDC user."
+    eval "$(cat <<EOF | python
+    import yaml
+    with open("$vars_file") as fd:
+        data = yaml.safe_load(fd)
+    sc_host=data["sc_host"]
+    sc_timeout=data["sc_timeout"]
+    print("export SC_HOST='{}'".format(sc_host))
+    print("export SC_TIMEOUT='{}'".format(sc_timeout))
+    print("export SC_USERNAME='{}'".format(data["sc_config"][sc_host]["oidc"]["users"][0]["username"]))
+    print("export SC_PASSWORD='{}'".format(data["sc_config"][sc_host]["oidc"]["users"][0]["password"]))
+    print("export SC_AUTH_METHOD=oidc")
+EOF
+    )"
     ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml run_ansible_both_false_tests.yml
 else
     echo "OIDC is not configured on host $SC_HOST, inventory plugin was not tested with OIDC user."

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -12,6 +12,7 @@ print("export SC_HOST='{}'".format(sc_host))
 print("export SC_TIMEOUT='{}'".format(sc_timeout))
 print("export SC_USERNAME='{}'".format(data["sc_config"][sc_host]["sc_username"]))
 print("export SC_PASSWORD='{}'".format(data["sc_config"][sc_host]["sc_password"]))
+# SC_AUTH_METHOD==local by default, leave it unset
 EOF
 )"
 
@@ -45,8 +46,34 @@ ansible-playbook -i localhost, -i hypercore_inventory_ansible_enable.yml run_ans
 ansible-playbook -i localhost, -i hypercore_inventory_ansible_disable.yml run_ansible_disable_tests.yml
 ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_true.yml run_ansible_both_true_tests.yml
 
-unset SC_TIMEOUT  # do one test without SC_TIMEOUT
-
+# do one test without SC_TIMEOUT
+unset SC_TIMEOUT
 ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml run_ansible_both_false_tests.yml
+# test with SC_AUTH_METHOD being set to "local"
+export SC_AUTH_METHOD=local
+ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml run_ansible_both_false_tests.yml
+
+# test with OIDC user
+eval "$(cat <<EOF | python
+import yaml
+with open("$vars_file") as fd:
+    data = yaml.safe_load(fd)
+sc_host=data["sc_host"]
+sc_timeout=data["sc_timeout"]
+print("export SC_HOST='{}'".format(sc_host))
+print("export SC_TIMEOUT='{}'".format(sc_timeout))
+print("export SC_USERNAME='{}'".format(data["sc_config"][sc_host]["oidc"]["users"][0]["username"]))
+print("export SC_PASSWORD='{}'".format(data["sc_config"][sc_host]["oidc"]["users"][0]["password"]))
+print("export SC_AUTH_METHOD=oidc")
+EOF
+)"
+if [[ "$SC_HOST" == "https://10.5.11.50" ]]
+then
+    # We can do this only if OIDC login is configured.
+    echo "Testing inventory plugin with OIDC user."
+    ansible-playbook -i localhost, -i hypercore_inventory_ansible_both_false.yml run_ansible_both_false_tests.yml
+else
+    echo "OIDC is not configured on host $SC_HOST, inventory plugin was not tested with OIDC user."
+fi
 
 ansible-playbook cleanup.yml

--- a/tests/integration/targets/utils_login/tasks/main.yml
+++ b/tests/integration/targets/utils_login/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+# Test modules are able to login to Hypercore.
+# The local or oidc user accounts are supported.
+
+# ===================================================================
+# local user, from environ
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+    SC_AUTH_METHOD: local
+
+  block:
+    - name: Get HC3 ping - local user, from environ
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/ping
+      register: ping_result
+    - &assert_ping_result
+      name: Check ping_result
+      ansible.builtin.assert:
+        that:
+          - ping_result is not changed
+          - ping_result.record.0 == "status"
+
+# ===================================================================
+# local user, from cluster_instance variable
+- vars:
+    cluster_instance:
+      host: "{{ sc_host }}"
+      username: "{{ sc_config[sc_host].sc_username }}"
+      password: "{{ sc_config[sc_host].sc_password }}"
+      auth_method: local
+  block:
+    - name: Get HC3 ping - local user, from cluster_instance variable
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/ping
+        cluster_instance: "{{ cluster_instance }}"
+      register: ping_result
+    - *assert_ping_result
+
+# ===================================================================
+# OIDC user, from environ
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_config[sc_host].oidc.users[0].username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].oidc.users[0].password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+    SC_AUTH_METHOD: oidc
+  block:
+    - name: Get HC3 ping - OIDC user, from environ
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/ping
+      register: ping_result
+    - *assert_ping_result
+
+# ===================================================================
+# OIDC user, from cluster_instance variable
+- vars:
+    cluster_instance: &cluster_instance_local
+      host: "{{ sc_host }}"
+      username: "{{ sc_config[sc_host].oidc.users[0].username }}"
+      password: "{{ sc_config[sc_host].oidc.users[0].password }}"
+      auth_method: oidc
+  block:
+    - name: Get HC3 ping - OIDC user, from cluster_instance variable
+      scale_computing.hypercore.api:
+        action: get
+        endpoint: /rest/v1/ping
+        cluster_instance: "{{ cluster_instance }}"
+      register: ping_result
+    - *assert_ping_result

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -95,7 +95,7 @@ class TestClientAuthHeader:
         resp_mock = mocker.MagicMock()
         resp_mock.status = 200  # Used when testing on Python 3
         resp_mock.read.return_value = (
-            '{"sessionID":"7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}'
+            '{"sessionID":"7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}'.encode("utf-8")
         )
 
         request_mock = mocker.patch.object(client, "Request").return_value

--- a/tests/unit/plugins/module_utils/test_client.py
+++ b/tests/unit/plugins/module_utils/test_client.py
@@ -83,11 +83,11 @@ class TestClientInit:
         with pytest.raises(
             errors.ScaleComputingError, match="Invalid instance host value"
         ):
-            client.Client(host, "user", "pass", None)
+            client.Client(host, "user", "pass", None, "local")
 
     @pytest.mark.parametrize("host", ["http://insecure.host", "https://secure.host"])
     def test_valid_host(self, host):
-        client.Client(host, "user", "pass", None)
+        client.Client(host, "user", "pass", None, "local")
 
 
 class TestClientAuthHeader:
@@ -101,7 +101,7 @@ class TestClientAuthHeader:
         request_mock = mocker.patch.object(client, "Request").return_value
         request_mock.open.return_value = resp_mock
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         assert c.auth_header == {
             "Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"
         }
@@ -109,7 +109,7 @@ class TestClientAuthHeader:
 
 class TestClientRequest:
     def test_request_without_data_success(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         mock_response = client.Response(
             200, '{"returned": "data"}', headers=[("Content-type", "application/json")]
@@ -129,7 +129,7 @@ class TestClientRequest:
         assert resp == mock_response
 
     def test_request_with_data_success(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         mock_response = client.Response(
             200, '{"returned": "data"}', headers=[("Content-type", "application/json")]
@@ -156,7 +156,7 @@ class TestClientRequest:
         request_mock = mocker.patch.object(client, "Request").return_value
         request_mock.open.side_effect = HTTPError("", 401, "Unauthorized", {}, None)
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         with pytest.raises(errors.AuthError):
             c.request("GET", "api/rest/v1/some/path")
@@ -167,7 +167,7 @@ class TestClientRequest:
             "", 404, "Not Found", {}, io.StringIO(to_text("My Error"))
         )
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         resp = c.request("GET", "api/rest/v1/some/path")
 
@@ -179,7 +179,7 @@ class TestClientRequest:
         request_mock = mocker.patch.object(client, "Request").return_value
         request_mock.open.side_effect = URLError("some error")
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
 
         with pytest.raises(errors.ScaleComputingError, match="some error"):
@@ -190,7 +190,7 @@ class TestClientRequest:
         raw_request = mocker.MagicMock(status=200)
         raw_request.read.return_value = "{}"
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         c.request("GET", "api/rest/v1/some path")
 
@@ -204,7 +204,7 @@ class TestClientRequest:
         raw_request = mocker.MagicMock(status=200)
         raw_request.read.return_value = "{}"
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         c.request("GET", "api/rest/v1/some/path", query=query)
 
@@ -225,7 +225,7 @@ class TestClientRequest:
         raw_request = mocker.MagicMock(status=200)
         raw_request.read.return_value = "{}"
 
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         c.request("GET", "api/rest/v1/some/path", query=query)
 
@@ -235,7 +235,7 @@ class TestClientRequest:
         assert parsed_query == dict((k, [str(v)]) for k, v in query.items())
 
     def test_request_without_data_binary_success(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         c._auth_header = {"Cookie": "sessionID=7e3a2a70-7130-41c4-9402-fc0953cc1d7b"}
         mock_response = client.Response(
             200, "data", headers=[("Content-type", "image/apng")]
@@ -263,7 +263,7 @@ class TestClientRequest:
 
 class TestClientGet:
     def test_ok(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         mock_response = client.Response(200, '{"incident": 1}', None)
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
@@ -274,7 +274,7 @@ class TestClientGet:
         assert resp.json == {"incident": 1}
 
     def test_ok_missing(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         mock_response = client.Response(404, "Not Found", None)
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
@@ -284,7 +284,7 @@ class TestClientGet:
         assert resp == mock_response
 
     def test_error(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(403, "forbidden")
 
@@ -292,7 +292,7 @@ class TestClientGet:
             c.get("api/rest/v1/table/incident/1")
 
     def test_query(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(200, '{"incident": 1}', None)
 
@@ -305,7 +305,7 @@ class TestClientGet:
 
 class TestClientPost:
     def test_ok(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         mock_response = client.Response(201, '{"incident": 1}')
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
@@ -316,7 +316,7 @@ class TestClientPost:
         assert resp.json == {"incident": 1}
 
     def test_error(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(400, "bad request")
 
@@ -324,7 +324,7 @@ class TestClientPost:
             c.post("api/rest/v1/table/incident", {"some": "data"})
 
     def test_query(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(201, '{"incident": 1}')
 
@@ -341,7 +341,7 @@ class TestClientPost:
 
 class TestClientPatch:
     def test_ok(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         mock_response = client.Response(200, '{"incident": 1}')
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
@@ -352,7 +352,7 @@ class TestClientPatch:
         assert resp.json == {"incident": 1}
 
     def test_error(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(400, "bad request")
 
@@ -360,7 +360,7 @@ class TestClientPatch:
             c.patch("api/rest/v1/table/incident/1", {"some": "data"})
 
     def test_query(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(200, '{"incident": 1}')
 
@@ -377,7 +377,7 @@ class TestClientPatch:
 
 class TestClientPut:
     def test_ok(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         mock_response = client.Response(200, '{"incident": 1}')
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = mock_response
@@ -388,7 +388,7 @@ class TestClientPut:
         assert resp.json == {"incident": 1}
 
     def test_error(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(400, "bad request")
 
@@ -396,7 +396,7 @@ class TestClientPut:
             c.put("api/rest/v1/table/incident/1", {"some": "data"})
 
     def test_query(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(200, '{"incident": 1}')
 
@@ -415,14 +415,14 @@ class TestClientPut:
 
 class TestClientDelete:
     def test_ok(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(204, {})
 
         c.delete("api/rest/v1/table/resource/1")
 
     def test_error(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(404, "not found")
 
@@ -430,7 +430,7 @@ class TestClientDelete:
             c.delete("api/rest/v1/table/resource/1")
 
     def test_query(self, mocker):
-        c = client.Client("https://instance.com", "user", "pass", None)
+        c = client.Client("https://instance.com", "user", "pass", None, "local")
         request_mock = mocker.patch.object(c, "request")
         request_mock.return_value = client.Response(204, {})
 

--- a/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
+++ b/tests/unit/plugins/module_utils/test_rest_client_CachedRestClient.py
@@ -50,7 +50,7 @@ class TestCachedRestClient:
             query1, query0 = query0, query1
             expected_data1, expected_data0 = expected_data0, expected_data1
 
-        client_obj = client.Client("https://thehost", "user", "pass", None)
+        client_obj = client.Client("https://thehost", "user", "pass", None, "local")
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
         client_mock.return_value = client.Response(200, data, "")
@@ -88,7 +88,7 @@ class TestCachedRestClient:
             else:
                 return client.Response(200, data1, "")
 
-        client_obj = client.Client("https://thehost", "user", "pass", None)
+        client_obj = client.Client("https://thehost", "user", "pass", None, "local")
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
         client_mock.side_effect = mockup_client_get
@@ -118,7 +118,7 @@ class TestCachedRestClient:
         endpoint = "vms"
         data = "[]"
 
-        client_obj = client.Client("https://thehost", "user", "pass", None)
+        client_obj = client.Client("https://thehost", "user", "pass", None, "local")
         cached_client = rest_client.CachedRestClient(client=client_obj)
         client_mock = mocker.patch.object(cached_client.client, "get")
         client_mock.return_value = client.Response(200, data, "")


### PR DESCRIPTION
PR allows collection to login to HyperCore cluster using a username form external OIDC provider. New environ varibale `SC_AUTH_METHOD` (possible value None/unset, `local` or `oidc`) is added as we need to know where is user defined.

Previously we used HTTP basic login for each request. PR first refactored code to get sessionID from HC3 and reuse it for subsequent requests. 

Since OIDC is configured on .50 test cluster only, the CI job `utils_login` will be run only there.
The inventory plugin will run on .200 and .201 VSNS (just as before). But since we do not test OIDC on VSNS, OIDC is not configured there, so now we test inventory plugin on .50 also, and there (and only there) inventory plugin with OIDC user is tested.
