### PR TITLE
Bump expected latest released HyperCore version

### DIFF
--- a/examples/version_update_single_node.yml
+++ b/examples/version_update_single_node.yml
@@ -7,7 +7,7 @@
   check_mode: true
 
   vars:
-    desired_version: 9.1.24.211326
+    desired_version: 9.2.17.211525
 
   tasks:
     - name: Show desired_version

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -141,8 +141,8 @@ sc_config:
     features:
       version_update:
         current_version: "9.1.14.208456"
-        next_version: "9.1.24.211326"
-        latest_version: "9.1.24.211326"
+        next_version: "9.2.17.211525"
+        latest_version: "9.2.17.211525"
         can_be_applied: False
         # We can try update, update will fail, and status.json will be present.
         old_update_status_present: True


### PR DESCRIPTION
In tests we have hardcoded expected HyperCore version. The 9.2.17 is GA (general availability), so this is what our test cluster should report as next available version.

I hate we need to manually bump this string every few weeks. Maybe we should have more complex integration test that could check not only "next_version == 9.2.17.211525", but also "next_version >= 9.2.17.211525".