### PR TITLE
Store HTTP requests/responses into a log file

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,6 +32,15 @@ export SC_USERNAME=admin
 export SC_PASSWORD=admin_pass
 ```
 
+## Debugging
+
+Requests sent to and responses received from HyperCore can be written to a file for debugging.
+Environ variable `SC_DEBUG_LOG_TRAFFIC=1` should be set, and `q` python library needs to be installed.
+The output is written to file `/tmp/q` on Ansible controller.
+
+Note that `/tmp/q` will contain login passwords, HTTP session cookies and other sensitive data.
+It should not be shared around.
+
 # Integration tests configuration
 
 For integration tests we need to configure access to test cluster.


### PR DESCRIPTION
I had problem figuring out why Ansible task fails with "500 Internal server error". The PR helps by logging HTTP requests/responses into a log file, and we can do post-mortem analysis.

My sample problem become obvious. Two subsequent requests are shown:
```
tail -f /tmp/q
41.6s _request: 
      request_in={'data': None, 'headers': {'Accept': 'application/json', 'Cookie': 'sessionID=cad85149-2418-4d17-b5b3-e190d1cf647e'}, 'method': 'DELETE', 'path': 'https://172.31.6.11/rest/v1/VirDomainBlockDevice/a795ef22-4f5b-43e3-94cb-d1fb1ea53462', 'timeout': 60.0},
      request_out={'data': b'{"taskTag":"449","createdUUID":""}', 'headers': {'access-control-allow-origin': '*', 'connection': 'close', 'content-length': '34', 'content-type': 'application/json; charset=utf-8', 'date': 'Mon, 03 Jul 2023 06:34:43 GMT', 'etag': 'W/"22-kVOpzzeFufx3JRxg6nc1xBl9aYI"', 'server': 'nginx', 'strict-transport-security': 'max-age=31536000', 'x-content-type-options': 'nosniff', 'x-frame-options': 'SAMEORIGIN', 'x-openapi-enforcer': 'controller', 'x-powered-by': 'Express', 'x-xss-protection': '1; mode=block'}, 'status': 200}

41.6s _request: 
      request_in={'data': '[{"virDomainUUID":"91a3657a-28d7-4e69-af3e-34d10cab4b1e","actionType":"START","cause":"INTERNAL"}]', 'headers': {'Accept': 'application/json', 'Content-type': 'application/json', 'Cookie': 'sessionID=cad85149-2418-4d17-b5b3-e190d1cf647e'}, 'method': 'POST', 'path': 'https://172.31.6.11/rest/v1/VirDomain/action', 'timeout': 60.0},
      request_out={'data': b'{"error":"An internal error occurred"}', 'headers': {'access-control-allow-origin': '*', 'connection': 'close', 'content-length': '38', 'content-type': 'application/json; charset=utf-8', 'date': 'Mon, 03 Jul 2023 06:34:43 GMT', 'etag': 'W/"26-6QmJuLmMIMO3P2eodnNgF/C4NMI"', 'server': 'nginx', 'x-powered-by': 'Express'}, 'status': 500}
```

After disk delete I forgot to call TaskTag wait, before starting VM.