### PR TITLE
Fix vm disk remove

### DIFF
--- a/plugins/module_utils/disk.py
+++ b/plugins/module_utils/disk.py
@@ -198,9 +198,10 @@ class Disk(PayloadMapper):
         # Delete and change type.
         if desired_disk and action == "update" and self.type != desired_disk.type:
             return True
-        if (
-            action == "delete" and self.type == "ide_cdrom"
-        ):  # ide_cdrom can never be deleted when VM is running.
+        if action == "delete" and self.type == "ide_cdrom":
+            # ide_cdrom can never be deleted when VM is running.
+            # Also other disks types cannot be deleted when VM is running
+            # if HyperCore thinks disk is being "used".
             return True
         return False
 

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -7,7 +7,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from typing import Union
+import json
+from typing import Union, Dict, Any
 from ansible.module_utils.urls import Request
 
 
@@ -111,3 +112,14 @@ class ScaleTimeoutError(ScaleComputingError):
     def __init__(self, data: Union[str, Exception]):
         self.message = f"Request timed out: {data}."
         super(ScaleTimeoutError, self).__init__(self.message)
+
+
+class TaskTagError(ScaleComputingError):
+    def __init__(self, task_status: Dict[Any, Any]):
+        # task_status is dict returned by GET /rest/v1/TaskTag
+        message = "There was a problem during this task execution."
+        message += f" Task details: {json.dumps(task_status)}"
+        self.message = message
+        self.task_status_state = task_status["state"]
+        self.task_status = task_status
+        super().__init__(self.message)

--- a/plugins/module_utils/task_tag.py
+++ b/plugins/module_utils/task_tag.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 __metaclass__ = type
 
-import json
 from time import sleep
 
 from ..module_utils import errors
@@ -47,9 +46,7 @@ class TaskTag:
                 "ERROR",
                 "UNINITIALIZED",
             ):  # TaskTag has finished unsucessfully or was never initialized, both are errors.
-                msg = "There was a problem during this task execution."
-                msg += f" Task details: {json.dumps(task_status)}"
-                raise errors.ScaleComputingError(msg)
+                raise errors.TaskTagError(task_status)
             if task_status.get("state", "") not in (
                 "RUNNING",
                 "QUEUED",

--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -1250,6 +1250,7 @@ class ManageVMDisks:
             changed = cls._delete_not_used_disks(
                 module, rest_client, vm_before, changed, disk_key
             )
+        vm_before.vm_power_up(module, rest_client)
         if called_from_vm_disk:
             vm_after, disks_after = cls.get_vm_by_name(module, rest_client)
             return (

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -18,6 +18,13 @@ short_description: Create, update or delete a VM.
 description:
   - Use this module to create, update or delete a VM. When creating or
     updating a VM, setting the disks, network nics and boot order is possible.
+
+  - Module tries to remove disks from a running VM.
+    If disk cannot be removed from running VM,
+    then VM will be shutdown, disk will be removed, and VM is started back.
+  - VM has C(shutdown_timeout) time to respond to shutdown request.
+    If VM is not shutoff within I(shutdown_timeout),
+    then a force shutdown will be issued if C(force_reboot=True).
 version_added: 1.0.0
 extends_documentation_fragment:
   - scale_computing.hypercore.cluster_instance

--- a/plugins/modules/vm_disk.py
+++ b/plugins/modules/vm_disk.py
@@ -332,6 +332,7 @@ def ensure_absent(module, rest_client):
         )
         TaskTag.wait_task(rest_client, task_tag, module.check_mode)
         changed = True
+    vm_before.vm_power_up(module, rest_client)
     vm_after, disks_after = ManageVMDisks.get_vm_by_name(module, rest_client)
     return (
         changed,
@@ -344,15 +345,12 @@ def ensure_absent(module, rest_client):
 def run(module, rest_client):
     # ensure_absent is located in modules/vm_disk.py, since it's only used here
     # ensure_present_or_set is located in module_utils/vm.py, since it's also used in module vm.
-    vm, disks = ManageVMDisks.get_vm_by_name(module, rest_client)
     if module.params["state"] == "absent":
         changed, records, diff, reboot = ensure_absent(module, rest_client)
     else:
         changed, records, diff, reboot = ManageVMDisks.ensure_present_or_set(
             module, rest_client, MODULE_PATH
         )
-    if vm:
-        vm.vm_power_up(module, rest_client)
     return changed, records, diff, reboot
 
 

--- a/plugins/modules/vm_disk.py
+++ b/plugins/modules/vm_disk.py
@@ -15,21 +15,28 @@ author:
   - Tjaž Eržen (@tjazsch)
 short_description: Manage VM's disks
 description:
-  Use this module to add, delete or set disks to the VM.
-  The module can also remove all disks from a VM,
-  attach and/or detach ISO image to the VM by ISO's name,
-  detach ISO image from the VM by disk's disk slot,
-  or update the existing disks (disk size etc.).
+  - Use this module to add, delete or set disks to the VM.
+    The module can also remove all disks from a VM,
+    attach and/or detach ISO image to the VM by ISO's name,
+    detach ISO image from the VM by disk's disk slot,
+    or update the existing disks (disk size etc.).
 
-  For a given VM, a particular disk is selected by combination of (I(type), I(disk_slot)).
-  I(disk_slot) means slot on bus (IDE, virtio or SCSI bus).
+  - For a given VM, a particular disk is selected by combination of (I(type), I(disk_slot)).
+    I(disk_slot) means slot on bus (IDE, virtio or SCSI bus).
 
-  Changing disk I(type) can change its I(disk_slot).
-  For example, VM has one IDE CD-ROM and one virtio_disk.
-  The disk will have C(type=virtio_disk) and C(disk_slot=0),
-  and CD-ROM will have C(type=ide_cdrom) and C(disk_slot=0).
-  Changing disk I(type) to C(ide_disk) will as place disk on IDE bus,
-  after the CD-ROM, and disk will get C(disk_slot=1).
+  - Changing disk I(type) can change its I(disk_slot).
+    For example, VM has one IDE CD-ROM and one virtio_disk.
+    The disk will have C(type=virtio_disk) and C(disk_slot=0),
+    and CD-ROM will have C(type=ide_cdrom) and C(disk_slot=0).
+    Changing disk I(type) to C(ide_disk) will as place disk on IDE bus,
+    after the CD-ROM, and disk will get C(disk_slot=1).
+
+  - Module tries to remove disks from a running VM.
+    If disk cannot be removed from running VM,
+    then VM will be shutdown, disk will be removed, and VM is started back.
+  - VM has C(shutdown_timeout) time to respond to shutdown request.
+    If VM is not shutoff within I(shutdown_timeout),
+    then a force shutdown will be issued if C(force_reboot=True).
 
 version_added: 1.0.0
 extends_documentation_fragment:

--- a/tests/integration/targets/vm__remove_disk/tasks/01_remove_disk_stopped.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/01_remove_disk_stopped.yml
@@ -1,0 +1,102 @@
+---
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+
+- name: Delete the VMs, if they exist from before
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prepare
+- name: Dummy task to store VM definition {{ vm_name_a }}
+  scale_computing.hypercore.vm: &vm_a_definition
+    vm_name: "{{ vm_name_a }}"
+    state: present
+    description: VM remove disk CI test
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 1
+    attach_guest_tools_iso: false
+    power_state: stop
+    nics: []
+    boot_devices: []
+  when: False
+
+# Create VM a
+- name: Create the VM {{ vm_name_a }}
+  scale_computing.hypercore.vm:
+    <<: *vm_a_definition
+    disks:
+      - type: ide_disk
+        disk_slot: 0
+        size: "{{ '10 GB' | human_to_bytes }}"
+      - type: ide_disk
+        disk_slot: 1
+        size: "{{ '11 GB' | human_to_bytes }}"
+  register: vm_result
+- name: Get info about VM {{ vm_name_a }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name_a }}"
+  register: vm_info_a_initial_result
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.record.0.description == "VM remove disk CI test"
+      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.disks | length == 2
+      - vm_result.vm_rebooted == False
+      - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
+      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.power_state == "stopped"
+      - vm_info_a_initial_result.records.0.disks | length == 2
+
+# ------------------------------------------------------------------------------------------------------------------
+# Remove disk from stopped VM
+# Shutdown is not allowed, and also not needed.
+- name: Remove disk from stopped VM
+  block: &remove_disk_from_vm
+    - name: Remove disk from stopped VM {{ vm_name_a }}
+      scale_computing.hypercore.vm:
+        <<: *vm_a_definition
+        disks:
+          # remove 1st disk, keep 2nd disk
+          - type: ide_disk
+            disk_slot: 1
+            size: "{{ '11 GB' | human_to_bytes }}"
+        force_reboot: True
+        shutdown_timeout: "{{ shutdown_timeout }}"
+      register: vm_result
+    - name: Get info about VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name_a }}"
+      register: vm_info_a_result
+    - ansible.builtin.assert:
+        that:
+          - vm_result is succeeded
+          - vm_result.vm_rebooted == False
+          - vm_result.record.0.power_state == "stopped"
+          - vm_result.record.0.disks | length == 1
+          - vm_info_a_result.records.0.power_state == "stopped"
+          - vm_info_a_result.records.0.disks | length == 1
+          - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+
+- name: Remove disk from stopped VM - idempotence
+  block:
+    *remove_disk_from_vm
+- ansible.builtin.assert:
+    that:
+      - vm_result is not changed
+
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete the VMs
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"

--- a/tests/integration/targets/vm__remove_disk/tasks/02_remove_disk_running.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/02_remove_disk_running.yml
@@ -1,0 +1,95 @@
+---
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+
+- name: Delete the VMs, if they exist from before
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prepare
+- name: Dummy task to store VM definition {{ vm_name_a }}
+  scale_computing.hypercore.vm: &vm_a_definition
+    vm_name: "{{ vm_name_a }}"
+    state: present
+    description: VM remove disk CI test
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 1
+    attach_guest_tools_iso: false
+    power_state: start
+    nics: []
+    boot_devices: []
+  when: False
+
+# Create VM a
+- name: Create the VM {{ vm_name_a }}
+  scale_computing.hypercore.vm:
+    <<: *vm_a_definition
+    disks:
+      - type: ide_disk
+        disk_slot: 0
+        size: "{{ '10 GB' | human_to_bytes }}"
+      - type: ide_disk
+        disk_slot: 1
+        size: "{{ '11 GB' | human_to_bytes }}"
+  register: vm_result
+- name: Get info about VM {{ vm_name_a }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name_a }}"
+  register: vm_info_a_initial_result
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.record.0.description == "VM remove disk CI test"
+      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.disks | length == 2
+      - vm_result.vm_rebooted == False
+      - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
+      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.power_state == "started"
+      - vm_info_a_initial_result.records.0.disks | length == 2
+
+# ------------------------------------------------------------------------------------------------------------------
+# Remove disk from running VM
+# Shutdown is not allowed, and module will fail.
+- name: Remove disk from running VM
+  block: &remove_disk_from_vm
+    - name: Remove disk from running VM {{ vm_name_a }}
+      scale_computing.hypercore.vm:
+        <<: *vm_a_definition
+        disks:
+          # remove 1st disk, keep 2nd disk
+          - type: ide_disk
+            disk_slot: 1
+            size: "{{ '11 GB' | human_to_bytes }}"
+        force_reboot: False
+        shutdown_timeout: "{{ shutdown_timeout }}"
+      register: vm_result
+      ignore_errors: True
+    - name: Get info about VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name_a }}"
+      register: vm_info_a_result
+    - ansible.builtin.assert:
+        that:
+          - vm_result is failed
+          - vm_result is not changed
+          - vm_info_a_result.records.0.power_state == "started"
+          - vm_info_a_result.records.0.disks | length == 2
+          - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.0.uuid
+          - vm_info_a_result.records.0.disks.1.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
+
+- name: Remove disk from running VM - idempotence
+  block:
+    *remove_disk_from_vm
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete the VMs
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"

--- a/tests/integration/targets/vm__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
@@ -30,10 +30,10 @@
   scale_computing.hypercore.vm:
     <<: *vm_a_definition
     disks:
-      - type: ide_disk
+      - type: "{{ disk_type }}"
         disk_slot: 0
         size: "{{ '10 GB' | human_to_bytes }}"
-      - type: ide_disk
+      - type: "{{ disk_type }}"
         disk_slot: 1
         size: "{{ '11 GB' | human_to_bytes }}"
   register: vm_result
@@ -47,6 +47,8 @@
       - vm_result.record.0.description == "VM remove disk CI test"
       - vm_result.record.0.vm_name == "{{ vm_name_a }}"
       - vm_result.record.0.disks | length == 2
+      - vm_result.record.0.disks.0.type  == disk_type
+      - vm_result.record.0.disks.1.type  == disk_type
       - vm_result.vm_rebooted == False
       - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
       - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
@@ -55,7 +57,9 @@
 
 # ------------------------------------------------------------------------------------------------------------------
 # Remove disk from running VM
-# Shutdown is allowed, and needed.
+# Force shutdown is allowed, and for disk_type:
+#  - ide_disk: force shutdown is needed to remove disk.
+#  - virtio_disk: in some HC3 versions disk can be removed from a running VM.
 - name: Remove disk from running VM with reboot
   block: &remove_disk_from_vm
     - name: Remove disk from running VM {{ vm_name_a }}
@@ -63,7 +67,7 @@
         <<: *vm_a_definition
         disks:
           # remove 1st disk, keep 2nd disk
-          - type: ide_disk
+          - type: "{{ disk_type }}"
             disk_slot: 1
             size: "{{ '11 GB' | human_to_bytes }}"
         force_reboot: True
@@ -78,11 +82,12 @@
           - vm_result is succeeded
           - vm_info_a_result.records.0.power_state == "started"
           - vm_info_a_result.records.0.disks  | length == 1
+          - vm_info_a_result.records.0.disks.0.type  == disk_type
           - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
 - ansible.builtin.assert:
     that:
       - vm_result is changed
-      - vm_result.vm_rebooted == True
+      - vm_result.vm_rebooted == expected_vm_reboot
 
 - name: Remove disk from running VM with reboot - idempotence
   block:

--- a/tests/integration/targets/vm__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
@@ -1,0 +1,100 @@
+---
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+
+- name: Delete the VMs, if they exist from before
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prepare
+- name: Dummy task to store VM definition {{ vm_name_a }}
+  scale_computing.hypercore.vm: &vm_a_definition
+    vm_name: "{{ vm_name_a }}"
+    state: present
+    description: VM remove disk CI test
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 1
+    attach_guest_tools_iso: false
+    power_state: start
+    nics: []
+    boot_devices: []
+  when: False
+
+# Create VM a
+- name: Create the VM {{ vm_name_a }}
+  scale_computing.hypercore.vm:
+    <<: *vm_a_definition
+    disks:
+      - type: ide_disk
+        disk_slot: 0
+        size: "{{ '10 GB' | human_to_bytes }}"
+      - type: ide_disk
+        disk_slot: 1
+        size: "{{ '11 GB' | human_to_bytes }}"
+  register: vm_result
+- name: Get info about VM {{ vm_name_a }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name_a }}"
+  register: vm_info_a_initial_result
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.record.0.description == "VM remove disk CI test"
+      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.disks | length == 2
+      - vm_result.vm_rebooted == False
+      - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
+      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.power_state == "started"
+      - vm_info_a_initial_result.records.0.disks | length == 2
+
+# ------------------------------------------------------------------------------------------------------------------
+# Remove disk from running VM
+# Shutdown is allowed, and needed.
+- name: Remove disk from running VM with reboot
+  block: &remove_disk_from_vm
+    - name: Remove disk from running VM {{ vm_name_a }}
+      scale_computing.hypercore.vm:
+        <<: *vm_a_definition
+        disks:
+          # remove 1st disk, keep 2nd disk
+          - type: ide_disk
+            disk_slot: 1
+            size: "{{ '11 GB' | human_to_bytes }}"
+        force_reboot: True
+        shutdown_timeout: "{{ shutdown_timeout }}"
+      register: vm_result
+    - name: Get info about VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name_a }}"
+      register: vm_info_a_result
+    - ansible.builtin.assert:
+        that:
+          - vm_result is succeeded
+          - vm_info_a_result.records.0.power_state == "started"
+          - vm_info_a_result.records.0.disks  | length == 1
+          - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.vm_rebooted == True
+
+- name: Remove disk from running VM with reboot - idempotence
+  block:
+    *remove_disk_from_vm
+- ansible.builtin.assert:
+    that:
+      - vm_result is not changed
+      - vm_result.vm_rebooted == False
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete the VMs
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"

--- a/tests/integration/targets/vm__remove_disk/tasks/main.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# This is a part of the vm module; testing vm disk remove
+# disk remove might require VM to be shutdown, or maybe VM can remain running.
+# Module should shutdown VM only if it is allowed to shutdown (force_reboot=True) and
+# if disk cannot be removed without shutdown.
+
+# Test with IDE disk, remove fails much faster compared to virtio disk (2 vs 60 sec).
+# See also https://github.com/ScaleComputing/HyperCoreAnsibleCollection/issues/249
+
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+  vars:
+     vm_name_a: "vm--remove-disk--a"
+     vm_names_all:
+       - "{{ vm_name_a }}"
+     shutdown_timeout: 30
+
+  block:
+    - include_tasks: 01_remove_disk_stopped.yml
+    - include_tasks: 02_remove_disk_running.yml
+    - include_tasks: 03_remove_disk_running_with_reboot.yml

--- a/tests/integration/targets/vm__remove_disk/tasks/main.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/main.yml
@@ -22,3 +22,19 @@
     - include_tasks: 01_remove_disk_stopped.yml
     - include_tasks: 02_remove_disk_running.yml
     - include_tasks: 03_remove_disk_running_with_reboot.yml
+      vars:
+        disk_type: ide_disk
+        expected_vm_reboot: True
+    - name: Get HyperCore version
+      scale_computing.hypercore.cluster_info:
+      register: cluster_info
+    - include_tasks: 03_remove_disk_running_with_reboot.yml
+      vars:
+        disk_type: virtio_disk
+        # HyperCore 9.1.14 could remove disk from running VM
+        # HyperCore 9.2.13, 9.2.17 could not remove disk from running VM
+        expected_vm_reboot: "{{ cluster_info.record.icos_version.startswith('9.2') }}"
+    - include_tasks: 03_remove_disk_running_with_reboot.yml
+      vars:
+        disk_type: scsi_disk
+        expected_vm_reboot: False

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/01_remove_disk_stopped.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/01_remove_disk_stopped.yml
@@ -1,0 +1,96 @@
+---
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+
+- name: Delete the VMs, if they exist from before
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prepare
+# Create VM a
+- name: Create the VM {{ vm_name_a }}
+  scale_computing.hypercore.vm:
+    vm_name: "{{ vm_name_a }}"
+    state: present
+    description: VM remove disk CI test
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 1
+    attach_guest_tools_iso: false
+    power_state: stop
+    nics: []
+    boot_devices: []
+    disks:
+      - type: ide_disk
+        disk_slot: 0
+        size: "{{ '10 GB' | human_to_bytes }}"
+      - type: ide_disk
+        disk_slot: 1
+        size: "{{ '11 GB' | human_to_bytes }}"
+  register: vm_result
+- name: Get info about VM {{ vm_name_a }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name_a }}"
+  register: vm_info_a_initial_result
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.record.0.description == "VM remove disk CI test"
+      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.disks | length == 2
+      - vm_result.vm_rebooted == False
+      - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
+      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.power_state == "stopped"
+      - vm_info_a_initial_result.records.0.disks | length == 2
+
+# ------------------------------------------------------------------------------------------------------------------
+# Remove disk from stopped VM
+# Shutdown is not allowed, and also not needed.
+- name: Remove disk from stopped VM
+  block: &remove_disk_from_vm
+    - name: Remove disk from stopped VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_disk:
+        vm_name: "{{ vm_name_a }}"
+        state: set
+        items:
+          # remove 1st disk, keep 2nd disk
+          - type: ide_disk
+            disk_slot: 1
+            size: "{{ '11 GB' | human_to_bytes }}"
+        force_reboot: True
+        shutdown_timeout: "{{ shutdown_timeout }}"
+      register: vm_disk_result
+    - name: Get info about VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name_a }}"
+      register: vm_info_a_result
+    - ansible.builtin.assert:
+        that:
+          - vm_disk_result is succeeded
+          - vm_disk_result.vm_rebooted == False
+          - vm_info_a_result.records.0.power_state == "stopped"
+          - vm_info_a_result.records.0.disks | length == 1
+          - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
+- ansible.builtin.assert:
+    that:
+      - vm_disk_result is changed
+
+- name: Remove disk from stopped VM - idempotence
+  block:
+    *remove_disk_from_vm
+- ansible.builtin.assert:
+    that:
+      - vm_disk_result is not changed
+
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete the VMs
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/02_remove_disk_running.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/02_remove_disk_running.yml
@@ -1,0 +1,91 @@
+---
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+
+- name: Delete the VMs, if they exist from before
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prepare
+# Create VM a
+- name: Create the VM {{ vm_name_a }}
+  scale_computing.hypercore.vm:
+    vm_name: "{{ vm_name_a }}"
+    state: present
+    description: VM remove disk CI test
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 1
+    attach_guest_tools_iso: false
+    power_state: start
+    nics: []
+    boot_devices: []
+    disks:
+      - type: ide_disk
+        disk_slot: 0
+        size: "{{ '10 GB' | human_to_bytes }}"
+      - type: ide_disk
+        disk_slot: 1
+        size: "{{ '11 GB' | human_to_bytes }}"
+  register: vm_result
+- name: Get info about VM {{ vm_name_a }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name_a }}"
+  register: vm_info_a_initial_result
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.record.0.description == "VM remove disk CI test"
+      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.disks | length == 2
+      - vm_result.vm_rebooted == False
+      - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
+      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.power_state == "started"
+      - vm_info_a_initial_result.records.0.disks | length == 2
+
+# ------------------------------------------------------------------------------------------------------------------
+# Remove disk from running VM
+# Shutdown is not allowed, and module will fail.
+- name: Remove disk from running VM
+  block: &remove_disk_from_vm
+    - name: Remove disk from running VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_disk:
+        vm_name: "{{ vm_name_a }}"
+        state: set
+        items:
+          # remove 1st disk, keep 2nd disk
+          - type: ide_disk
+            disk_slot: 1
+            size: "{{ '11 GB' | human_to_bytes }}"
+        force_reboot: False
+        shutdown_timeout: "{{ shutdown_timeout }}"
+      register: vm_disk_result
+      ignore_errors: True
+    - name: Get info about VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name_a }}"
+      register: vm_info_a_result
+    - ansible.builtin.assert:
+        that:
+          - vm_disk_result is failed
+          - vm_disk_result is not changed
+          - vm_info_a_result.records.0.power_state == "started"
+          - vm_info_a_result.records.0.disks | length == 2
+          - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.0.uuid
+          - vm_info_a_result.records.0.disks.1.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
+
+- name: Remove disk from running VM - idempotence
+  block:
+    *remove_disk_from_vm
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete the VMs
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
@@ -1,0 +1,96 @@
+---
+# ------------------------------------------------------------------------------------------------------------------
+# Cleanup
+
+- name: Delete the VMs, if they exist from before
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"
+
+# ------------------------------------------------------------------------------------------------------------------
+# Prepare
+# Create VM a
+- name: Create the VM {{ vm_name_a }}
+  scale_computing.hypercore.vm:
+    vm_name: "{{ vm_name_a }}"
+    state: present
+    description: VM remove disk CI test
+    tags:
+      - Xlab
+    memory: "{{ '512 MB' | human_to_bytes }}"
+    vcpu: 1
+    attach_guest_tools_iso: false
+    power_state: start
+    nics: []
+    boot_devices: []
+    disks:
+      - type: ide_disk
+        disk_slot: 0
+        size: "{{ '10 GB' | human_to_bytes }}"
+      - type: ide_disk
+        disk_slot: 1
+        size: "{{ '11 GB' | human_to_bytes }}"
+  register: vm_result
+- name: Get info about VM {{ vm_name_a }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ vm_name_a }}"
+  register: vm_info_a_initial_result
+- ansible.builtin.assert:
+    that:
+      - vm_result is changed
+      - vm_result.record.0.description == "VM remove disk CI test"
+      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.disks | length == 2
+      - vm_result.vm_rebooted == False
+      - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
+      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.power_state == "started"
+      - vm_info_a_initial_result.records.0.disks | length == 2
+
+# ------------------------------------------------------------------------------------------------------------------
+# Remove disk from running VM
+# Shutdown is allowed, and needed.
+- name: Remove disk from running VM with reboot
+  block: &remove_disk_from_vm
+    - name: Remove disk from running VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_disk:
+        vm_name: "{{ vm_name_a }}"
+        state: set
+        items:
+          # remove 1st disk, keep 2nd disk
+          - type: ide_disk
+            disk_slot: 1
+            size: "{{ '11 GB' | human_to_bytes }}"
+        force_reboot: True
+        shutdown_timeout: "{{ shutdown_timeout }}"
+      register: vm_disk_result
+    - name: Get info about VM {{ vm_name_a }}
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name_a }}"
+      register: vm_info_a_result
+    - ansible.builtin.assert:
+        that:
+          - vm_disk_result is succeeded
+          - vm_info_a_result.records.0.power_state == "started"
+          - vm_info_a_result.records.0.disks | length == 1
+          - vm_info_a_result.records.0.disks.0.uuid == vm_info_a_initial_result.records.0.disks.1.uuid
+- ansible.builtin.assert:
+    that:
+      - vm_disk_result is changed
+      - vm_disk_result.vm_rebooted == True
+
+- name: Remove disk from running VM with reboot - idempotence
+  block:
+    *remove_disk_from_vm
+- ansible.builtin.assert:
+    that:
+      - vm_disk_result is not changed
+      - vm_disk_result.vm_rebooted == False
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+- name: Delete the VMs
+  scale_computing.hypercore.vm:
+    vm_name: "{{ item }}"
+    state: absent
+  loop: "{{ vm_names_all }}"

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/main.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# This is a part of the vm module; testing vm disk remove
+# disk remove might require VM to be shutdown, or maybe VM can remain running.
+# Module should shutdown VM only if it is allowed to shutdown (force_reboot=True) and
+# if disk cannot be removed without shutdown.
+
+# Test with IDE disk, remove fails much faster compared to virtio disk (2 vs 60 sec).
+# See also https://github.com/ScaleComputing/HyperCoreAnsibleCollection/issues/249
+
+- environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+  vars:
+     vm_name_a: "vm-disk--remove-disk--a"
+     vm_names_all:
+       - "{{ vm_name_a }}"
+     shutdown_timeout: 30
+
+  block:
+    - include_tasks: 01_remove_disk_stopped.yml
+    - include_tasks: 02_remove_disk_running.yml
+    - include_tasks: 03_remove_disk_running_with_reboot.yml


### PR DESCRIPTION
Sometimes we can remove disk from a running VM, and sometimes we need to shutdown VM before disk can be removed. It depends on HyperCore thinking VM might be using the disk.

The PR:
- first tries to remove disk from a running VM (the behaviour before this PR)
- if this fails, it shutdowns VM, tries delete a second time and start VM back

Integration tests for all this is included, for `vm` and `vm_disk` modules. It covers 3 cases:
- VM being off
- VM running and cannot be shutdown (it does not respond to nice shutdown, and force shutdown is not allowed)
- VM running and can be shutdown (force shutdown is allowed)

A small bug in vm_disk module was also fixed. The module didn't start back VM if it was shutdown during execution.