### PR TITLE
Fix bug - default type of version_update_single_node_shutdown_wait_time

### DIFF
--- a/roles/version_update_single_node/tasks/shutdown_vms.yml
+++ b/roles/version_update_single_node/tasks/shutdown_vms.yml
@@ -13,7 +13,7 @@
 # Wait up to 300 sec (30*10)
 - name: Wait until VMs shutdown
   ansible.builtin.include_tasks: wait_vm_shutdown.yml
-  loop: "{{ range(0, (version_update_single_node_shutdown_wait_time / 10.0) | round(0, 'ceil') | int) | list }}"
+  loop: "{{ range(0, ((version_update_single_node_shutdown_wait_time | float) / 10.0) | round(0, 'ceil') | int) | list }}"
   when: not version_update_single_node_all_vms_stopped
 
 - name: Force shutdown the remaining running VMs


### PR DESCRIPTION
Default value of version_update_single_node_shutdown_wait_time is str, not int. This is because default value is computed in roles/version_update_single_node/defaults/main.yml.

Fixes #257