### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -366,9 +366,7 @@ jobs:
       - run: ansible-playbook tests/integration/cleanup/ci_replica_cleanup.yml
 
   smb_cleanup:
-    needs:
-      - integ
-      - integ-seq
+    needs: []
     runs-on: [self-hosted2]
     container: quay.io/justinc1_github/scale_ci_integ:8
     defaults:

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -339,9 +339,7 @@ jobs:
       - run: ansible-test integration --local ${{ matrix.test_name }}
 
   replica_cleanup:
-    needs:
-      - integ
-      - integ-seq
+    needs: []
     runs-on: [self-hosted2]
     container: quay.io/justinc1_github/scale_ci_integ:8
     env:

--- a/examples/version_update_single_node.yml
+++ b/examples/version_update_single_node.yml
@@ -7,7 +7,7 @@
   check_mode: true
 
   vars:
-    desired_version: 9.2.17.211525
+    desired_version: 9.2.22.212325
 
   tasks:
     - name: Show desired_version

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -173,14 +173,9 @@ class Client:
                 )
                 q_log(request_in, request_out)
             return resp
-        except Exception as ex:
+        except Exception as exception:
             if SC_DEBUG_LOG_TRAFFIC:
-                request_out = dict(
-                    status=resp.status,
-                    data=resp.data,
-                    headers=resp.headers,
-                )
-                q_log(request_in, exception=ex)
+                q_log(request_in, exception)
             raise
 
     def _request_no_log(

--- a/tests/integration/cleanup/ci_replica_cleanup.yml
+++ b/tests/integration/cleanup/ci_replica_cleanup.yml
@@ -4,8 +4,9 @@
 - name: Find VM replicas on replication-destination cluster
   hosts: localhost
   connection: local
-  gather_facts: false
+  gather_facts: true
   vars:
+    min_replica_age: 2 * 24*60*60
     replication_dest_cluster:
       host: "{{ sc_config[sc_host].sc_replication_dest_host }}"
       username: "{{ sc_config[sc_host].sc_replication_dest_username }}"
@@ -41,13 +42,15 @@
     # ==================================================================
     # destination cluster
     - name: Get info about all VMs
-      scale_computing.hypercore.vm_info:
+      scale_computing.hypercore.api:
         cluster_instance: "{{ replication_dest_cluster }}"
-      register: vm_info_result
+        action: get
+        endpoint: /rest/v1/VirDomain
+      register: vm_api_info_result
 
     - name: Show VM count before
       ansible.builtin.debug:
-        msg: count={{ vm_info_result.records | count }}
+        msg: count={{ vm_api_info_result.record | count }}
 
     - name: Find VMs with tag=Xlab and tag=CI
       ansible.builtin.set_fact:
@@ -55,10 +58,10 @@
 
     - name: Find VMs with tag=Xlab and tag=CI
       ansible.builtin.set_fact:
-        remove_vms: "{{ remove_vms + ([{'uuid': vm.uuid, 'vm_name': vm.vm_name}] if ('Xlab' in vm.tags  and 'CI' in vm.tags) else [])  }}"
-      loop: "{{ vm_info_result.records }}"
+        remove_vms: "{{ remove_vms + ([{'uuid': vmapi.uuid, 'vm_name': vmapi.name}] if ('Xlab' in (vmapi.tags | split(',')) and (ansible_date_time.epoch_int | int - vmapi.latestTaskTag.modified | int) > min_replica_age | int) else []) }}"
+      loop: "{{ vm_api_info_result.record }}"
       loop_control:
-        loop_var: vm
+        loop_var: vmapi
 
     - name: Show VM UUIDs to be removes
       ansible.builtin.debug:

--- a/tests/integration/cleanup/smb_cleanup.sh
+++ b/tests/integration/cleanup/smb_cleanup.sh
@@ -21,7 +21,7 @@ delete_files () {
     files="$(echo "$list_dir" | head --lines=-2 | tail --lines=+3)"
     echo "files=$files"
 
-    today_date=$(date +'%b:%-d:%Y')
+    today_date=$(date +'%b:%Y')
     echo "Todays date: $today_date"
 
     while IFS= read -r line
@@ -33,7 +33,8 @@ delete_files () {
         continue
       fi
       filename="$(echo "$line" | awk '{print $1}')"
-      file_date=$(echo "$line" | awk '{print $5":"$6":"$8}')
+      # file_date=$(echo "$line" | awk '{print $5":"$6":"$8}')  # "Apr:27:2020"
+      file_date=$(echo "$line" | awk '{print $5":"$8}')  # "Apr:2020"
       if [ "$file_date" == "$today_date" ]
       then
         echo "Keeping file $filename, timestamp is $file_date"

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -141,8 +141,8 @@ sc_config:
     features:
       version_update:
         current_version: "9.1.14.208456"
-        next_version: "9.2.17.211525"
-        latest_version: "9.2.17.211525"
+        next_version: "9.2.22.212325"
+        latest_version: "9.2.22.212325"
         can_be_applied: False
         # We can try update, update will fail, and status.json will be present.
         old_update_status_present: True
@@ -176,8 +176,8 @@ sc_config:
     features:
       version_update:
         current_version: "9.2.13.211102"
-        next_version: ""
-        latest_version: ""
+        next_version: "9.2.22.212325"
+        latest_version: "9.2.22.212325"
         can_be_applied: False
         old_update_status_present: False
       virtual_disk:


### PR DESCRIPTION
Only small fixes. The debug HTTP request logging can be enabled with `SC_DEBUG_LOG_TRAFFIC=1` environ variable.  The code crashed if request timed out, as we wanted to log HTTP response, but variable was not set.

The CI test need to expect 9.2.17.211525 as available update (HyperCore version upgrade).

The cleanup on SMB server is modified to run even if tests fail. The cleanup will remove all files not from current month (before: not from current day). This cloud interfere with tests on first/last day of month, but in practice we should not have a problem as the cleanup will be scheduled before tests.

Similar for DR target cluster, we will remove all VMs older that 2 days. Should not interfere with tests at all.
Here we remove all old replicated VMs with tag "Xlab" (before tag Xlab and CI was needed; but we forgot to include "CI" string in some tests, so VMs were not removed).