### PR TITLE
Fix for machine_type on HyperCore 9.3

### DIFF
--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -588,12 +588,12 @@ class VM(PayloadMapper):
             dom["cloudInitData"] = cloud_init_payload
         options = dict(attachGuestToolsISO=payload["attachGuestToolsISO"])
         if hcversion.verify(">=9.3.0"):
-            machine_type_keyword = (
-                VmMachineType.from_ansible_to_hypercore_machine_type_keyword(
-                    self.machine_type
+            if self.machine_type:
+                machine_type_keyword = (
+                    VmMachineType.from_ansible_to_hypercore_machine_type_keyword(
+                        self.machine_type
+                    )
                 )
-            )
-            if machine_type_keyword:
                 options.update(dict(machineTypeKeyword=machine_type_keyword))
         return dict(dom=dom, options=options)
 

--- a/tests/integration/targets/vm__min_params/tasks/main.yml
+++ b/tests/integration/targets/vm__min_params/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+# This is a part of the vm module.
+# The main vm test was divided into smaller tests for sake of synchronous testing.
+
+# HC3 9.3 added machine_type_keyword
+# There was a corner case when omitted machine_type was not correctly handled.
+- name: Test VM create with minimum parameters
+  environment:
+    SC_HOST: "{{ sc_host }}"
+    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
+    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+    SC_TIMEOUT: "{{ sc_timeout }}"
+  vars:
+    vm_name: "vm-min-params"
+
+  block:
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+    - &delete-vm
+      name: Delete the minimal params VM if it exists from before
+      scale_computing.hypercore.vm:
+        vm_name: "{{ vm_name }}"
+        state: absent
+      register: vm_deleted
+
+# ----------------------------------Job-------------------------------------------------------------------------------------
+    - &create-vm
+      name: Create the VM using minimal params
+      scale_computing.hypercore.vm:
+        vm_name: "{{ vm_name }}"
+        state: present
+        memory: "{{ '512 MB' | human_to_bytes }}"
+        vcpu: 2
+        disks: []
+        nics: []
+        boot_devices: []
+      register: vm_created
+    - ansible.builtin.assert:
+        that:
+          - vm_created is succeeded
+          - vm_created is changed
+    - &test-create-vm
+      ansible.builtin.assert:
+        that:
+          - vm_created.record.0.description == ""
+          - vm_created.record.0.memory == 536870912
+          - vm_created.record.0.tags == [""]
+          - vm_created.record.0.vcpu == 2
+          - vm_created.record.0.vm_name == "{{ vm_name }}"
+          - vm_created.record.0.disks | length == 0
+          - vm_created.record.0.nics | length == 0
+          - vm_created.record.0.boot_devices | length == 0
+          - vm_created.record.0.power_state == "started"
+          - vm_created.record.0.machine_type == "BIOS"
+
+    - &vm-info
+      name: Retrieve info about minimal params VM
+      scale_computing.hypercore.vm_info:
+        vm_name: "{{ vm_name }}"
+      register: vm_created
+    - &test-vm-info
+      ansible.builtin.assert:
+        that:
+          - vm_created.records.0.description == ""
+          - vm_created.records.0.memory == 536870912
+          - vm_created.records.0.tags == [""]
+          - vm_created.records.0.vcpu == 2
+          - vm_created.records.0.vm_name == "{{ vm_name }}"
+          - vm_created.records.0.disks | length == 0
+          - vm_created.records.0.nics | length == 0
+          - vm_created.records.0.boot_devices | length == 0
+          - vm_created.records.0.power_state == "started"
+          - vm_created.records.0.machine_type == "BIOS"
+
+# ----------------------------------Idempotence check------------------------------------------------------------------------
+    - name: Create the VM using minimal params - Idempotence
+      <<: *create-vm
+    - ansible.builtin.assert:
+        that:
+          - vm_created is succeeded
+          - vm_created is not changed
+    - *test-create-vm
+    - name: Retrieve info about minimal params VM - Idempotence
+      <<: *vm-info
+    - *test-vm-info
+
+# ----------------------------------Cleanup--------------------------------------------------------------------------------
+    - name: Delete the minimal params VM
+      <<: *delete-vm

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -31,6 +31,10 @@ from ansible_collections.scale_computing.hypercore.plugins.module_utils.task_tag
     TaskTag,
 )
 
+from ansible_collections.scale_computing.hypercore.plugins.module_utils.hypercore_version import (
+    HyperCoreVersion,
+)
+
 
 @pytest.fixture
 def client(mocker):
@@ -193,3 +197,10 @@ def run_main_info(mocker):
         basic.AnsibleModule, exit_json=exit_json_mock, fail_json=fail_json_mock
     )
     return runner
+
+
+@pytest.fixture
+def hcversion(mocker, version_str="9.2.0.112233"):
+    hcv = HyperCoreVersion(rest_client=None)  # type: ignore
+    hcv._version = version_str
+    return hcv

--- a/tests/unit/plugins/modules/test_vm.py
+++ b/tests/unit/plugins/modules/test_vm.py
@@ -1110,7 +1110,7 @@ class TestEnsurePresent:
             True,
         )
 
-    def test_ensure_present_create_vm_no_boot_devices_power_state_is_shutdown(
+    def test_ensure_present_create_vm_no_boot_devices_power_state_is_shutdown_v92(
         self, create_module, rest_client, task_wait, mocker
     ):
         module = create_module(
@@ -1141,6 +1141,7 @@ class TestEnsurePresent:
 
         rest_client.get_record.side_effect = [
             None,
+            dict(icosVersion="9.2.0.12345"),
             dict(
                 uuid="id",
                 nodeUUID="",
@@ -1275,7 +1276,173 @@ class TestEnsurePresent:
             False,
         )
 
-    def test_ensure_present_create_vm_boot_devices_set_power_state_is_shutdown(
+    def test_ensure_present_create_vm_no_boot_devices_power_state_is_shutdown_v93(
+        self, create_module, rest_client, task_wait, mocker
+    ):
+        module = create_module(
+            params=dict(
+                cluster_instance=dict(
+                    host="https://0.0.0.0",
+                    username="admin",
+                    password="admin",
+                ),
+                vm_name="VM-name-unique",
+                description="desc",
+                memory=42,
+                vcpu=2,
+                power_state="shutdown",
+                state="present",
+                tags="",
+                disks=[],
+                nics=[],
+                boot_devices=[],
+                attach_guest_tools_iso=None,
+                cloud_init=dict(
+                    user_data=None,
+                    meta_data=None,
+                ),
+                machine_type="BIOS",
+            ),
+        )
+
+        rest_client.get_record.side_effect = [
+            None,
+            dict(icosVersion="9.3.0.12345"),
+            dict(
+                uuid="id",
+                nodeUUID="",
+                name="VM-name-unique",
+                tags="XLAB-test-tag1,XLAB-test-tag2",
+                description="desc",
+                mem=42,
+                state="SHUTDOWN",
+                numVCPU=2,
+                netDevs=[],
+                blockDevs=[],
+                bootDevices=[],
+                attachGuestToolsISO=False,
+                operatingSystem=None,
+                affinityStrategy={
+                    "strictAffinity": False,
+                    "preferredNodeUUID": "",
+                    "backupNodeUUID": "",
+                },
+                snapshotScheduleUUID="snapshot-id",
+                machineType="scale-7.2",
+                sourceVirDomainUUID="",
+                snapUUIDs=[],
+            ),
+            dict(
+                uuid="id",
+                nodeUUID="",
+                name="VM-name-unique",
+                tags="XLAB-test-tag1,XLAB-test-tag2",
+                description="desc",
+                mem=42,
+                state="SHUTDOWN",
+                numVCPU=2,
+                netDevs=[],
+                blockDevs=[],
+                bootDevices=[],
+                attachGuestToolsISO=False,
+                operatingSystem=None,
+                affinityStrategy={
+                    "strictAffinity": False,
+                    "preferredNodeUUID": "",
+                    "backupNodeUUID": "",
+                },
+                snapshotScheduleUUID="snapshot-id",
+                machineType="scale-7.2",
+                sourceVirDomainUUID="",
+                snapUUIDs=[],
+            ),
+        ]
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.Node.get_node"
+        ).return_value = None
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
+        ).return_value = None
+        rest_client.create_record.return_value = {
+            "taskTag": 123,
+            "createdUUID": "",
+        }
+        result = vm.ensure_present(module, rest_client)
+        assert result == (
+            True,
+            [
+                {
+                    "attach_guest_tools_iso": False,
+                    "boot_devices": [],
+                    "description": "desc",
+                    "disks": [],
+                    "machine_type": "BIOS",
+                    "memory": 42,
+                    "nics": [],
+                    "node_affinity": {
+                        "backup_node": {
+                            "backplane_ip": "",
+                            "lan_ip": "",
+                            "node_uuid": "",
+                            "peer_id": None,
+                        },
+                        "preferred_node": {
+                            "backplane_ip": "",
+                            "lan_ip": "",
+                            "node_uuid": "",
+                            "peer_id": None,
+                        },
+                        "strict_affinity": False,
+                    },
+                    "operating_system": None,
+                    "power_state": "shutdown",
+                    "replication_source_vm_uuid": "",
+                    "snapshot_schedule": "",
+                    "tags": ["XLAB-test-tag1", "XLAB-test-tag2"],
+                    "uuid": "id",
+                    "vcpu": 2,
+                    "vm_name": "VM-name-unique",
+                }
+            ],
+            {
+                "after": {
+                    "attach_guest_tools_iso": False,
+                    "boot_devices": [],
+                    "description": "desc",
+                    "disks": [],
+                    "machine_type": "BIOS",
+                    "memory": 42,
+                    "nics": [],
+                    "node_affinity": {
+                        "backup_node": {
+                            "backplane_ip": "",
+                            "lan_ip": "",
+                            "node_uuid": "",
+                            "peer_id": None,
+                        },
+                        "preferred_node": {
+                            "backplane_ip": "",
+                            "lan_ip": "",
+                            "node_uuid": "",
+                            "peer_id": None,
+                        },
+                        "strict_affinity": False,
+                    },
+                    "operating_system": None,
+                    "power_state": "shutdown",
+                    "replication_source_vm_uuid": "",
+                    "snapshot_schedule": "",
+                    "tags": ["XLAB-test-tag1", "XLAB-test-tag2"],
+                    "uuid": "id",
+                    "vcpu": 2,
+                    "vm_name": "VM-name-unique",
+                },
+                "before": None,
+            },
+            False,
+        )
+
+    def test_ensure_present_create_vm_boot_devices_set_power_state_is_shutdown_v92(
         self, create_module, rest_client, task_wait, mocker
     ):
         module = create_module(
@@ -1320,6 +1487,7 @@ class TestEnsurePresent:
 
         rest_client.get_record.side_effect = [
             None,
+            dict(icosVersion="9.2.0.12345"),
             dict(
                 uuid="id",
                 nodeUUID="",
@@ -1546,7 +1714,7 @@ class TestEnsurePresent:
             False,
         )
 
-    def test_ensure_present_no_boot_devices_set_power_state_is_not_shutdown(
+    def test_ensure_present_no_boot_devices_set_power_state_is_not_shutdown_v92(
         self, create_module, rest_client, task_wait, mocker
     ):
         module = create_module(
@@ -1583,6 +1751,7 @@ class TestEnsurePresent:
 
         rest_client.get_record.side_effect = [
             None,
+            dict(icosVersion="9.2.0.12345"),
             dict(
                 uuid="id",
                 nodeUUID="",


### PR DESCRIPTION
On HyperCore v9.3 we can POST `machineTypeKeyword` instead of `machineType`. In addition, GET responses have new possible values for `machineType`.

Fixes #262
