### PR TITLE
Ci for 9.3

### DIFF
--- a/tests/integration/prepare/prepare_iso.yml
+++ b/tests/integration/prepare/prepare_iso.yml
@@ -14,6 +14,7 @@
       username: "{{ sc_config[sc_host].sc_username }}"
       password: "{{ sc_config[sc_host].sc_password }}"
       timeout: "{{ sc_timeout }}"
+    expected_iso_size: 356352
   vars_files:
     - ../integration_config.yml
 
@@ -22,30 +23,53 @@
     ansible.builtin.debug:
       msg: SC_HOST={{ lookup('ansible.builtin.env', 'SC_HOST') }} sc_host={{ sc_host }}
 
-  - name: Delete the ISO image (if it may exist)
-    scale_computing.hypercore.iso:
+  - name: Get integration-test.iso and integration-test-disk.iso info
+    scale_computing.hypercore.iso_info:
       cluster_instance: "{{ cluster_instance }}"
       name: "{{ item }}"
-      state: absent
+    register: iso_info_all
     loop:
-        - integration-test.iso
-        - integration-test-disk.iso
+      - integration-test.iso
+      - integration-test-disk.iso
 
-  - name: Create a text file
-    command: touch integration.txt
+  - name: Show existing ISO size
+    debug:
+      msg: |
+        name={{ iso_info_all.results.0.item }} size={{ iso_info_all.results.0.records.0.size | default(omit) }}
+        name={{ iso_info_all.results.1.item }} size={{ iso_info_all.results.1.records.0.size | default(omit) }}
 
-  - name: Create an ISO file
-    command: genisoimage -output integration.iso integration.txt
+  - name: Recreate ISOs if needed
+    when: |
+      not (
+        ((iso_info_all.results.1.records.0.size | default(0)) == expected_iso_size)
+        and
+        ((iso_info_all.results.0.records.0.size | default(0)) == expected_iso_size)
+      )
+    block:
+      - name: Delete the ISO image (if it may exist)
+        scale_computing.hypercore.iso:
+          cluster_instance: "{{ cluster_instance }}"
+          name: "{{ item }}"
+          state: absent
+        loop:
+          - integration-test.iso
+          - integration-test-disk.iso
 
-  - name: Upload ISO image integration-test.iso to HyperCore API
-    scale_computing.hypercore.iso:
-      cluster_instance: "{{ cluster_instance }}"
-      name: "{{ item }}"
-      source: "integration.iso"
-      state: present
-    loop:
-        - integration-test.iso
-        - integration-test-disk.iso
+      - name: Create a text file
+        command: touch integration.txt
+
+      - name: Create an ISO file
+        command: genisoimage -output integration.iso integration.txt
+
+      - name: Upload ISO image integration-test.iso to HyperCore API
+        scale_computing.hypercore.iso:
+          cluster_instance: "{{ cluster_instance }}"
+          name: "{{ item }}"
+          source: "integration.iso"
+          state: present
+        loop:
+            - integration-test.iso
+            - integration-test-disk.iso
 
   - name: Get integration-test.iso info
     scale_computing.hypercore.iso_info:
@@ -57,6 +81,7 @@
         - uploaded_iso_info.records | length > 0
         - uploaded_iso_info.records.0.name == "integration-test.iso"
         - uploaded_iso_info.records.0.ready_for_insert is true
+        - uploaded_iso_info.records.0.size == expected_iso_size
 
   - name: Get integration-test-disk.iso info
     scale_computing.hypercore.iso_info:
@@ -68,6 +93,7 @@
         - uploaded_iso_info.records | length > 0
         - uploaded_iso_info.records.0.name == "integration-test-disk.iso"
         - uploaded_iso_info.records.0.ready_for_insert is true
+        - uploaded_iso_info.records.0.size == expected_iso_size
 
   # =========================================================================================
   # prepare other ISO images we use.
@@ -99,7 +125,7 @@
           state: present
         when: uploaded_iso_info.records == []
 
-      - name: Get integration-test-disk.iso info
+      - name: Get {{ iso_filename }} info
         scale_computing.hypercore.iso_info:
           cluster_instance: "{{ cluster_instance }}"
           name: "{{ iso_filename }}"

--- a/tests/integration/targets/i_vm_params/tasks/main.yml
+++ b/tests/integration/targets/i_vm_params/tasks/main.yml
@@ -64,6 +64,7 @@
       power_state: stop
       snapshot_schedule: "{{ snapshot_schedule.record[0].name }}"
       force_reboot: True
+      shutdown_timeout: 10
     register: output
   - ansible.builtin.assert:
       that:

--- a/tests/integration/targets/iso/tasks/main.yml
+++ b/tests/integration/targets/iso/tasks/main.yml
@@ -23,33 +23,33 @@
 
     - name: Delete the ISO image (if it may exist)
       scale_computing.hypercore.iso: &iso-delete
-        name: "TinyCore-iso-integration.iso"
+        name: "ci-upload-iso-integration.iso"
         state: absent
       register: result
 
     - name: Create a text file
-      command: touch integration.txt
+      command: touch ci-upload-iso-integration.txt
 
     - name: Create an ISO file
-      command: genisoimage -output integration.iso integration.txt
+      command: genisoimage -output ci-upload-iso-integration.iso ci-upload-iso-integration.txt
 
-    - name: Upload ISO image TinyCore-iso-integration.iso to HyperCore API
+    - name: Upload ISO image ci-upload-iso-integration.iso to HyperCore API
       scale_computing.hypercore.iso: &iso-upload
-        name: "TinyCore-iso-integration.iso"
-        source: "integration.iso"
+        name: "ci-upload-iso-integration.iso"
+        source: "ci-upload-iso-integration.iso"
         state: present
       register: result
 
     - name: Assert that ISO image has been uploaded and that the image is ready for insertion
       scale_computing.hypercore.iso_info:
-        name: TinyCore-iso-integration.iso
+        name: ci-upload-iso-integration.iso
       register: result
     - ansible.builtin.assert:
         that:
           - "{{result.records.0.ready_for_insert}} is true"
 
 
-    - name: Upload ISO image TinyCore-iso-integration.iso to HyperCore API (test idempotence)
+    - name: Upload ISO image ci-upload-iso-integration.iso to HyperCore API (test idempotence)
       scale_computing.hypercore.iso: *iso-upload
       register: result
     - ansible.builtin.assert:
@@ -62,7 +62,7 @@
 
     - name: Verify that deletion was successful
       scale_computing.hypercore.iso_info:
-        name: TinyCore-iso-integration.iso
+        name: ci-upload-iso-integration.iso
       register: result
     - ansible.builtin.assert:
         that:
@@ -70,16 +70,16 @@
 
     - name: Delete locally installed ISO image from current dir
       ansible.builtin.file:
-        path: integration.iso
+        path: ci-upload-iso-integration.iso
         state: absent
       register: file_deleted
     - ansible.builtin.assert:
         that:
           file_deleted is changed
 
-    - name: Assert that TinyCore-iso-integration.iso is not in iso_info result any more
+    - name: Assert that ci-upload-iso-integration.iso is not in iso_info result any more
       scale_computing.hypercore.iso_info:
-        name: TinyCore-iso-integration.iso
+        name: ci-upload-iso-integration.iso
       register: result
     - ansible.builtin.assert:
         that:

--- a/tests/integration/targets/vm__remove_disk/tasks/main.yml
+++ b/tests/integration/targets/vm__remove_disk/tasks/main.yml
@@ -32,8 +32,8 @@
       vars:
         disk_type: virtio_disk
         # HyperCore 9.1.14 could remove disk from running VM
-        # HyperCore 9.2.13, 9.2.17 could not remove disk from running VM
-        expected_vm_reboot: "{{ cluster_info.record.icos_version.startswith('9.2') }}"
+        # HyperCore 9.2.13, 9.2.17, 9.3.1 could not remove disk from running VM
+        expected_vm_reboot: "{{ cluster_info.record.icos_version is version('9.2', '>=') }}"
     - include_tasks: 03_remove_disk_running_with_reboot.yml
       vars:
         disk_type: scsi_disk

--- a/tests/integration/targets/vm_boot_devices/tasks/main.yml
+++ b/tests/integration/targets/vm_boot_devices/tasks/main.yml
@@ -32,22 +32,9 @@
       scale_computing.hypercore.iso_info:
         name: "integration-test.iso"
       register: uploaded_iso_info
-
-    - name: Create a text file
-      command: touch integration.txt
-      when: uploaded_iso_info.records | length == 0
-
-    - name: Create an ISO file
-      command: genisoimage -output integration.iso integration.txt
-      when: uploaded_iso_info.records | length == 0
-
-    - name: Upload ISO image integration-test.iso to HyperCore API
-      scale_computing.hypercore.iso:
-        name: "integration-test.iso"
-        source: "integration.iso"
-        state: present
-      when: uploaded_iso_info.records | length == 0
-      register: result
+    - ansible.builtin.assert:
+        that:
+          - uploaded_iso_info.records | length == 1
 
     - name: Set a couple of disks
       scale_computing.hypercore.vm_disk:

--- a/tests/integration/targets/vm_disk/tasks/main.yml
+++ b/tests/integration/targets/vm_disk/tasks/main.yml
@@ -133,28 +133,26 @@
           - result is changed
           - result.record | length == 0
 
+    # The file should be already created by prepare_iso.yml
     - name: Get integration-test.iso info
       scale_computing.hypercore.iso_info:
         name: "integration-test.iso"
       register: uploaded_iso_info
+    - ansible.builtin.assert:
+        that:
+          - uploaded_iso_info.records | length == 1
+          - uploaded_iso_info.records.0.size == 356352
 
-    - name: Create a text file
-      command: touch integration.txt
-      when: uploaded_iso_info.records | length == 0
-
-    - name: Create an ISO file
-      command: genisoimage -output integration.iso integration.txt
-      when: uploaded_iso_info.records | length == 0
-
-    - name: Upload ISO image integration-test.iso to HyperCore API
-      scale_computing.hypercore.iso:
+    - name: Get integration-test-disk.iso info
+      scale_computing.hypercore.iso_info:
         name: "integration-test-disk.iso"
-        source: "integration.iso"
-        state: present
-      when: uploaded_iso_info.records | length == 0
-      register: result
+      register: uploaded_iso_info
+    - ansible.builtin.assert:
+        that:
+          - uploaded_iso_info.records | length == 1
+          - uploaded_iso_info.records.0.size == 356352
 
-    - name: Attach integration.iso ISO onto the current CD-ROM device
+    - name: Attach integration-test-disk.iso ISO onto the current CD-ROM device
       scale_computing.hypercore.vm_disk: &create-cdrom-disk
         vm_name: vm-integration-test-disks
         items:
@@ -258,12 +256,6 @@
           - result is succeeded
           - result is changed
           - result.record == []
-
-    - name: Delete locally installed ISO image from current dir
-      ansible.builtin.file:
-        path: integration.iso
-        state: absent
-      register: file_deleted
 
     - name: Delete the VM on which the tests were performed
       scale_computing.hypercore.vm: *vm-delete

--- a/tests/unit/plugins/modules/test_snapshot_schedule.py
+++ b/tests/unit/plugins/modules/test_snapshot_schedule.py
@@ -43,7 +43,7 @@ class TestEnsureAbsent:
             name="SnapshotSchedule-test-name",
             rrules=[],
         )
-        rest_client.delete_record.return_value = None
+        rest_client.delete_record.return_value = dict(taskTag="", createdUUID="")
         result = snapshot_schedule.ensure_absent(module, rest_client)
         assert result == (
             True,


### PR DESCRIPTION
We were missing wait on tasktag for SnapshotSchedule create, and wait on object begin delete for SnapshotSchedule and VirtualDisk.

Other changes are just small CI speedup, and fix how CI test check if HyperCore version >= 9.2.