### PR TITLE
Remove duplicated email alerts

### DIFF
--- a/plugins/module_utils/email_alert.py
+++ b/plugins/module_utils/email_alert.py
@@ -18,7 +18,7 @@ from ..module_utils.typed_classes import (
     TypedEmailAlertToAnsible,
     TypedEmailAlertFromAnsible,
 )
-from typing import Union, Any, Dict, Optional
+from typing import Union, Any, Dict, Optional, List
 
 
 class EmailAlert(PayloadMapper):
@@ -98,7 +98,7 @@ class EmailAlert(PayloadMapper):
         ansible_dict: Dict[Any, Any],
         rest_client: RestClient,
         must_exist: bool = False,
-    ):
+    ) -> Optional[EmailAlert]:
         query = get_query(ansible_dict, "uuid", ansible_hypercore_map=dict(uuid="uuid"))
         hypercore_dict = rest_client.get_record(
             "/rest/v1/AlertEmailTarget", query, must_exist=must_exist
@@ -112,7 +112,7 @@ class EmailAlert(PayloadMapper):
         ansible_dict: Dict[Any, Any],
         rest_client: RestClient,
         must_exist: bool = False,
-    ):
+    ) -> Optional[EmailAlert]:
         query = get_query(
             ansible_dict,
             "email",
@@ -124,6 +124,26 @@ class EmailAlert(PayloadMapper):
 
         alert_email_from_hypercore = EmailAlert.from_hypercore(hypercore_dict)
         return alert_email_from_hypercore
+
+    @classmethod
+    def list_by_email(
+        cls,
+        ansible_dict: Dict[Any, Any],
+        rest_client: RestClient,
+    ) -> List[EmailAlert]:
+        query = get_query(
+            ansible_dict,
+            "email",
+            ansible_hypercore_map=dict(email="emailAddress"),
+        )
+        hypercore_dict_list = rest_client.list_records(
+            "/rest/v1/AlertEmailTarget", query
+        )
+
+        alert_email_from_hypercore_list = [
+            EmailAlert.from_hypercore(hc_dict) for hc_dict in hypercore_dict_list
+        ]
+        return alert_email_from_hypercore_list
 
     @classmethod
     def get_state(

--- a/tests/integration/targets/email_alert/tasks/01_email_alert_info.yml
+++ b/tests/integration/targets/email_alert/tasks/01_email_alert_info.yml
@@ -1,18 +1,73 @@
 ---
-- environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+# =================================================================
+# Empty cluster, no email alerts
+- include_tasks: helper_api_email_alert_delete_all.yml
 
-  block:
-    - name: Retrieve info about Email alert recipients
-      scale_computing.hypercore.email_alert_info:
-      register: emails
-    - ansible.builtin.debug:
-        var: emails
-    - ansible.builtin.assert:
-        that:
-          - emails.records != []
-          - emails.records[0].keys() | sort ==
-            ['alert_tag_uuid', 'email', 'latest_task_tag',
-            'resend_delay', 'silent_period', 'uuid']
+- name: Retrieve info about Email alert recipients
+  scale_computing.hypercore.email_alert_info:
+  register: emails
+- ansible.builtin.debug:
+    var: emails
+- ansible.builtin.assert:
+    that:
+      - emails.records == []
+
+# =================================================================
+# One email alerts
+- name: API add email aa
+  include_tasks: helper_api_email_alert_create_one.yml
+  vars:
+    email_alert_email: "{{ email_aa }}"
+
+- name: Retrieve info about Email alert recipients
+  scale_computing.hypercore.email_alert_info:
+  register: emails
+- ansible.builtin.debug:
+    var: emails
+- ansible.builtin.assert:
+    that:
+      - emails.records | length == 1
+      - emails.records[0].keys() | sort ==
+        ['alert_tag_uuid', 'email', 'latest_task_tag',
+        'resend_delay', 'silent_period', 'uuid']
+      - emails.records[0].email == email_aa
+
+# =================================================================
+# Two email alerts
+- name: API add email bb
+  include_tasks: helper_api_email_alert_create_one.yml
+  vars:
+    email_alert_email: "{{ email_bb }}"
+
+- name: Retrieve info about Email alert recipients
+  scale_computing.hypercore.email_alert_info:
+  register: emails
+- ansible.builtin.debug:
+    var: emails
+- ansible.builtin.assert:
+    that:
+      - emails.records | length == 2
+      - emails.records[0].keys() | sort ==
+        ['alert_tag_uuid', 'email', 'latest_task_tag',
+        'resend_delay', 'silent_period', 'uuid']
+      - emails.records | map(attribute='email') | sort == email_all | sort
+
+# =================================================================
+# Three email alerts - one email is duplicated
+- name: API add email bb duplicated
+  include_tasks: helper_api_email_alert_create_one.yml
+  vars:
+    email_alert_email: "{{ email_bb }}"
+
+- name: Retrieve info about Email alert recipients
+  scale_computing.hypercore.email_alert_info:
+  register: emails
+- ansible.builtin.debug:
+    var: emails
+- ansible.builtin.assert:
+    that:
+      - emails.records | length == 3
+      - emails.records[0].keys() | sort ==
+        ['alert_tag_uuid', 'email', 'latest_task_tag',
+        'resend_delay', 'silent_period', 'uuid']
+      - emails.records | map(attribute='email') | sort == (email_all + [email_bb]) | sort

--- a/tests/integration/targets/email_alert/tasks/02_email_alert.yml
+++ b/tests/integration/targets/email_alert/tasks/02_email_alert.yml
@@ -1,200 +1,177 @@
 ---
-- environment:
-    SC_HOST: "{{ sc_host }}"
-    SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
-    SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
+- name: Prepare for test - cleanup (also test Remove with loop)
+  include_tasks: helper_api_email_alert_delete_all.yml
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - info.records == []
+      - info.records|length == 0|int
 
-  vars:
-    new_email: new@test.com
-    create_email: test@test.com
-    new_email_2: new_2@test.com
-    create_email_2: test_2@test.com
+# -----------------------------------------------------------
 
-  block:
-    - name: Get starting emails
-      scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.set_fact:
-        starting_emails: "{{ info.records }}"
+- name: Create new Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: "{{ create_email }}"
+    state: present
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == True
+      - result.diff.before != result.diff.after
+- ansible.builtin.assert: &test0
+    that:
+      - result.record != {}
+      - result.record.keys() | sort ==
+        ['alert_tag_uuid', 'email', 'latest_task_tag',
+        'resend_delay', 'silent_period', 'uuid']
+      - info.records|length == 1|int
+      - info.records[0].email == "{{ create_email }}"
 
-    # -----------------------------------------------------------
+- name: Create new Email Alert Recipient - idempotence
+  scale_computing.hypercore.email_alert:
+    email: "{{ create_email }}"
+    state: present
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == False
+      - result.diff.before == result.diff.after
+- ansible.builtin.assert: *test0
 
-    - name: Prepare for test - cleanup (also test Remove with loop)
-      scale_computing.hypercore.email_alert:
-        email: "{{ item.email }}"
-        state: absent
-      loop: "{{ starting_emails }}"
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - info.records == []
-          - info.records|length == 0|int
+- name: Modify existing Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: "{{ create_email }}"
+    email_new: "{{ new_email }}"
+    state: present
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == True
+      - result.diff.before != result.diff.after
+- ansible.builtin.assert: &test1
+    that:
+      - result.record != {}
+      - result.record.keys() | sort ==
+        ['alert_tag_uuid', 'email', 'latest_task_tag',
+        'resend_delay', 'silent_period', 'uuid']
+      - info.records|length == 1|int
 
-    # -----------------------------------------------------------
-
-    - name: Create new Email Alert Recipient
-      scale_computing.hypercore.email_alert:
-        email: "{{ create_email }}"
-        state: present
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == True
-          - result.diff.before != result.diff.after
-    - ansible.builtin.assert: &test0
-        that:
-          - result.record != {}
-          - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email', 'latest_task_tag',
-            'resend_delay', 'silent_period', 'uuid']
-          - info.records|length == 1|int
-          - info.records[0].email == "{{ create_email }}"
-
-    - name: Create new Email Alert Recipient - idempotence
-      scale_computing.hypercore.email_alert:
-        email: "{{ create_email }}"
-        state: present
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == False
-          - result.diff.before == result.diff.after
-    - ansible.builtin.assert: *test0
-
-    - name: Modify existing Email Alert Recipient
-      scale_computing.hypercore.email_alert:
-        email: "{{ create_email }}"
-        email_new: "{{ new_email }}"
-        state: present
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == True
-          - result.diff.before != result.diff.after
-    - ansible.builtin.assert: &test1
-        that:
-          - result.record != {}
-          - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email', 'latest_task_tag',
-            'resend_delay', 'silent_period', 'uuid']
-          - info.records|length == 1|int
-
-    - name: Modify existing Email Alert Recipient - idempotence
-      scale_computing.hypercore.email_alert:
-        email: "{{ create_email }}"
-        email_new: "{{ new_email }}"
-        state: present
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == False
-          - result.diff.before == result.diff.after
-    - ansible.builtin.assert: *test1
+- name: Modify existing Email Alert Recipient - idempotence
+  scale_computing.hypercore.email_alert:
+    email: "{{ create_email }}"
+    email_new: "{{ new_email }}"
+    state: present
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == False
+      - result.diff.before == result.diff.after
+- ansible.builtin.assert: *test1
 
 
-    - name: Modify existing Email Alert Recipient - email==email_new
-      scale_computing.hypercore.email_alert:
-        email: "{{ new_email }}"
-        email_new: "{{ new_email }}"
-        state: present
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == False
-          - result.diff.before == result.diff.after
-          - info.records|length == 1|int
-          - result.record != {}
-          - result.record.keys() | sort ==
-            ['alert_tag_uuid', 'email', 'latest_task_tag',
-            'resend_delay', 'silent_period', 'uuid']
+- name: Modify existing Email Alert Recipient - email==email_new
+  scale_computing.hypercore.email_alert:
+    email: "{{ new_email }}"
+    email_new: "{{ new_email }}"
+    state: present
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == False
+      - result.diff.before == result.diff.after
+      - info.records|length == 1|int
+      - result.record != {}
+      - result.record.keys() | sort ==
+        ['alert_tag_uuid', 'email', 'latest_task_tag',
+        'resend_delay', 'silent_period', 'uuid']
 
-    # Sending email can fail.
-    # We are using external SMTP server, and email address is from external domain.
-    # Either of two might not work.
-    # Try to resend after delay.
-    # Alternatives:
-    # - Set up a dedicated SMTP server, and use it during test.
-    #   It will have IP, but no DNS domain.
-    # - Use a temp email address from some public service (like https://temp-mail.org).
-    #   Again external service.
-    # - test was correctly triggered also when HyperCore returns
-    #   "Unexpected response - 400 b'{\"error\":\"There was an error sending alert to new@test.com. Please verify your alert settings.\"}'"
-    #   In this case, record and diff are missing in output.
-    - name: Send test email to an existing Email Alert Recipient
-      scale_computing.hypercore.email_alert:
-        email: "{{ new_email }}"
-        state: test
-      register: result
-      failed_when: >-
-        result is not succeeded and
-        "There was an error sending alert to {{ new_email }}. Please verify your alert settings." not in result.msg
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.debug:
-        msg: "{{ result }}"
-    - ansible.builtin.assert:
-        that:
-          - result is succeeded
-          - result.changed == False
-          # - result.diff.before == result.diff.after
-          - info.records|length == 1|int
-          # - result.record != {}
-          # - result.record.keys() | sort ==
-          #   ['alert_tag_uuid', 'email', 'latest_task_tag',
-          #   'resend_delay', 'silent_period', 'uuid']
+# Sending email can fail.
+# We are using external SMTP server, and email address is from external domain.
+# Either of two might not work.
+# Try to resend after delay.
+# Alternatives:
+# - Set up a dedicated SMTP server, and use it during test.
+#   It will have IP, but no DNS domain.
+# - Use a temp email address from some public service (like https://temp-mail.org).
+#   Again external service.
+# - test was correctly triggered also when HyperCore returns
+#   "Unexpected response - 400 b'{\"error\":\"There was an error sending alert to new@test.com. Please verify your alert settings.\"}'"
+#   In this case, record and diff are missing in output.
+- name: Send test email to an existing Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: "{{ new_email }}"
+    state: test
+  register: result
+  failed_when: >-
+    result is not succeeded and
+    "There was an error sending alert to {{ new_email }}. Please verify your alert settings." not in result.msg
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.debug:
+    msg: "{{ result }}"
+- ansible.builtin.assert:
+    that:
+      - result is succeeded
+      - result.changed == False
+      # - result.diff.before == result.diff.after
+      - info.records|length == 1|int
+      # - result.record != {}
+      # - result.record.keys() | sort ==
+      #   ['alert_tag_uuid', 'email', 'latest_task_tag',
+      #   'resend_delay', 'silent_period', 'uuid']
 
 
-    - name: Remove previously created Email Alert Recipient
-      scale_computing.hypercore.email_alert:
-        email: "{{ new_email }}"
-        state: absent
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == True
-          - result.diff.before != result.diff.after
-    - ansible.builtin.assert: &test2
-        that:
-          - info.records|length == 0|int
-          - result.record == {}
+- name: Remove previously created Email Alert Recipient
+  scale_computing.hypercore.email_alert:
+    email: "{{ new_email }}"
+    state: absent
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == True
+      - result.diff.before != result.diff.after
+- ansible.builtin.assert: &test2
+    that:
+      - info.records|length == 0|int
+      - result.record == {}
 
-    - name: Remove previously created Email Alert Recipient - idempotence
-      scale_computing.hypercore.email_alert:
-        email: "{{ new_email }}"
-        state: absent
-      register: result
-    - scale_computing.hypercore.email_alert_info:
-      register: info
-    - ansible.builtin.assert:
-        that:
-          - result.changed == False
-          - result.diff.before == result.diff.after
-    - ansible.builtin.assert: *test2
+- name: Remove previously created Email Alert Recipient - idempotence
+  scale_computing.hypercore.email_alert:
+    email: "{{ new_email }}"
+    state: absent
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result.changed == False
+      - result.diff.before == result.diff.after
+- ansible.builtin.assert: *test2
 
-    # -----------------------------------------------------------
-    # Invalid parameter combination
-    # email_new makes sense only with state=present
-    # Should fail also if neither email nor email_new is present on HyperCore.
-    - name: Modify/rename existing Email Alert Recipient - with state=absent
-      scale_computing.hypercore.email_alert:
-        email: "{{ create_email_2 }}"
-        email_new: "{{ new_email_2 }}"
-        state: absent
-      register: result
-      ignore_errors: True
-    - ansible.builtin.assert:
-        that:
-          - result is failed
+# -----------------------------------------------------------
+# Invalid parameter combination
+# email_new makes sense only with state=present
+# Should fail also if neither email nor email_new is present on HyperCore.
+- name: Modify/rename existing Email Alert Recipient - with state=absent
+  scale_computing.hypercore.email_alert:
+    email: "{{ create_email_2 }}"
+    email_new: "{{ new_email_2 }}"
+    state: absent
+  register: result
+  ignore_errors: True
+- ansible.builtin.assert:
+    that:
+      - result is failed

--- a/tests/integration/targets/email_alert/tasks/03_email_alert_duplicated.yml
+++ b/tests/integration/targets/email_alert/tasks/03_email_alert_duplicated.yml
@@ -1,0 +1,77 @@
+---
+# A corner case.
+# See https://github.com/ScaleComputing/HyperCoreAnsibleCollection/issues/264
+# On existing cluster are duplicated email_alerts.
+# Remove all duplicates in one pass.
+- name: Prepare for test - cleanup (also test Remove with loop)
+  include_tasks: helper_api_email_alert_delete_all.yml
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - info.records == []
+      - info.records|length == 0|int
+
+- name: API add emails aa*1 bb*2
+  include_tasks: helper_api_email_alert_create_one.yml
+  vars:
+    email_alert_email: "{{ item }}"
+  loop:
+    - "{{ email_aa }}"
+    - "{{ email_bb }}"
+    - "{{ email_bb }}"
+
+# -----------------------------------------------------------
+# Try to create aa or bb
+# email_aa is just regular idempotence
+- name: Create new Email Alert Recipient aa
+  scale_computing.hypercore.email_alert:
+    email: "{{ email_aa }}"
+    state: present
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result is succeeded
+      - result is not changed
+      - result.record.email == email_aa
+- &assert_info
+  ansible.builtin.assert:
+    that:
+      - info.records|length == 3
+      - info.records | map(attribute='email') | sort == [email_aa, email_bb, email_bb] | sort
+
+# email_bb - module will fail, nothing should change
+- name: Create new Email Alert Recipient bb
+  scale_computing.hypercore.email_alert:
+    email: "{{ email_bb }}"
+    state: present
+  register: result
+  ignore_errors: true
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result is failed
+      - result is not changed
+      - "'2 records from endpoint' in result.msg"
+- *assert_info
+
+# -----------------------------------------------------------
+- name: Remove Email Alert Recipient bb
+  scale_computing.hypercore.email_alert:
+    email: "{{ email_bb }}"
+    state: absent
+  register: result
+- scale_computing.hypercore.email_alert_info:
+  register: info
+- ansible.builtin.assert:
+    that:
+      - result is succeeded
+      - result is changed
+      - result.record == {}
+- ansible.builtin.assert:
+    that:
+      - info.records|length == 1
+      - info.records | map(attribute='email') | sort == [email_aa] | sort

--- a/tests/integration/targets/email_alert/tasks/helper_api_email_alert_create_one.yml
+++ b/tests/integration/targets/email_alert/tasks/helper_api_email_alert_create_one.yml
@@ -1,0 +1,8 @@
+---
+# Create one email alert
+- name: HELPER CREATE ONE Create configured email_alert
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/AlertEmailTarget
+    data:
+      emailAddress: "{{ email_alert_email }}"

--- a/tests/integration/targets/email_alert/tasks/helper_api_email_alert_delete_all.yml
+++ b/tests/integration/targets/email_alert/tasks/helper_api_email_alert_delete_all.yml
@@ -1,0 +1,13 @@
+---
+# Remove oll email alerts
+- name: HELPER DELETE ALL Get current email_alert
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/AlertEmailTarget
+  register: api_email_alert_result
+
+- name: HELPER DELETE ALL Remove current email_alert
+  scale_computing.hypercore.api:
+    action: delete
+    endpoint: /rest/v1/AlertEmailTarget/{{ item.uuid }}
+  loop: "{{ api_email_alert_result.record }}"

--- a/tests/integration/targets/email_alert/tasks/helper_api_email_alert_reset.yml
+++ b/tests/integration/targets/email_alert/tasks/helper_api_email_alert_reset.yml
@@ -1,0 +1,22 @@
+---
+# Reset email alert configuration after CI tests finishes.
+
+- name: HELPER RESET Get current email_alert
+  scale_computing.hypercore.api:
+    action: get
+    endpoint: /rest/v1/AlertEmailTarget
+  register: api_email_alert_result
+
+- name: HELPER RESET Remove current email_alert
+  scale_computing.hypercore.api:
+    action: delete
+    endpoint: /rest/v1/AlertEmailTarget/{{ item.uuid }}
+  loop: "{{ api_email_alert_result.record }}"
+
+- name: HELPER RESET Create configured email_alert
+  scale_computing.hypercore.api:
+    action: post
+    endpoint: /rest/v1/AlertEmailTarget
+    data:
+      emailAddress: "{{ item }}"
+  loop: "{{ email_alert_config }}"

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -6,27 +6,14 @@
     SC_TIMEOUT: "{{ sc_timeout }}"
   vars:
     email_alert_config: "{{ sc_config[sc_host].email_alert }}"
+    email_aa: aa@test.com
+    email_bb: bb@test.com
+    email_all:
+      - "{{ email_aa }}"
+      - "{{ email_bb }}"
 
   block:
     - include_tasks: 01_email_alert_info.yml
     - include_tasks: 02_email_alert.yml
   always:
-    - name: Get current email_alert
-      scale_computing.hypercore.api:
-        action: get
-        endpoint: /rest/v1/AlertEmailTarget
-      register: api_email_alert_result
-
-    - name: Remove current email_alert
-      scale_computing.hypercore.api:
-        action: delete
-        endpoint: /rest/v1/AlertEmailTarget/{{ item.uuid }}
-      loop: "{{ api_email_alert_result.record }}"
-
-    - name: Create configured email_alert
-      scale_computing.hypercore.api:
-        action: post
-        endpoint: /rest/v1/AlertEmailTarget
-        data:
-          emailAddress: "{{ item }}"
-      loop: "{{ email_alert_config }}"
+    - include_tasks: helper_api_email_alert_reset.yml

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -19,5 +19,6 @@
   block:
     - include_tasks: 01_email_alert_info.yml
     - include_tasks: 02_email_alert.yml
+    - include_tasks: 03_email_alert_duplicated.yml
   always:
     - include_tasks: helper_api_email_alert_reset.yml

--- a/tests/integration/targets/email_alert/tasks/main.yml
+++ b/tests/integration/targets/email_alert/tasks/main.yml
@@ -11,6 +11,10 @@
     email_all:
       - "{{ email_aa }}"
       - "{{ email_bb }}"
+    new_email: new@test.com
+    create_email: test@test.com
+    new_email_2: new_2@test.com
+    create_email_2: test_2@test.com
 
   block:
     - include_tasks: 01_email_alert_info.yml


### PR DESCRIPTION
When removing email alerts we need to allow duplicated emails.

Fixes #264
