### PR TITLE
CI vm_clone fix wrong variable being used

### DIFF
--- a/tests/integration/targets/vm_clone/tasks/10_clone_stopped.yml
+++ b/tests/integration/targets/vm_clone/tasks/10_clone_stopped.yml
@@ -1,3 +1,13 @@
+# ---------------------------------------------------------------------------------------------------------------------
+- name: Retrieve XLAB-vm_clone_CI-test
+  scale_computing.hypercore.vm_info:
+    vm_name: XLAB-vm_clone-CI_test
+  register: source_info
+- ansible.builtin.assert:
+    that:
+      - source_info.records | length == 1
+
+# ----------------------------------Clone check------------------------------------------------------------------------
 - name: Clone XLAB-vm_clone_CI-test into XLAB-vm_clone_CI-test-clone
   scale_computing.hypercore.vm_clone:
     vm_name: XLAB-vm_clone_CI-test-clone

--- a/tests/integration/targets/vm_clone/tasks/11_clone_stopped_cloudinit.yml
+++ b/tests/integration/targets/vm_clone/tasks/11_clone_stopped_cloudinit.yml
@@ -1,3 +1,14 @@
+# ---------------------------------------------------------------------------------------------------------------------
+- name: Retrieve XLAB-vm_clone_CI-test
+  scale_computing.hypercore.vm_info:
+    vm_name: XLAB-vm_clone-CI_test
+  register: source_info
+- ansible.builtin.assert:
+    that:
+      - source_info.records | length == 1
+
+# ----------------------------------Clone check------------------------------------------------------------------------
+
 - name: Clone XLAB-vm_clone_CI-test into XLAB-vm_clone_CI-test-cloud_init-clone
   scale_computing.hypercore.vm_clone:
     vm_name: XLAB-vm_clone_CI-test-cloud_init-clone
@@ -28,7 +39,7 @@
       - source_info.records.0.boot_devices | length == cloned_cloud_init_info.records.0.boot_devices | length
       - source_info.records.0.disks | length != cloned_cloud_init_info.records.0.disks | length
       - source_info.records.0.nics | length == cloned_cloud_init_info.records.0.nics | length
-      - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
+      - source_info.records.0.nics.0.mac !=  cloned_cloud_init_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_cloud_init_info.records.0.node_affinity
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
@@ -62,5 +73,5 @@
       - source_info.records.0.boot_devices | length == cloned_cloud_init_info.records.0.boot_devices | length
       - source_info.records.0.disks | length != cloned_cloud_init_info.records.0.disks | length
       - source_info.records.0.nics | length == cloned_cloud_init_info.records.0.nics | length
-      - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
+      - source_info.records.0.nics.0.mac !=  cloned_cloud_init_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_cloud_init_info.records.0.node_affinity

--- a/tests/integration/targets/vm_clone/tasks/12_clone_running.yml
+++ b/tests/integration/targets/vm_clone/tasks/12_clone_running.yml
@@ -29,7 +29,7 @@
       - demo_server_info.records.0.boot_devices | length == cloned_while_running_info.records.0.boot_devices | length
       - demo_server_info.records.0.disks | length == cloned_while_running_info.records.0.disks | length
       - demo_server_info.records.0.nics | length == cloned_while_running_info.records.0.nics | length
-      - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
+      - demo_server_info.records.0.nics.0.mac !=  cloned_while_running_info.records.0.nics.0.mac
       - demo_server_info.records.0.node_affinity != cloned_while_running_info.records.0.node_affinity
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
@@ -55,5 +55,5 @@
       - demo_server_info.records.0.boot_devices | length == cloned_while_running_info.records.0.boot_devices | length
       - demo_server_info.records.0.disks | length == cloned_while_running_info.records.0.disks | length
       - demo_server_info.records.0.nics | length == cloned_while_running_info.records.0.nics | length
-      - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
+      - demo_server_info.records.0.nics.0.mac !=  cloned_while_running_info.records.0.nics.0.mac
       - demo_server_info.records.0.node_affinity != cloned_while_running_info.records.0.node_affinity

--- a/tests/integration/targets/vm_clone/tasks/13_clone_stopped_preserve_mac.yml
+++ b/tests/integration/targets/vm_clone/tasks/13_clone_stopped_preserve_mac.yml
@@ -1,3 +1,13 @@
+# ---------------------------------------------------------------------------------------------------------------------
+- name: Retrieve XLAB-vm_clone_CI-test
+  scale_computing.hypercore.vm_info:
+    vm_name: XLAB-vm_clone-CI_test
+  register: source_info
+- ansible.builtin.assert:
+    that:
+      - source_info.records | length == 1
+
+# ----------------------------------Clone check------------------------------------------------------------------------
 - name: Clone XLAB-vm_clone_CI-test into XLAB-vm_clone_CI-test-preserve-mac-clone
   scale_computing.hypercore.vm_clone:
     vm_name: XLAB-vm_clone_CI-test-preserve-mac-clone

--- a/tests/integration/targets/vm_clone/tasks/main.yml
+++ b/tests/integration/targets/vm_clone/tasks/main.yml
@@ -6,6 +6,8 @@
     SC_TIMEOUT: "{{ sc_timeout }}"
 
   block:
+    # For manual testing, run 01 and 02 once.
+    # Then a single 10, 11 etc test can be run.
     - include_tasks: 01_cleanup.yml
     - include_tasks: 02_prepare_source_vms.yml
     - include_tasks: 10_clone_stopped.yml


### PR DESCRIPTION
CI test was comparing wrong variables in a few places. PR fixes that.

PR also make sure we can run a single sub-test after
test/source VMs were prepared.

Fixes #273

TY @shoriminimoe for noticing this.