### PR TITLE
CI fix expected version string

### DIFF
--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -97,7 +97,7 @@ sc_config:
     features:
       version_update:
         # Current SW (ICOS) version running on the host.
-        current_version: "9.2.13.211102"
+        current_version: "9.2.24.212633"
         # The next version available update for the host.
         next_version: ""
         # The latest version available update for the host.
@@ -141,8 +141,8 @@ sc_config:
     features:
       version_update:
         current_version: "9.1.14.208456"
-        next_version: "9.2.22.212325"
-        latest_version: "9.2.22.212325"
+        next_version: "9.2.24.212633"
+        latest_version: "9.2.24.212633"
         can_be_applied: False
         # We can try update, update will fail, and status.json will be present.
         old_update_status_present: True
@@ -176,8 +176,8 @@ sc_config:
     features:
       version_update:
         current_version: "9.2.13.211102"
-        next_version: "9.2.22.212325"
-        latest_version: "9.2.22.212325"
+        next_version: ""
+        latest_version: ""
         can_be_applied: False
         old_update_status_present: False
       virtual_disk:


### PR DESCRIPTION
For some reason, VSNS201 does not offer update to 9.2.24.212633. There is no available update also in GUI.
The VSNS200 shows update 9.2.24.212633 as available.