### PR TITLE
Ci 9.4.0

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -287,7 +287,7 @@ jobs:
       - integ
     if: "always() && (needs.integ-matrix.result=='success')"
     runs-on: [ self-hosted2 ]
-    container: quay.io/justinc1_github/scale_ci_integ:3
+    container: quay.io/justinc1_github/scale_ci_integ:9
     env:
       DEBIAN_FRONTEND: noninteractive
     defaults:
@@ -330,7 +330,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ env.WORKDIR }}
-      - run: pip install ansible-core~=2.13.0
+      - run: pip install ansible-core~=2.16.0
       # We have ansible.cfg "for testing" in git repo
       # (it is excluded in galaxy.yml, so it is not part of collection artifact)
       # But it does affect ansible-galaxy and ansible-test commands.

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -60,9 +60,10 @@ jobs:
       fail-fast: false
       matrix:
         sc_host:
-          - https://10.5.11.200
-          - https://10.5.11.201
-          - https://10.5.11.203 # HC 9.3.x
+          - https://10.5.11.200  # HC 9.1.x
+          - https://10.5.11.201  # HC 9.2.x
+          - https://10.5.11.203  # HC 9.3.x
+          - https://10.5.11.204  # HC 9.4.x
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -179,7 +180,7 @@ jobs:
       # ${{ env.WORKDIR }} cannot be used
       - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
         with:
-          sc_host: https://10.5.11.203
+          sc_host: https://10.5.11.204
           sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
           smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
           oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
@@ -219,6 +220,7 @@ jobs:
           - https://10.5.11.200
           - https://10.5.11.201
           - https://10.5.11.203
+          - https://10.5.11.204
         include:
           - sc_host: https://10.5.11.50
             test_name: vm_replication
@@ -236,11 +238,15 @@ jobs:
             test_name: vm_replication
           - sc_host: https://10.5.11.203
             test_name: vm_replication
+          - sc_host: https://10.5.11.204
+            test_name: vm_replication
           - sc_host: https://10.5.11.200
             test_name: vm_clone__replicated
           - sc_host: https://10.5.11.201
             test_name: vm_clone__replicated
           - sc_host: https://10.5.11.203
+            test_name: vm_clone__replicated
+          - sc_host: https://10.5.11.204
             test_name: vm_clone__replicated
           # Seem as VSNS nodes cannot open remote tunnel.
           # Code/port that worked (was opened, then closed) on real HyperCode
@@ -250,6 +256,8 @@ jobs:
           - sc_host: https://10.5.11.201
             test_name: support_tunnel
           - sc_host: https://10.5.11.203
+            test_name: support_tunnel
+          - sc_host: https://10.5.11.204
             test_name: support_tunnel
     steps:
       - name: Checkout
@@ -308,6 +316,7 @@ jobs:
           - https://10.5.11.200
           - https://10.5.11.201
           - https://10.5.11.203
+          - https://10.5.11.204
         exclude:
           # role cluster_config can be used with HC3 9.1, but you need to omit cluster_name setting.
           # CI job role_cluster_config does try to set cluster_name, so it would fail.

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -219,3 +219,37 @@ sc_config:
         replication_factor: 1
       cluster_name:
         is_writable: True
+
+  https://10.5.11.204:
+    <<: *base_cfg
+    sc_username: admin
+    sc_password: admin
+    sc_replication_dest_host: ""
+    sc_replication_dest_cluster_name: ""
+    sc_replication_dest_username: ""
+    sc_replication_dest_password: ""
+    cluster:
+      name: VSNS204
+    support_tunnel:
+      open: true
+      code: "4426"
+    smtp:
+      <<: *base_smtp
+      from_address: VSNS204@scalecomputing.com
+    version_update:
+      magic_allow_string: "oh-no-no"
+      vm_shutdown_restart_allow_string: "allow-vm-shutdown-restart-test"
+    syslog_server:
+      host: 10.5.11.222
+    features:
+      version_update:
+        current_version: "9.4.0.213268"
+        next_version: ""
+        latest_version: ""
+        can_be_applied: False
+        old_update_status_present: False
+      virtual_disk:
+        is_supported: True
+        replication_factor: 1
+      cluster_name:
+        is_writable: True


### PR DESCRIPTION
Add HyperCore 9.4.0 to CI test matrix.

Also run examples with latest ansible 2.16

Fixes #294 