### PR TITLE
Ci fixes

### DIFF
--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -181,8 +181,9 @@ sc_config:
     features:
       version_update:
         current_version: "9.2.13.211102"
-        next_version: "9.2.24.212633"
-        latest_version: "9.2.27.213408"
+        # This VSNS does not get list of available updates from update server.
+        next_version: ""
+        latest_version: ""
         can_be_applied: False
         old_update_status_present: False
       virtual_disk:

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -72,6 +72,7 @@ sc_config:
 
   https://10.5.11.50:
     <<: *base_cfg
+    ci_system_name: pub5
     sc_username: "{{ sc_username_50 }}"
     sc_password: "{{ sc_password_50 }}"
     # Only .50 is configured with remote replication.
@@ -122,6 +123,7 @@ sc_config:
 
   https://10.5.11.200:
     <<: *base_cfg
+    ci_system_name: vsns200
     sc_username: admin
     sc_password: admin
     sc_replication_dest_host: ""
@@ -159,6 +161,7 @@ sc_config:
 
   https://10.5.11.201:
     <<: *base_cfg
+    ci_system_name: vsns201
     sc_username: admin
     sc_password: admin
     sc_replication_dest_host: ""
@@ -196,6 +199,7 @@ sc_config:
 
   https://10.5.11.203:
     <<: *base_cfg
+    ci_system_name: vsns203
     sc_username: admin
     sc_password: admin
     sc_replication_dest_host: ""
@@ -232,6 +236,7 @@ sc_config:
 
   https://10.5.11.204:
     <<: *base_cfg
+    ci_system_name: vsns204
     sc_username: admin
     sc_password: admin
     sc_replication_dest_host: ""

--- a/tests/integration/integration_config.yml.j2
+++ b/tests/integration/integration_config.yml.j2
@@ -260,5 +260,7 @@ sc_config:
       virtual_disk:
         is_supported: True
         replication_factor: 1
+      vtpm_disk:
+        is_supported: True
       cluster_name:
         is_writable: True

--- a/tests/integration/targets/vm_import/tasks/main.yml
+++ b/tests/integration/targets/vm_import/tasks/main.yml
@@ -4,6 +4,13 @@
     SC_USERNAME: "{{ sc_config[sc_host].sc_username }}"
     SC_PASSWORD: "{{ sc_config[sc_host].sc_password }}"
     SC_TIMEOUT: "{{ sc_timeout }}"
+  vars:
+    # Multiple HC3 cluster write to same SMB share.
+    # The import test might fail if two clusters write to same directory.
+    # This is likely reason why those two failed:
+    # - https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/7954381469/job/21711756495#step:8:79
+    # - https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/7954381469/job/21711756629#step:8:79
+    ci_system_name: "{{ sc_config[sc_host].ci_system_name }}"
 
   block:
 # ----------------------------------Cleanup------------------------------------------------------------------------
@@ -77,7 +84,7 @@
         vm_name: XLAB-import-test-integration
         smb:
           server: "{{ smb_server }}"
-          path: "{{ smb_share }}/integration-test-vm-import"
+          path: "{{ smb_share }}/integration-test-vm-import-{{ ci_system_name }}"
           username: "{{ smb_username }}"
           password: "{{ smb_password }}"
       register: output
@@ -91,7 +98,7 @@
         vm_name: XLAB-import-test-integration-imported
         smb:
           server: "{{ smb_server }}"
-          path: "{{ smb_share }}/integration-test-vm-import"
+          path: "{{ smb_share }}/integration-test-vm-import-{{ ci_system_name }}"
           username: "{{ smb_username }}"
           password: "{{ smb_password }}"
       register: import_vm
@@ -119,7 +126,7 @@
         vm_name: XLAB-import-test-integration-imported-cloud-init
         smb:
           server: "{{ smb_server }}"
-          path: "{{ smb_share }}/integration-test-vm-import"
+          path: "{{ smb_share }}/integration-test-vm-import-{{ ci_system_name }}"
           username: "{{ smb_username }}"
           password: "{{ smb_password }}"
         cloud_init:
@@ -159,7 +166,7 @@
         vm_name: XLAB-import-test-integration-imported
         smb:
           server: "{{ smb_server }}"
-          path: "{{ smb_share }}/integration-test-vm-import"
+          path: "{{ smb_share }}/integration-test-vm-import-{{ ci_system_name }}"
           username: "{{ smb_username }}"
           password: "{{ smb_password }}"
       register: import_vm
@@ -187,7 +194,7 @@
         vm_name: XLAB-import-test-integration-imported-cloud-init
         smb:
           server: "{{ smb_server }}"
-          path: "{{ smb_share }}/integration-test-vm-import"
+          path: "{{ smb_share }}/integration-test-vm-import-{{ ci_system_name }}"
           username: "{{ smb_username }}"
           password: "{{ smb_password }}"
         cloud_init:


### PR DESCRIPTION
vm_import test was failing because multiple clusters were writing to same directory. Now we will use unique directory name.

I forgot one VSVN does not know about available updates, here relevant commit is partially reverted. 

vTPM disk is supported on v9.4 too, corresponding flag is added to VSNS with v9.4.