### PR TITLE
vm_params need to start/shutdown/reboot etc VM if requested

### DIFF
--- a/tests/integration/targets/i_vm_params/tasks/02_machine_type.yml
+++ b/tests/integration/targets/i_vm_params/tasks/02_machine_type.yml
@@ -210,8 +210,7 @@
         - not output.records[0].snapshot_schedule
 
   # ===================================================================
-  # Set nonexisting snapshot schedule
-  - name: Set VMs power_state - applied
+  - name: Set VMs power_state - reset
     scale_computing.hypercore.vm_params:
       vm_name: "{{ vm_name }}"
       power_state: reset
@@ -225,6 +224,11 @@
         - output is changed
         - output.vm_rebooted is false  # true  # todo - is this reported? should we pretend reboot==reset - it is not same.
 
+    # HC3 returned error for RESET, but it did reset VM (HC3 v9.4.0)
+    # After RESET, VM was 10-15 sec in stopped state.
+  - name: Wait on VM stop/start to finish
+    ansible.builtin.pause:
+      seconds: 20
   - name: Check VMs power_state isn't changed
     scale_computing.hypercore.vm_info:
       vm_name: "{{ vm_name }}"
@@ -232,7 +236,6 @@
   - ansible.builtin.assert:
       that:
         - output is succeeded
-        # HC3 9.2.22 - RESET is accepted, but VM remains stopped as it was stopped before.
         - output.records[0].power_state == "started"
 
   # ===================================================================

--- a/tests/unit/plugins/module_utils/test_vm.py
+++ b/tests/unit/plugins/module_utils/test_vm.py
@@ -2060,7 +2060,9 @@ class TestManageVMParams:
         mocker.patch(
             "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.VM.wait_shutdown"
         ).return_value = True
-        changed, diff = ManageVMParams.set_vm_params(module, rest_client, vm_before, [])
+        changed, diff, changed_parameters = ManageVMParams.set_vm_params(
+            module, rest_client, vm_before, []
+        )
 
         assert changed is True
         assert diff == {
@@ -2082,6 +2084,15 @@ class TestManageVMParams:
                 "power_state": "started",
                 "snapshot_schedule": "",
             },
+        }
+        assert changed_parameters == {
+            "vm_name": True,
+            "description": True,
+            "tags": False,
+            "memory": False,
+            "vcpu": True,
+            "power_state": False,
+            "snapshot_schedule": False,
         }
 
     def test_run_no_change(self, create_module, rest_client, mocker):
@@ -2118,12 +2129,22 @@ class TestManageVMParams:
             snapshot_schedule="",
         )
 
-        changed, diff = ManageVMParams.set_vm_params(module, rest_client, vm_before, [])
+        changed, diff, changed_parameters = ManageVMParams.set_vm_params(
+            module, rest_client, vm_before, []
+        )
 
         assert changed is False
         assert diff == {
             "before": None,
             "after": None,
+        }
+        assert changed_parameters == {
+            "description": False,
+            "tags": False,
+            "memory": False,
+            "vcpu": False,
+            "power_state": False,
+            "snapshot_schedule": False,
         }
         assert vm_before.was_vm_rebooted() is False
 

--- a/tests/unit/plugins/modules/test_vm.py
+++ b/tests/unit/plugins/modules/test_vm.py
@@ -812,7 +812,7 @@ class TestEnsurePresent:
         ).return_value = None
         mocker.patch(
             "ansible_collections.scale_computing.hypercore.plugins.modules.vm._set_vm_params"
-        ).return_value = False
+        ).return_value = (False, {})
         mocker.patch(
             "ansible_collections.scale_computing.hypercore.plugins.modules.vm._set_disks"
         ).return_value = False


### PR DESCRIPTION
The test for vm_params__power_state was added recently (in #287), and it was failing.
See https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/8059420864/job/22068199119#step:8:138.
ACPI shutdown was just not sent to the VM.
The PR fixes this.

Integ test in https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/8284495601 and https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/8382148003