### PR TITLE
Role meta

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -62,3 +62,9 @@ jobs:
           ansible-core-version: ${{ matrix.ansible }}
           target-python-version: ${{ matrix.python }}
           testing-type: units
+
+  import-galaxy-test:
+    permissions:
+      contents: read
+    name: Import collection with Galaxy importer
+    uses: ansible-community/github-action-test-galaxy-import/.github/workflows/test-galaxy-import.yml@main

--- a/roles/check_local_time/meta/main.yml
+++ b/roles/check_local_time/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author: Polona Mihalic <polona.mihalic@xlab.si>
+  role_name: check_local_time
+  description: Check if local time is within given time interval
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14.0"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all

--- a/roles/cluster_config/meta/main.yml
+++ b/roles/cluster_config/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author: Justin Cinkelj <justin.cinkelj@xlab.si>
+  role_name: cluster_config
+  description: Fully configure or partially reconfigure a HyperCore server
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14.0"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all

--- a/roles/version_update_single_node/meta/main.yml
+++ b/roles/version_update_single_node/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author: Ana Zobec <ana.zobec@xlab.si>
+  role_name: version_update_single_node
+  description: Update version on Scale Computing HyperCore cluster
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14.0"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all


### PR DESCRIPTION
Add `role/x/meta/main.yml` to fix ansible-lint error during galaxy import.

Also test galaxy import in CI - just to get output visible before we create release.
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/8552020641/job/23432317707 - a sample CI job.

Fixes #303
