### PR TITLE
Include tests/config.yml into tar.gz

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,9 @@ homepage: https://github.com/ScaleComputing/HyperCoreAnsibleCollection
 issues: https://github.com/ScaleComputing/HyperCoreAnsibleCollection/issues
 build_ignore:
   - .*
-  - tests
+  - tests/integration
+  - tests/output
+  - tests/unit
   - docs
   # all this should be under hacking/ or similar
   - ci-infra


### PR DESCRIPTION
Having `tests/config.yml` in built `.tar.gz` should help `ansible-test sanity` to not test with old python version (2.7 etc).