### PR TITLE
url2template and template2vm roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/integration/inventory
 
 docs/build
 docs/source/modules
+ci-infra/local-dev

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,14 @@ To be able to run example playbooks execute in shell:
 export SC_HOST=https://1.2.3.4
 export SC_USERNAME=admin
 export SC_PASSWORD=admin_pass
+
+# For convience you can store the environ variables into .sh or .env file in git-ignored directory:
+cat <EOF >>ci-infra/local-dev/env-host-4.sh
+export SC_HOST=https://1.2.3.4
+export SC_USERNAME=admin
+export SC_PASSWORD=admin_pass
+EOF
+source ci-infra/local-dev/env-host-4.sh
 ```
 
 ## Debugging

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,7 +4,7 @@
 stdout_callback     = community.general.yaml
 retry_files_enabled = False
 forks               = 16
-collections_paths = ../../../
+collections_path = ../../../
 # To test the inventory file: hypercore_inventory.yml
 #[inventory]
 #enable_plugins = scale_computing.hypercore.hypercore

--- a/changelogs/fragments/20240508-url2template.yml
+++ b/changelogs/fragments/20240508-url2template.yml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - Added roles url2template and template2vm.
+    (https://github.com/ScaleComputing/HyperCoreAnsibleCollection/pull/310)

--- a/examples/url2template/hypercore.yml
+++ b/examples/url2template/hypercore.yml
@@ -1,0 +1,2 @@
+---
+plugin: scale_computing.hypercore.hypercore

--- a/examples/url2template/meta-data.ubuntu-22.04.yml.j2
+++ b/examples/url2template/meta-data.ubuntu-22.04.yml.j2
@@ -1,0 +1,16 @@
+dsmode: local
+local-hostname: "{{ vm_name }}"
+network-interfaces: |
+  auto lo
+  iface lo inet loopback
+
+{% if vm_network_mode == "dhcp" %}
+  iface {{ vm_network_iface }} inet dhcp
+{% endif %}
+{% if vm_network_mode == "static" %}
+  iface {{ vm_network_iface }} inet static
+    address {{ vm_network_ip_address }}
+    netmask {{ vm_network_netmask }}
+    gateway {{ vm_network_gateway }}
+    dns-nameservers {{ vm_network_dns_nameservers }}
+{% endif %}

--- a/examples/url2template/template2vm.yml
+++ b/examples/url2template/template2vm.yml
@@ -1,0 +1,71 @@
+---
+
+# Run as
+# ansible-playbook -i localhost, -i examples/url2template/hypercore.yml examples/url2template/template2vm.yml -v
+
+- name: Create VM from template VM
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    vm_group: test-clones
+    source_vm_name: ubuntu-22.04-server-cloudimg-amd64.img
+    vm_name: "{{ vm_group }}-server-0"
+    description: created from {{ source_vm_name }}
+    vcpu: 4
+    memory: "{{ '1 GB' | human_to_bytes }}"
+    disk_size: "{{ '20 GB' | human_to_bytes }}"
+    #
+    # do we have ens1 or enp1s0 or something else
+    vm_network_iface: ens3
+    # DHCP IP address from DHCP
+    vm_network_mode: "dhcp"
+    # vm_network_mode: "static"
+    # Static IP address
+    # vm_network_ip_address: 172.31.6.20
+    # vm_network_netmask: 255.255.255.0
+    # vm_network_gateway: 172.31.6.1
+    # vm_network_dns_nameservers: 8.8.8.8
+
+    # Add your ssh public key for publickey authentication
+    vm_ssh_authorized_keys:
+      - ssh-ed25519 rest-of-you-ssh-key-here...
+    # Import SSH key from github.com
+    vm_ssh_import_id: ""
+    # vm_ssh_import_id: "gh:your_username"
+
+  tasks:
+    - name: Create VM from template
+      ansible.builtin.include_role:
+        name: scale_computing.hypercore.template2vm
+      vars:
+        template2vm_source_vm_name: "{{ source_vm_name }}"
+        template2vm_vm_name: "{{ vm_name }}"
+        template2vm_description: test server, created from {{ source_vm_name }}
+        template2vm_vm_tags:
+          - "{{ vm_group }}"
+          - ansible_group__{{ vm_group }}
+          # If static IP address is used, optionally uncomment this to set ansible_host
+          # - ansible_host__{{ vm_network_ip_address }}
+        template2vm_vcpu: "{{ vcpu }}"
+        template2vm_memory: "{{ memory }}"
+        template2vm_disk_size: "{{ disk_size }}"
+        template2vm_power_state: start
+        # cloud-init
+        template2vm_user_data: "{{ lookup('template', 'user-data.ubuntu-22.04.yml.j2') }}"
+        template2vm_meta_data: "{{ lookup('template', 'meta-data.ubuntu-22.04.yml.j2') }}"
+
+    - name: Refresh inventory
+      ansible.builtin.meta: refresh_inventory
+
+- name: Wait on VM to boot
+  hosts: "{{ vm_group }}"
+  gather_facts: false
+  vars:
+    vm_group: test-clones
+  tasks:
+    - name: Refresh inventory and wait
+      ansible.builtin.include_role:
+        name: scale_computing.hypercore.template2vm
+        tasks_from: wait_vm_boot_tasks.yml
+      loop: "{{ range(10) }}"

--- a/examples/url2template/url2template.yml
+++ b/examples/url2template/url2template.yml
@@ -1,0 +1,18 @@
+---
+# Run as
+# ansible-playbook -i localhost, examples/url2template/template2vm.yml -v
+- name: Create template VM from disk image URL
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    image_url: https://cloud-images.ubuntu.com/releases/22.04/release-20240416/ubuntu-22.04-server-cloudimg-amd64.img
+    machine_type: BIOS
+
+  roles:
+    - role: scale_computing.hypercore.url2template
+      vars:
+        url2template_image_url: "{{ image_url }}"
+        url2template_vm_name: "{{ vm_name | default(image_url | split('/') | last) }}"
+        url2template_machine_type: "{{ machine_type }}"
+        url2template_operating_system: os_other

--- a/examples/url2template/user-data.ubuntu-22.04.yml.j2
+++ b/examples/url2template/user-data.ubuntu-22.04.yml.j2
@@ -1,0 +1,65 @@
+Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+
+# Tested with Ubuntu 22.04 cloud image.
+
+# Uncomment for password login
+# password: "password"
+# chpasswd: { expire: False }
+# ssh_pwauth: True
+
+hostname: {{ vm_name | replace("_", "-") }}
+# fqdn: {{ vm_name | replace("_", "-") }}.example.com
+manage_etc_hosts: localhost
+ssh_authorized_keys: {{ vm_ssh_authorized_keys }}
+disable_root: false
+ssh_import_id: {{ vm_ssh_import_id }}
+package_update: true
+package_upgrade: false
+packages:
+ - qemu-guest-agent
+package_reboot_if_required: true
+# runcmd runs only on first boot
+runcmd:
+  - [ sh, -c, 'sudo echo GRUB_CMDLINE_LINUX="nomodeset" >> /etc/default/grub' ]
+  - [ sh, -c, 'sudo echo GRUB_GFXPAYLOAD_LINUX="1024x768" >> /etc/default/grub' ]
+  - [ sh, -c, 'sudo echo GRUB_DISABLE_LINUX_UUID=true >> /etc/default/grub' ]
+  - [ sh, -c, 'sudo update-grub' ]
+  - [ echo, message, CC-runcmd-jc ]
+# bootcmd runs on every boot
+# bootcmd:
+# qemu-guest-agent is not yet installed - packages are installed later
+# network is not yet up
+#  - apt update
+#  - DEBIAN_FRONTEND=noninteractive apt install -y qemu-guest-agent
+#  - [ systemctl, restart, --no-block, qemu-guest-agent ]
+# scripts_user:
+# write_files: []
+final_message: |
+  cloud-init has finished
+  version: $version
+  timestamp: $timestamp
+  datasource: $datasource
+  uptime: $uptime
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+#!/bin/bash
+  # mkdir test-userscript
+  # touch /test-userscript/userscript.txt
+  # echo "Created by bash shell script" >> /test-userscript/userscript.txt
+  # echo which qemu-ga >> /test-userscript/userscript.txt
+  # which qemu-ga >> /test-userscript/userscript.txt 2>1
+  systemctl start qemu-guest-agent
+--//--

--- a/roles/template2vm/README.md
+++ b/roles/template2vm/README.md
@@ -1,0 +1,31 @@
+# template2vm
+
+Role template2vm can be used to:
+- clone a template VM to a regular VM
+- wait on regular VM until it is booted (e.g. ssh connection can be made)
+
+## Requirements
+
+- NA
+
+## Role Variables
+
+See [argument_specs.yml](../../roles/template2vm/meta/argument_specs.yml).
+
+## Limitations
+
+- NA
+
+## Dependencies
+
+- NA
+
+## Example Playbook
+
+See [cluster_config.yml](../../examples/url2template/template2vm.yml).
+
+## License
+
+GNU General Public License v3.0 or later
+
+See [LICENSE](../../LICENSE) to see the full text.

--- a/roles/template2vm/meta/argument_specs.yml
+++ b/roles/template2vm/meta/argument_specs.yml
@@ -1,0 +1,77 @@
+---
+argument_specs:
+  main:
+    short_description: Clone a template VM to a regular VM
+    description:
+      - Role url2template is used to clone a template VM to a regular VM.
+      - Most parameters have 1-to-1 mapping to M(scale_computing.hypercore.vm) parameters.
+    options:
+      template2vm_source_vm_name:
+        description:
+          - The source template VM used to create a new VM.
+        required: true
+        type: str
+      template2vm_vm_name:
+        description:
+          - The VM to be created.
+        required: true
+        type: str
+      template2vm_description:
+        description:
+          - Description for new VM.
+        required: true
+        type: str
+      template2vm_vm_tags:
+        description:
+          - VM tags for new VM.
+        required: true
+        type: list
+        elements: str
+      template2vm_vcpu:
+        description:
+          - vCPU count for new VM.
+        required: true
+        type: int
+      template2vm_memory:
+        description:
+          - Memory for new VM.
+        required: true
+        type: int
+      template2vm_disk_size:
+        description:
+          - Disk size for VM OS disk, in bytes unit.
+          - Needs to be bigger or equal to source template VM OS disk.
+        required: true
+        type: int
+      template2vm_power_state:
+        description:
+          - Power state for new VM.
+        required: true
+        type: str
+      template2vm_user_data:
+        description:
+          - Cloud-init user-data.
+        required: false
+        type: str
+        default: ""
+      template2vm_meta_data:
+        description:
+          - Cloud-init meta-data.
+        required: false
+        type: str
+        default: ""
+
+  wait_vm_boot_tasks:
+    short_description: Wait until VM is booted
+    description:
+      - Wait until VM is booted - e.g. ssh connection can be made.
+      - As new VM(s) were just created on HyperCore, an inventory refresh is made
+        before check if VMs are reachable via ssh.
+      - Inventory refresh is needed before each check, to ensure we get DHCP assigned VM IP address.
+    options:
+      template2vm_wait_vm_boot_tasks_dummy_param:
+        description:
+          - Ignore this. ansible-lint does not like role with empty options; so we have a dummy param.
+        required: false
+        type: str
+        default: ""

--- a/roles/template2vm/meta/main.yml
+++ b/roles/template2vm/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author: Justin Cinkelj <justin.cinkelj@xlab.si>
+  role_name: template2vm
+  description: Clone a template VM to a regular VM
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14.0"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all

--- a/roles/template2vm/tasks/main.yml
+++ b/roles/template2vm/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Clone template VM {{ " ".join([template2vm_source_vm_name, "to", template2vm_vm_name]) }}
+#  throttle: 1
+  scale_computing.hypercore.vm_clone:
+    vm_name: "{{ template2vm_vm_name }}"
+    source_vm_name: "{{ template2vm_source_vm_name }}"
+    # tags: "{{ vm_tags }}"  # TODO tags are added, not replaced
+    cloud_init:
+      user_data: "{{ template2vm_user_data }}"
+      meta_data: "{{ template2vm_meta_data }}"
+
+- name: Set disk size
+  scale_computing.hypercore.vm_disk:
+    vm_name: "{{ template2vm_vm_name }}"
+    items:
+      - disk_slot: 1
+        type: virtio_disk
+        size: "{{ template2vm_disk_size }}"
+    state: present
+
+# TODO add extra /data disk
+
+- name: Set params and start VM {{ template2vm_vm_name }}
+  scale_computing.hypercore.vm_params:
+    vm_name: "{{ template2vm_vm_name }}"
+    description: "{{ template2vm_description }}"
+    tags: "{{ template2vm_vm_tags }}"
+    vcpu: "{{ template2vm_vcpu }}"
+    memory: "{{ template2vm_memory }}"
+    power_state: "{{ template2vm_power_state }}"

--- a/roles/template2vm/tasks/wait_vm_boot_tasks.yml
+++ b/roles/template2vm/tasks/wait_vm_boot_tasks.yml
@@ -1,0 +1,13 @@
+---
+- name: Refresh inventory
+  ansible.builtin.meta: refresh_inventory
+
+# qemu-ga was not yet asked for VM IP, so inventory plugin has wrong address (hostname, not IP).
+# Retry N times.
+- name: Wait for ssh connection to VM
+  ansible.builtin.wait_for_connection:
+    timeout: 30
+    sleep: 10
+  when: template2vm_wait_ssh_result is not defined or template2vm_wait_ssh_result is failed
+  register: template2vm_wait_ssh_result
+  ignore_errors: true

--- a/roles/url2template/README.md
+++ b/roles/url2template/README.md
@@ -1,0 +1,30 @@
+# url2template
+
+Role url2template can be used to:
+- download VM image from URL and create a template VM
+
+## Requirements
+
+- NA
+
+## Role Variables
+
+See [argument_specs.yml](../../roles/url2template/meta/argument_specs.yml).
+
+## Limitations
+
+- NA
+
+## Dependencies
+
+- NA
+
+## Example Playbook
+
+See [cluster_config.yml](../../examples/url2template/url2template.yml).
+
+## License
+
+GNU General Public License v3.0 or later
+
+See [LICENSE](../../LICENSE) to see the full text.

--- a/roles/url2template/meta/argument_specs.yml
+++ b/roles/url2template/meta/argument_specs.yml
@@ -1,0 +1,31 @@
+---
+argument_specs:
+  main:
+    short_description: Download VM image from URL and create a template VM
+    description:
+      - Role url2template can be use to download VM image from URL and create a template VM.
+        Role first downloads image from URL, then it created a VirtualDisk from it.
+        Next a template VM is created using the VirtualDisk.
+    options:
+      url2template_image_url:
+        description:
+          - The URL with disk image.
+        required: true
+        type: str
+      url2template_vm_name:
+        description:
+          - The name for the template VM.
+        required: true
+        type: str
+      url2template_machine_type:
+        description:
+          - The I(machine_type) for the template VM.
+          - For allowed values see I(machine_type) in M(scale_computing.hypercore.vm).
+        required: true
+        type: str
+      url2template_operating_system:
+        description:
+          - The operating system for the template VM.
+          - For allowed values see I(operating_system) in M(scale_computing.hypercore.vm).
+        required: true
+        type: str

--- a/roles/url2template/meta/main.yml
+++ b/roles/url2template/meta/main.yml
@@ -1,0 +1,10 @@
+galaxy_info:
+  author: Justin Cinkelj <justin.cinkelj@xlab.si>
+  role_name: url2template
+  description: Download VM image from URL and create a template VM
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14.0"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all

--- a/roles/url2template/tasks/main.yml
+++ b/roles/url2template/tasks/main.yml
@@ -1,97 +1,78 @@
 ---
-# tasks file for url2template role - takes image_url and turns it into a VM template of the same name
-# returns that name as image_name
-  - name: Set image name as ansible fact (for single image)
-    ansible.builtin.set_fact:
-      image_name: "{{ item | split('/') | last }}"
-    loop: "{{ image_url }}"
+- name: Get info about template VM {{ url2template_vm_name }}
+  scale_computing.hypercore.vm_info:
+    vm_name: "{{ url2template_vm_name }}"
+  register: vm_info_result
 
-  - name: Download Virtual Disk(s) image from URL list
-    ansible.builtin.get_url:
-      url: "{{ item }}"
-      dest: "{{ image_path }}{{ image_name}}"
-      timeout: 10000
-      validate_certs: false
-      force: false
-    register: download
-    loop: "{{ image_url }}"
-    throttle: 1 
+- name: Create template VM if it does not already exist {{ url2template_vm_name }}
+  when: vm_info_result.records | length == 0
+  block:
+    - name: Set url2template_image_filename as ansible fact
+      ansible.builtin.set_fact:
+        url2template_image_filename: "{{ url2template_image_url | split('/') | last }}"
 
-  - name: Delete existing uploading-"{{ image_name }}" virtual disk # recovers from any previous failed upload 
-    scale_computing.hypercore.virtual_disk:
-      name: "uploading-{{ image_name }}"
-      state: absent
-    register: deleted
-    loop: "{{ image_url }}"      
+    - name: Download Virtual Disk image from URL
+      ansible.builtin.get_url:
+        url: "{{ url2template_image_url }}"
+        dest: /tmp/{{ url2template_image_filename }}
+        mode: "0644"
+        timeout: 10000
+        validate_certs: false
 
-  - name: Upload Virtual Disk {{ item | split('/') | last }}" to HyperCore "{{ inventory_hostname }}"
-    scale_computing.hypercore.virtual_disk:
-      name: "{{ image_name }}"
-      source: "{{ image_path }}{{ image_name }}"
-      state: present
-    register: uploadResult
-    loop: "{{ image_url }}" 
-    ignore_errors: false
-    throttle: 1 
-#TODO - could use a handler to force update virtual disk attached to template only if there is a new download or upload?
+    - name: Upload Virtual Disk to HyperCore {{ url2template_image_filename }}"
+      scale_computing.hypercore.virtual_disk:
+        name: "{{ url2template_image_filename }}"
+        source: /tmp/{{ url2template_image_filename }}
+        state: present
 
-  - name: Get info about template VM {{ image_name }}
-    scale_computing.hypercore.vm_info:
-      vm_name: "{{ image_name }}"
-    register: vm_info_result
+  # TODO - could use a handler to force update virtual disk attached to template only if there is a new download or upload?
+  # ANS - no way to know if downloaded image is different from existing image on HyperCore;
+  # for this HC3 would need to return file content hash.
 
-  - name: Create "{{ image_name }}" template vm if it does not already exist 
-    scale_computing.hypercore.vm:
-      vm_name: "{{ image_name }}"
-      description: "{{ image_url[0] }} template "
-      state: present
-      tags:
-        - template
-        - serial
-      memory: "{{ '1 GB' | human_to_bytes }}"
-      vcpu: 0 # makes template vm unbootable - must change cpu on cloned vm 
-      power_state: stop
-      disks:
-        - type: ide_cdrom
-          disk_slot: 0
-        # - type: virtio
-        #   disk_slot: 0
-      nics:
-        - vlan: 0
-          type: virtio
-      operating_system:  os_other
-      machine_type: "BIOS"    
-    when:  vm_info_result.records | length == 0   #only create VM if it doesn't already exist - else would delete existing template disk
-    register: template
-    throttle: 1 
+    - name: Compute template VM disks - BIOS type
+      when: url2template_machine_type in ["BIOS"]
+      ansible.builtin.set_fact:
+        url2template_vm_disks: []
+    - name: Compute template VM disks - UEFI types
+      when: url2template_machine_type not in ["BIOS"]
+      ansible.builtin.set_fact:
+        url2template_vm_disks:
+          - type: nvram
+            disk_slot: -1
+            # size: 540672
 
-  - name: Attach uploaded virtual disk to  "{{ image_name }}" template  # this will attach latest image every time - should there be way to only attach if not exist?
-    scale_computing.hypercore.virtual_disk_attach:
-      name: "{{ image_name }}"
-      vm_name: "{{ image_name }}"
-      disk:
-        type: virtio_disk
-        disk_slot: 1
-        disable_snapshotting: false
-    register: diskattached
-    throttle: 1 
+    - name: Create template VM "{{ url2template_vm_name }}"
+      scale_computing.hypercore.vm:
+        vm_name: "{{ url2template_vm_name }}"
+        description: "{{ url2template_vm_name }} template, source URL {{ url2template_image_url }}"
+        state: present
+        # TODO params
+        tags:
+          - template
+          - serial
+        memory: "{{ '1 GB' | human_to_bytes }}"
+        vcpu: 0  # makes template vm unbootable - must change cpu on cloned vm
+        power_state: stop
+        disks: "{{ url2template_vm_disks }}"
+        nics:
+          - vlan: 0
+            type: virtio
+        operating_system: "{{ url2template_operating_system }}"
+        machine_type: "{{ url2template_machine_type }}"
 
-  - name: Set attached vsd device as bootable
-    scale_computing.hypercore.vm_boot_devices:
-      vm_name: "{{ image_name }}"
-      items:
-        - type: virtio_disk
-          disk_slot: 1
-      state: present
-    register: bootable
-    throttle: 1 
-
-  - name: Disk desired configuration for "{{ image_name }}"   # seems resizing disk before first boot causes panic on debian11 bulseye unless serial port exists - add SERIAL to tag or description
-    scale_computing.hypercore.vm_disk:
-      vm_name: "{{ image_name }}"
-      items:
-        - disk_slot: 1
+    - name: Attach uploaded virtual disk to template VM - {{ ' '.join([url2template_image_filename, url2template_vm_name]) }}
+      scale_computing.hypercore.virtual_disk_attach:
+        name: "{{ url2template_image_filename }}"
+        vm_name: "{{ url2template_vm_name }}"
+        disk:
+          # TODO param
           type: virtio_disk
-          size: "{{ '50 GB' | human_to_bytes }}" # 50GB | human to bytes results in 53.7GB VSD in Hypercore
-      state: present
-    throttle: 1 
+          disk_slot: 1
+
+    - name: Set attached disk device as bootable
+      scale_computing.hypercore.vm_boot_devices:
+        vm_name: "{{ url2template_vm_name }}"
+        items:
+          - type: virtio_disk
+            disk_slot: 1
+        state: present

--- a/roles/url2template/tasks/main.yml
+++ b/roles/url2template/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+# tasks file for url2template role - takes image_url and turns it into a VM template of the same name
+# returns that name as image_name
+  - name: Set image name as ansible fact (for single image)
+    ansible.builtin.set_fact:
+      image_name: "{{ item | split('/') | last }}"
+    loop: "{{ image_url }}"
+
+  - name: Download Virtual Disk(s) image from URL list
+    ansible.builtin.get_url:
+      url: "{{ item }}"
+      dest: "{{ image_path }}{{ image_name}}"
+      timeout: 10000
+      validate_certs: false
+      force: false
+    register: download
+    loop: "{{ image_url }}"
+    throttle: 1 
+
+  - name: Delete existing uploading-"{{ image_name }}" virtual disk # recovers from any previous failed upload 
+    scale_computing.hypercore.virtual_disk:
+      name: "uploading-{{ image_name }}"
+      state: absent
+    register: deleted
+    loop: "{{ image_url }}"      
+
+  - name: Upload Virtual Disk {{ item | split('/') | last }}" to HyperCore "{{ inventory_hostname }}"
+    scale_computing.hypercore.virtual_disk:
+      name: "{{ image_name }}"
+      source: "{{ image_path }}{{ image_name }}"
+      state: present
+    register: uploadResult
+    loop: "{{ image_url }}" 
+    ignore_errors: false
+    throttle: 1 
+#TODO - could use a handler to force update virtual disk attached to template only if there is a new download or upload?
+
+  - name: Get info about template VM {{ image_name }}
+    scale_computing.hypercore.vm_info:
+      vm_name: "{{ image_name }}"
+    register: vm_info_result
+
+  - name: Create "{{ image_name }}" template vm if it does not already exist 
+    scale_computing.hypercore.vm:
+      vm_name: "{{ image_name }}"
+      description: "{{ image_url[0] }} template "
+      state: present
+      tags:
+        - template
+        - serial
+      memory: "{{ '1 GB' | human_to_bytes }}"
+      vcpu: 0 # makes template vm unbootable - must change cpu on cloned vm 
+      power_state: stop
+      disks:
+        - type: ide_cdrom
+          disk_slot: 0
+        # - type: virtio
+        #   disk_slot: 0
+      nics:
+        - vlan: 0
+          type: virtio
+      operating_system:  os_other
+      machine_type: "BIOS"    
+    when:  vm_info_result.records | length == 0   #only create VM if it doesn't already exist - else would delete existing template disk
+    register: template
+    throttle: 1 
+
+  - name: Attach uploaded virtual disk to  "{{ image_name }}" template  # this will attach latest image every time - should there be way to only attach if not exist?
+    scale_computing.hypercore.virtual_disk_attach:
+      name: "{{ image_name }}"
+      vm_name: "{{ image_name }}"
+      disk:
+        type: virtio_disk
+        disk_slot: 1
+        disable_snapshotting: false
+    register: diskattached
+    throttle: 1 
+
+  - name: Set attached vsd device as bootable
+    scale_computing.hypercore.vm_boot_devices:
+      vm_name: "{{ image_name }}"
+      items:
+        - type: virtio_disk
+          disk_slot: 1
+      state: present
+    register: bootable
+    throttle: 1 
+
+  - name: Disk desired configuration for "{{ image_name }}"   # seems resizing disk before first boot causes panic on debian11 bulseye unless serial port exists - add SERIAL to tag or description
+    scale_computing.hypercore.vm_disk:
+      vm_name: "{{ image_name }}"
+      items:
+        - disk_slot: 1
+          type: virtio_disk
+          size: "{{ '50 GB' | human_to_bytes }}" # 50GB | human to bytes results in 53.7GB VSD in Hypercore
+      state: present
+    throttle: 1 


### PR DESCRIPTION
2 new roles are added.

url2template creates template VM from disk image URL.
Example URL is https://cloud-images.ubuntu.com/releases/22.04/release-20240416/ubuntu-22.04-server-cloudimg-amd64.img. 

Next template2url can be used to create new VMs from template VMs. Here we typically need to configure VM with cloud-init.
Cloud-init configuration data depends on the used image. A working example for above Ubuntu image is included.