### PR TITLE
Ci refactor

### DIFF
--- a/.github/job_retry_needed.py
+++ b/.github/job_retry_needed.py
@@ -90,6 +90,19 @@ def main():
             job["id"], job["status"], job["conclusion"], job["name"]
         )
 
+    # Double check input job name is one of actual job names
+    # Naming convention changed at some time:
+    #   new: 'integ-seq-run (https://10.5.11.201) / ansible-test (utils_login)'
+    #   old: 'integ-seq-run (https://10.5.11.201), ansible-test (utils_login)'
+    all_job_names = [
+        job["name"]
+        for job in previous_jobs
+    ]
+    if job_name not in all_job_names:
+        logger.exception("ERROR, job_name='%s' is unknown, job will be re-run", job_name)
+        # exit with 0, this will re-run the job.
+        return
+
     # Decide which jobs should NOT be re-run.
     # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
     # conclusion == success, failure, cancelled, or skipped.

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -50,14 +50,14 @@ on:
         type: string
         description: |-
           List examples to exclude from testing.
-        default: ""
+        default: "^version_update_single_node.yml$|^vm_os_upgrade$|^vm_snapshot_attach_disk.yml$|^url2template$"
 env:
   INTEG_TESTS_INCLUDE_SCHEDULE: "*"
   INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$|^vm_replication$|^vm_replication_info$|^vm_clone__replicated$|^support_tunnel$"
   INTEG_SEQ_TESTS_INCLUDE_SCHEDULE: "^dns_config$|^oidc_config$|^smtp$|^role_cluster_config$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$"
   INTEG_SEQ_TESTS_EXCLUDE_SCHEDULE: ""
   EXAMPLES_TESTS_INCLUDE_SCHEDULE: "*"
-  EXAMPLES_TESTS_EXCLUDE_SCHEDULE: ""
+  EXAMPLES_TESTS_EXCLUDE_SCHEDULE: "^version_update_single_node.yml$|^vm_os_upgrade$|^vm_snapshot_attach_disk.yml$|^url2template$"
   # ansible-test needs special directory structure.
   # WORKDIR is a subdir of GITHUB_WORKSPACE
   WORKDIR: work-dir/ansible_collections/scale_computing/hypercore

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -304,6 +304,23 @@ jobs:
       test_names: ${{ needs.integ-seq-matrix.outputs.matrix }}
       outer_job_name: integ-seq-run
 
+  # On physical HyperCore
+  integ-physical:
+    strategy:
+      fail-fast: false
+    secrets: inherit
+    uses: ./.github/workflows/z_ansible-test.yml
+    with:
+      sc_host: https://10.5.11.50
+      test_names: >-
+        [
+          "vm_replication",
+          'vm_replication_info",
+          "vm_clone__replicated",
+          "support_tunnel"
+        ]
+      outer_job_name: integ-physical
+
   replica_cleanup:
     needs: []
     runs-on: [self-hosted2]

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -18,13 +18,14 @@ on:
       # smtp - email_alert test requires a configured SMTP
       # role_cluster_config - role cluster_config reconfigures DNS, SMTP, OIDC. And it is slow.
       # version_update_single_node - role would change version, VSNS system cannot be updated.
+      # vm_replication vm_clone__replicated - VSNS were not configured with replication
       integ_tests_exclude:
         type: string
         description: |-
           List integration tests to exclude.
           Use "*" to exclude all tests.
           Use regex like 'node|^git_issue|^dns_config$' to exclude only a subset.
-        default: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$"
+        default: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$|^vm_replication$|^vm_replication_info$|^vm_clone__replicated$|^support_tunnel$"
       integ_seq_tests_include:
         type: string
         description: |-
@@ -52,7 +53,7 @@ on:
         default: ""
 env:
   INTEG_TESTS_INCLUDE_SCHEDULE: "*"
-  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$"
+  INTEG_TESTS_EXCLUDE_SCHEDULE: "^dns_config$|^cluster_shutdown$|^version_update$|^oidc_config$|^smtp$|^role_cluster_config$|^role_version_update_single_node$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$|^vm_replication$|^vm_replication_info$|^vm_clone__replicated$|^support_tunnel$"
   INTEG_SEQ_TESTS_INCLUDE_SCHEDULE: "^dns_config$|^oidc_config$|^smtp$|^role_cluster_config$|^version_update__shutdown_restart_vms$|^utils_login$|^certificate$"
   INTEG_SEQ_TESTS_EXCLUDE_SCHEDULE: ""
   EXAMPLES_TESTS_INCLUDE_SCHEDULE: "*"
@@ -267,96 +268,21 @@ jobs:
   integ-run:
     needs:
       - integ-matrix
-    runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:9
-    env:
-      DEBIAN_FRONTEND: noninteractive
-    defaults:
-      run:
-        working-directory: ${{ env.WORKDIR }}
+    if: "(!cancelled()) && (needs.integ-matrix.result=='success')"
     strategy:
       fail-fast: false
       matrix:
-        # ansible: [2.16.0]
-        # python: [3.11]
-        # test_name: [user_info]
-        test_name: ${{ fromJson(needs.integ-matrix.outputs.matrix) }}
         sc_host:
           - https://10.5.11.200
           - https://10.5.11.201
           - https://10.5.11.203
           - https://10.5.11.204
-        include:
-          - sc_host: https://10.5.11.50
-            test_name: vm_replication
-          - sc_host: https://10.5.11.50
-            test_name: vm_replication_info
-          - sc_host: https://10.5.11.50
-            test_name: support_tunnel
-          - sc_host: https://10.5.11.50
-            test_name: vm_clone__replicated
-        exclude:
-          # The VSNS were not configured with remote replication cluster.
-          - sc_host: https://10.5.11.200
-            test_name: vm_replication
-          - sc_host: https://10.5.11.201
-            test_name: vm_replication
-          - sc_host: https://10.5.11.203
-            test_name: vm_replication
-          - sc_host: https://10.5.11.204
-            test_name: vm_replication
-          - sc_host: https://10.5.11.200
-            test_name: vm_clone__replicated
-          - sc_host: https://10.5.11.201
-            test_name: vm_clone__replicated
-          - sc_host: https://10.5.11.203
-            test_name: vm_clone__replicated
-          - sc_host: https://10.5.11.204
-            test_name: vm_clone__replicated
-          # Seem as VSNS nodes cannot open remote tunnel.
-          # Code/port that worked (was opened, then closed) on real HyperCode
-          # did not work with VSNS.
-          - sc_host: https://10.5.11.200
-            test_name: support_tunnel
-          - sc_host: https://10.5.11.201
-            test_name: support_tunnel
-          - sc_host: https://10.5.11.203
-            test_name: support_tunnel
-          - sc_host: https://10.5.11.204
-            test_name: support_tunnel
-          # Virtual disk:
-          # - not supported on 9.1 https://10.5.11.200
-          # - experimantal on 9.2 https://10.5.11.201, some images (compressed?) do not work
-          - sc_host: https://10.5.11.200
-            test_name: role_url2template
-          - sc_host: https://10.5.11.201
-            test_name: role_url2template
-          - sc_host: https://10.5.11.200
-            test_name: role_template2vm
-          - sc_host: https://10.5.11.201
-            test_name: role_template2vm
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.WORKDIR }}
-      - run: pip install ansible-core~=2.16.0
-      # We have ansible.cfg "for testing" in git repo
-      # (it is excluded in galaxy.yml, so it is not part of collection artifact)
-      # But it does affect ansible-galaxy and ansible-test commands.
-      - run: ansible-galaxy collection install community.crypto
-      - run: ansible-galaxy collection list
-      # ${{ env.WORKDIR }} cannot be used
-      - uses: ./work-dir/ansible_collections/scale_computing/hypercore/.github/actions/make-integ-config
-        with:
-          sc_host: ${{ matrix.sc_host }}
-          sc_password_50: ${{ secrets.CI_CONFIG_HC_IP50_SC_PASSWORD }}
-          smb_password: ${{ secrets.CI_CONFIG_HC_IP50_SMB_PASSWORD }}
-          oidc_client_secret: ${{ secrets.OIDC_CLIENT_SECRET }}
-          oidc_users_0_password: ${{ secrets.OIDC_USERS_0_PASSWORD }}
-          working_directory: ${{ env.WORKDIR }}
-      - run: ansible-test integration --local ${{ matrix.test_name }}
+    secrets: inherit
+    uses: ./.github/workflows/z_ansible-test.yml
+    with:
+      sc_host: ${{ matrix.sc_host }}
+      test_names: ${{ needs.integ-matrix.outputs.matrix }}
+      outer_job_name: integ-run
 
   integ-seq-run:
     needs:
@@ -376,6 +302,7 @@ jobs:
     with:
       sc_host: ${{ matrix.sc_host }}
       test_names: ${{ needs.integ-seq-matrix.outputs.matrix }}
+      outer_job_name: integ-seq-run
 
   replica_cleanup:
     needs: []

--- a/.github/workflows/z_ansible-test.yml
+++ b/.github/workflows/z_ansible-test.yml
@@ -15,6 +15,10 @@ on:
         type: string
         required: true
         description: List of tests to run. JSON encoded.
+      outer_job_name:
+        type: string
+        required: true
+        description: Name of job including this workflow.
 
 jobs:
   ansible_test:
@@ -41,8 +45,10 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          X_GITHUB_JOB_NAME: "integ-seq-run (${{ inputs.sc_host }}), ansible-test (${{ matrix.test_name }})"
+          X_GITHUB_JOB_NAME: "${{ inputs.outer_job_name }} (${{ inputs.sc_host }}), ansible-test (${{ matrix.test_name }})"
         run: |
+          echo DBG X_GITHUB_JOB_NAME=$X_GITHUB_JOB_NAME
+          echo DBG inputs.outer_job_name=${{ inputs.outer_job_name }}
           if ! .github/job_retry_needed.py
           then
             echo SKIP test, job retry not needed

--- a/.github/workflows/z_ansible-test.yml
+++ b/.github/workflows/z_ansible-test.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          X_GITHUB_JOB_NAME: "${{ inputs.outer_job_name }} (${{ inputs.sc_host }}), ansible-test (${{ matrix.test_name }})"
+          X_GITHUB_JOB_NAME: "${{ inputs.outer_job_name }} (${{ inputs.sc_host }}) / ansible-test (${{ matrix.test_name }})"
         run: |
           echo DBG X_GITHUB_JOB_NAME=$X_GITHUB_JOB_NAME
           echo DBG inputs.outer_job_name=${{ inputs.outer_job_name }}

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/01_remove_disk_stopped.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/01_remove_disk_stopped.yml
@@ -40,11 +40,11 @@
     that:
       - vm_result is changed
       - vm_result.record.0.description == "VM remove disk CI test"
-      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.vm_name == vm_name_a
       - vm_result.record.0.disks | length == 2
       - vm_result.vm_rebooted == False
       - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
-      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.vm_name == vm_name_a
       - vm_info_a_initial_result.records.0.power_state == "stopped"
       - vm_info_a_initial_result.records.0.disks | length == 2
 

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/02_remove_disk_running.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/02_remove_disk_running.yml
@@ -40,11 +40,11 @@
     that:
       - vm_result is changed
       - vm_result.record.0.description == "VM remove disk CI test"
-      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.vm_name == vm_name_a
       - vm_result.record.0.disks | length == 2
       - vm_result.vm_rebooted == False
       - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
-      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.vm_name == vm_name_a
       - vm_info_a_initial_result.records.0.power_state == "started"
       - vm_info_a_initial_result.records.0.disks | length == 2
 

--- a/tests/integration/targets/vm_disk__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
+++ b/tests/integration/targets/vm_disk__remove_disk/tasks/03_remove_disk_running_with_reboot.yml
@@ -40,11 +40,11 @@
     that:
       - vm_result is changed
       - vm_result.record.0.description == "VM remove disk CI test"
-      - vm_result.record.0.vm_name == "{{ vm_name_a }}"
+      - vm_result.record.0.vm_name == vm_name_a
       - vm_result.record.0.disks | length == 2
       - vm_result.vm_rebooted == False
       - vm_info_a_initial_result.records.0.description == "VM remove disk CI test"
-      - vm_info_a_initial_result.records.0.vm_name == "{{ vm_name_a }}"
+      - vm_info_a_initial_result.records.0.vm_name == vm_name_a
       - vm_info_a_initial_result.records.0.power_state == "started"
       - vm_info_a_initial_result.records.0.disks | length == 2
 


### PR DESCRIPTION
Running more than one CI test per HyperCore cluster is a bit problematic. PR refactor `integ-test` job to same pattern as we have for `integ-seq-test` - include the helper workflow `z_ansible-test.yml`. This allows running tests on all 4 clusters in parallel, and at most 1 test pre cluster.

Some tests require physical cluster. Those are run in newly added `integ-physical` job, on https://10.5.11.50.

We test examples with simple `ansible-playbook ... example_name.yml`. This does not work for some examples, so do not test those to avoid false failures.