### PR TITLE
ci(release): publish to Ansible Automation Platform

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
       - run: ls -al docs/build/html
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs-html
           path: work-dir/ansible_collections/scale_computing/hypercore/docs/build/html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,30 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
 
-  publish-collection:
+  publish-to-galaxy:
     needs: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Publish to galaxy 🌌
+      - name: Publish to Ansible Galaxy 🌌
         uses: ansible/ansible-publish-action@v1.0.0
         with:
           api_key: ${{ secrets.GALAXY_API_KEY }}
+
+  publish-to-automation-platform:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish to Ansible Automation Platform 🌌
+        uses: ansible/ansible-publish-action@v1.0.0
+        env:
+          ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL: https://console.redhat.com/api/automation-hub/
+          ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+          ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN: ${{ secrets.AUTOMATION_HUB_API_KEY }}
+        with:
+          api_key: ${{ secrets.AUTOMATION_HUB_API_KEY }}
+          api_server: automation_hub
 
   publish-docs:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies 👽
@@ -44,7 +44,7 @@ jobs:
           echo "See also: [CHANGELOG](${CHANGELOG_URL}#${REF_NAME//./-})" >>release_notes.md
 
       - name: Release 🛸
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             *.tar.gz


### PR DESCRIPTION
Automates the steps to publish to the Ansible Automation Platform. This
requires the `AUTOMATION_PLATFORM_API_KEY` to be set in the repo
secrets.