### PR TITLE
CI stop running unit tests with ansible 2.9

### DIFF
--- a/.github/workflows/files/ansible-test-units-matrix.yml
+++ b/.github/workflows/files/ansible-test-units-matrix.yml
@@ -1,7 +1,4 @@
 # version_matrix for "ansible-test units"
-- ansible: "stable-2.9"
-  python: "3.8"
-
 - ansible: "stable-2.10"
   python: "3.8"
 - ansible: "stable-2.10"


### PR DESCRIPTION
See
https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/9869001773/job/27251970472#step:4:707

The ansible-community/ansible-test-gh-action wants to use quay.io/ansible/default-test-container:1.10.1 image, and this image no longer works with a recent docker.