### PR TITLE
ci: fix unsafe conditional

### DIFF
--- a/tests/integration/targets/git_issue_41/tasks/issue_41_cloud_init_disks.yml
+++ b/tests/integration/targets/git_issue_41/tasks/issue_41_cloud_init_disks.yml
@@ -65,7 +65,7 @@
       - vm_created.record.0.disks.2.type == "ide_cdrom"
       - vm_created.record.0.disks.2.disk_slot == 1
       # VM with "uuid": "e640e784-606f-4b96-9de2-31970e0a13e8" has ISO with "iso_name": "cloud-init-e640e784.iso"
-      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created.record.0.disks.2.iso_name == "cloud-init-" + (vm_created.record.0.uuid | split("-") | first) + ".iso"
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
       - vm_created.record.0.disks.1.iso_name == ""
@@ -135,7 +135,7 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.2.type == "ide_cdrom"
       - vm_created_2.record.0.disks.2.disk_slot == 1
-      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created_2.record.0.disks.2.iso_name == "cloud-init-" + (vm_created_2.record.0.uuid | split("-") | first) + ".iso"
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
       - vm_created_2.record.0.disks.1.iso_name == ""
@@ -170,7 +170,7 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.2.type == "ide_cdrom"    # This stays, module logic should recognize this is cloud_init IDE from the disk name.
       - vm_created.record.0.disks.2.disk_slot == 1
-      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created.record.0.disks.2.iso_name == "cloud-init-" + (vm_created.record.0.uuid | split("-") | first) + ".iso"
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
       - vm_created.record.0.disks.1.iso_name == ""
@@ -230,7 +230,7 @@
       - vm_created.record.0.nics.1.type == "virtio"
       - vm_created.record.0.disks.2.type == "ide_cdrom"
       - vm_created.record.0.disks.2.disk_slot == 1
-      - '"{{ vm_created.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created.record.0.disks.2.iso_name == "cloud-init-" + (vm_created.record.0.uuid | split("-") | first) + ".iso"
       - vm_created.record.0.disks.1.type == "ide_cdrom"
       - vm_created.record.0.disks.1.disk_slot == 0
       - vm_created.record.0.disks.1.iso_name == ""
@@ -264,7 +264,7 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.2.type == "ide_cdrom"
       - vm_created_2.record.0.disks.2.disk_slot == 1
-      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created_2.record.0.disks.2.iso_name == "cloud-init-" + (vm_created_2.record.0.uuid | split("-") | first) + ".iso"
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
       - vm_created_2.record.0.disks.1.iso_name == ""
@@ -324,7 +324,7 @@
       - vm_created_2.record.0.nics.1.type == "virtio"
       - vm_created_2.record.0.disks.2.type == "ide_cdrom"
       - vm_created_2.record.0.disks.2.disk_slot == 1
-      - '"{{ vm_created_2.record.0.disks.2.iso_name }}" == "cloud-init-{{ (vm_created_2.record.0.uuid | split("-")) [0] }}.iso"'
+      - vm_created_2.record.0.disks.2.iso_name == "cloud-init-" + (vm_created_2.record.0.uuid | split("-") | first) + ".iso"
       - vm_created_2.record.0.disks.1.type == "ide_cdrom"
       - vm_created_2.record.0.disks.1.disk_slot == 0
       - vm_created_2.record.0.disks.1.iso_name == ""


### PR DESCRIPTION
The git_issue_41 integration test failed in #328 with

```
fatal: [testhost]: FAILED! => {"msg": "The conditional check '\"{{ vm_created.record.0.disks.2.iso_name }}\" == \"cloud-init-{{ (vm_created.record.0.uuid | split(\"-\")) [0] }}.iso\"' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."}
```

PR fixes the testing code. I checked on my PC that test failed with ansible-core 2.16 before, and passed after. 