### PR TITLE
ci: Remove jinja2 from assert, to avoid warnings

### DIFF
--- a/tests/integration/targets/inventory/tests/test_ansible_both_false.yml
+++ b/tests/integration/targets/inventory/tests/test_ansible_both_false.yml
@@ -5,62 +5,62 @@
 - name: Check vmX in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'localhost' in hostvars }}"
-      - "{{ 'ci-inventory-vm0' in hostvars }}"
-      - "{{ 'ci-inventory-vm1' in hostvars }}"
-      - "{{ 'ci-inventory-vm2' in hostvars }}"
-      - "{{ 'ci-inventory-vm3' in hostvars }}"
-      - "{{ 'ci-inventory-vm4' in hostvars }}"
-      - "{{ 'ci-inventory-vm5' in hostvars }}"
-      - "{{ 'ci-inventory-vm6' in hostvars }}"
+      - "'localhost' in hostvars"
+      - "'ci-inventory-vm0' in hostvars"
+      - "'ci-inventory-vm1' in hostvars"
+      - "'ci-inventory-vm2' in hostvars"
+      - "'ci-inventory-vm3' in hostvars"
+      - "'ci-inventory-vm4' in hostvars"
+      - "'ci-inventory-vm5' in hostvars"
+      - "'ci-inventory-vm6' in hostvars"
 
 - name: Check hosts in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm0']['ansible_host'] == 'ci-inventory-vm0' }}"
-      - "{{ hostvars['ci-inventory-vm1']['ansible_host'] == '10.0.0.1' }}"
-      - "{{ hostvars['ci-inventory-vm2']['ansible_host'] == '10.0.0.2' }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6' }}"
+      - hostvars['ci-inventory-vm0']['ansible_host'] == 'ci-inventory-vm0'
+      - hostvars['ci-inventory-vm1']['ansible_host'] == '10.0.0.1'
+      - hostvars['ci-inventory-vm2']['ansible_host'] == '10.0.0.2'
+      - hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3'
+      - hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4'
+      - hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5'
+      - hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6'
 
 - name: Check port in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm0']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm1']['ansible_port'] == 33 }}"
-      - "{{ hostvars['ci-inventory-vm2']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_port'] == 22 }}"
+      - hostvars['ci-inventory-vm0']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm1']['ansible_port'] == 33
+      - hostvars['ci-inventory-vm2']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm3']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm4']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm5']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm6']['ansible_port'] == 22
 
 - name: Check user in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm0']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm1']['ansible_user'] == 'first' }}"
-      - "{{ hostvars['ci-inventory-vm2']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_user'] == 'second' }}"
+      - hostvars['ci-inventory-vm0']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm1']['ansible_user'] == 'first'
+      - hostvars['ci-inventory-vm2']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm3']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm4']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm5']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm6']['ansible_user'] == 'second'
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'ci-inventory-vm0' in hostvars['ci-inventory-vm0']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm1' in hostvars['ci-inventory-vm1']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm2' in hostvars['ci-inventory-vm2']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1'] }}"
+      - "'ci-inventory-vm0' in hostvars['ci-inventory-vm0']['groups']['ungrouped']"
+      - "'ci-inventory-vm1' in hostvars['ci-inventory-vm1']['groups']['ungrouped']"
+      - "'ci-inventory-vm2' in hostvars['ci-inventory-vm2']['groups']['ungrouped']"
+      - "'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped']"
+      - "'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0']"
+      - "'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1']"
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'}}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt' }}"
+      - hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'
+      - hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt'

--- a/tests/integration/targets/inventory/tests/test_ansible_both_true.yml
+++ b/tests/integration/targets/inventory/tests/test_ansible_both_true.yml
@@ -5,50 +5,50 @@
 - name: Check vmX in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'localhost' in hostvars }}"
-      - "{{ 'ci-inventory-vm0' not in hostvars }}"
-      - "{{ 'ci-inventory-vm1' not in hostvars }}"
-      - "{{ 'ci-inventory-vm2' not in hostvars }}"
-      - "{{ 'ci-inventory-vm3' in hostvars }}"
-      - "{{ 'ci-inventory-vm4' in hostvars }}"
-      - "{{ 'ci-inventory-vm5' in hostvars }}"
-      - "{{ 'ci-inventory-vm6' in hostvars }}"
+      - "'localhost' in hostvars"
+      - "'ci-inventory-vm0' not in hostvars"
+      - "'ci-inventory-vm1' not in hostvars"
+      - "'ci-inventory-vm2' not in hostvars"
+      - "'ci-inventory-vm3' in hostvars"
+      - "'ci-inventory-vm4' in hostvars"
+      - "'ci-inventory-vm5' in hostvars"
+      - "'ci-inventory-vm6' in hostvars"
 
 - name: Check hosts in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6' }}"
+      - hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3'
+      - hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4'
+      - hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5'
+      - hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6'
 
 - name: Check port in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_port'] == 22 }}"
+      - hostvars['ci-inventory-vm3']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm4']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm5']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm6']['ansible_port'] == 22
 
 - name: Check user in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_user'] == 'second' }}"
+      - hostvars['ci-inventory-vm3']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm4']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm5']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm6']['ansible_user'] == 'second'
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1'] }}"
+      - "'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped']"
+      - "'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0']"
+      - "'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1']"
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'}}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt' }}"
+      - hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'
+      - hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt'

--- a/tests/integration/targets/inventory/tests/test_ansible_disable.yml
+++ b/tests/integration/targets/inventory/tests/test_ansible_disable.yml
@@ -5,54 +5,54 @@
 - name: Check vmX in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'localhost' in hostvars }}"
-      - "{{ 'ci-inventory-vm0' in hostvars }}"
-      - "{{ 'ci-inventory-vm1' not in hostvars }}"
-      - "{{ 'ci-inventory-vm2' not in hostvars }}"
-      - "{{ 'ci-inventory-vm3' in hostvars }}"
-      - "{{ 'ci-inventory-vm4' in hostvars }}"
-      - "{{ 'ci-inventory-vm5' in hostvars }}"
-      - "{{ 'ci-inventory-vm6' in hostvars }}"
+      - "'localhost' in hostvars"
+      - "'ci-inventory-vm0' in hostvars"
+      - "'ci-inventory-vm1' not in hostvars"
+      - "'ci-inventory-vm2' not in hostvars"
+      - "'ci-inventory-vm3' in hostvars"
+      - "'ci-inventory-vm4' in hostvars"
+      - "'ci-inventory-vm5' in hostvars"
+      - "'ci-inventory-vm6' in hostvars"
 
 - name: Check hosts in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm0']['ansible_host'] == 'ci-inventory-vm0' }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6' }}"
+      - hostvars['ci-inventory-vm0']['ansible_host'] == 'ci-inventory-vm0'
+      - hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3'
+      - hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4'
+      - hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5'
+      - hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6'
 
 - name: Check port in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm0']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_port'] == 22 }}"
+      - hostvars['ci-inventory-vm0']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm3']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm4']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm5']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm6']['ansible_port'] == 22
 
 - name: Check user in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm0']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_user'] == 'second' }}"
+      - hostvars['ci-inventory-vm0']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm3']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm4']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm5']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm6']['ansible_user'] == 'second'
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'ci-inventory-vm0' in hostvars['ci-inventory-vm0']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1'] }}"
+      - "'ci-inventory-vm0' in hostvars['ci-inventory-vm0']['groups']['ungrouped']"
+      - "'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped']"
+      - "'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0']"
+      - "'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1']"
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'}}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt' }}"
+      - hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'
+      - hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt'

--- a/tests/integration/targets/inventory/tests/test_ansible_enable.yml
+++ b/tests/integration/targets/inventory/tests/test_ansible_enable.yml
@@ -5,53 +5,53 @@
 - name: Check vmX in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'ci-inventory-vm0' not in hostvars }}"
-      - "{{ 'ci-inventory-vm1' not in hostvars }}"
-      - "{{ 'ci-inventory-vm2' in hostvars }}"
-      - "{{ 'ci-inventory-vm3' in hostvars }}"
-      - "{{ 'ci-inventory-vm4' in hostvars }}"
-      - "{{ 'ci-inventory-vm5' in hostvars }}"
-      - "{{ 'ci-inventory-vm6' in hostvars }}"
+      - "'ci-inventory-vm0' not in hostvars"
+      - "'ci-inventory-vm1' not in hostvars"
+      - "'ci-inventory-vm2' in hostvars"
+      - "'ci-inventory-vm3' in hostvars"
+      - "'ci-inventory-vm4' in hostvars"
+      - "'ci-inventory-vm5' in hostvars"
+      - "'ci-inventory-vm6' in hostvars"
 
 - name: Check hosts in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm2']['ansible_host'] == '10.0.0.2' }}"
-      - "{{ hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6' }}"
+      - hostvars['ci-inventory-vm2']['ansible_host'] == '10.0.0.2'
+      - hostvars['ci-inventory-vm3']['ansible_host'] == '10.0.0.3'
+      - hostvars['ci-inventory-vm4']['ansible_host'] == '10.0.0.4'
+      - hostvars['ci-inventory-vm5']['ansible_host'] == 'ci-inventory-vm5'
+      - hostvars['ci-inventory-vm6']['ansible_host'] == 'ci-inventory-vm6'
 
 - name: Check port in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm2']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_port'] == 22 }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_port'] == 22 }}"
+      - hostvars['ci-inventory-vm3']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm2']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm4']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm5']['ansible_port'] == 22
+      - hostvars['ci-inventory-vm6']['ansible_port'] == 22
 
 - name: Check user in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm2']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm4']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_user'] == 'root' }}"
-      - "{{ hostvars['ci-inventory-vm6']['ansible_user'] == 'second' }}"
+      - hostvars['ci-inventory-vm3']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm2']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm4']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm5']['ansible_user'] == 'root'
+      - hostvars['ci-inventory-vm6']['ansible_user'] == 'second'
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ 'ci-inventory-vm2' in hostvars['ci-inventory-vm2']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped'] }}"
-      - "{{ 'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0'] }}"
-      - "{{ 'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1'] }}"
+      - "'ci-inventory-vm2' in hostvars['ci-inventory-vm2']['groups']['ungrouped']"
+      - "'ci-inventory-vm3' in hostvars['ci-inventory-vm3']['groups']['ungrouped']"
+      - "'ci-inventory-vm4' in hostvars['ci-inventory-vm4']['groups']['grp0']"
+      - "'ci-inventory-vm5' in hostvars['ci-inventory-vm5']['groups']['grp1']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp0']"
+      - "'ci-inventory-vm6' in hostvars['ci-inventory-vm6']['groups']['grp1']"
 
 - name: Check groups in inventory
   ansible.builtin.assert:
     that:
-      - "{{ hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'}}"
-      - "{{ hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt' }}"
+      - hostvars['ci-inventory-vm3']['ansible_ssh_private_key_file'] == 'that_file.txt'
+      - hostvars['ci-inventory-vm5']['ansible_ssh_private_key_file'] == 'this_file.txt'


### PR DESCRIPTION
Warnings that are fixed were like
  Warning: : conditional statements should not include jinja2 templating
  delimiters such as {{ }} or {% %}. Found: {{ 'localhost' in hostvars }}