### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
   mypy:
     name: Type checks (mypy)
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -27,7 +27,7 @@ jobs:
 
   docs:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -47,7 +47,7 @@ jobs:
 
   sanity-test:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -68,7 +68,7 @@ jobs:
 
   units-test:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -73,7 +73,7 @@ jobs:
   # to delay integ-test until integration-prepare-env finishes.
   integration-prepare-env:
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     env:
       ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
     defaults:
@@ -109,7 +109,7 @@ jobs:
 
   integ-matrix:
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -140,7 +140,7 @@ jobs:
     needs:
       - integ-matrix
     runs-on: [ubuntu-latest]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - integ-seq-matrix
     runs-on: [ ubuntu-latest ]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}
@@ -203,7 +203,7 @@ jobs:
       - integ-seq-run
     if: "(!cancelled())  && (needs.examples-matrix.result=='success')"
     runs-on: [ self-hosted2 ]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     env:
       ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
       DEBIAN_FRONTEND: noninteractive
@@ -322,7 +322,7 @@ jobs:
   replica_cleanup:
     needs: []
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     env:
       ANSIBLE_COLLECTIONS_PATH: $GITHUB_WORKSPACE/work-dir
     defaults:
@@ -349,7 +349,7 @@ jobs:
   smb_cleanup:
     needs: []
     runs-on: [self-hosted2]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     defaults:
       run:
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/z_ansible-test.yml
+++ b/.github/workflows/z_ansible-test.yml
@@ -24,7 +24,7 @@ jobs:
   ansible_test:
     name: ansible-test
     runs-on: [ self-hosted2 ]
-    container: quay.io/justinc1_github/scale_ci_integ:10
+    container: quay.io/justinc1_github/scale_ci_integ:11
     env:
       DEBIAN_FRONTEND: noninteractive
     defaults:

--- a/ci-infra/docker-image/README.md
+++ b/ci-infra/docker-image/README.md
@@ -20,8 +20,16 @@ Minimal local test of the new image:
 
 ```
 # git code is at path .../ansible_collections/scale_computing/hypercore
-docker run --rm -it -w /code/ansible_collections/scale_computing/hypercore -v $PWD/../../..:/code quay.io/justinc1_github/scale_ci_integ:10-dev0 bash
+docker run --rm -it -w /code/ansible_collections/scale_computing/hypercore -v $PWD/../../..:/code quay.io/justinc1_github/scale_ci_integ:11 bash
 git config --global --add safe.directory $PWD
 ansible-test units --local --python 3.12
 ansible-test sanity --local --python 3.12
+```
+
+Check if documentation is correctly built:
+
+```
+rm -fr docs/build docs/temp-rst
+make docs
+browse docs/build/html/index.html
 ```

--- a/ci-infra/docker-image/build.sh
+++ b/ci-infra/docker-image/build.sh
@@ -11,7 +11,7 @@ set -eux
 # Where to push images
 DOCKER_REGISTRY_REPO=quay.io/justinc1_github/scale_ci_integ
 # Tag to push
-DOCKER_IMAGE_TAG=10
+DOCKER_IMAGE_TAG=11
 
 DOCKER_CACHE="${DOCKER_CACHE:-n}"
 if [ "$DOCKER_CACHE" == "n" ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-antsibull-docs >= 1.0.0, < 2.0.0
+antsibull-docs
 ansible-pygments
 sphinx
 sphinx-ansible-theme >= 0.9.0


### PR DESCRIPTION
Generate HTML documentation was wrong. All modules contained something like `extra fields not permitted (type=value_error.extra)`. Problem was we were using outdated antsibull-docs. The new docker image uses latest antsibull-docs.

HTML docs built by CI job are at https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/10793721063/artifacts/1914436268.
