### PR TITLE
CI avoid testing virtual disk with empty disk image - continued

### DIFF
--- a/tests/integration/targets/virtual_disk/tasks/02_not_supported.yml
+++ b/tests/integration/targets/virtual_disk/tasks/02_not_supported.yml
@@ -1,7 +1,12 @@
 ---
 - name: Generate virtual disk file qcow2
   ansible.builtin.shell:
-    cmd: qemu-img create -f qcow2 xlab-ci-test-VD.qcow2 10M
+    cmd: |
+      qemu-img create -f raw xlab-ci-test-VD.raw 10M
+      # HC3 has some problems with very small/empty disk images.
+      # Run mkfs to populate image.
+      mkfs.ext4 xlab-ci-test-VD.raw
+      qemu-img convert -c -O qcow2 xlab-ci-test-VD.raw xlab-ci-test-VD.qcow2
   register: generated_img
 
 - name: Create virtual disk, must fail

--- a/tests/integration/targets/virtual_disk_attach/tasks/01_supported.yml
+++ b/tests/integration/targets/virtual_disk_attach/tasks/01_supported.yml
@@ -20,7 +20,12 @@
 
 - name: Generate virtual disk file qcow2
   ansible.builtin.shell:
-    cmd: qemu-img create -f qcow2 xlab-ci-test-VD-attach.qcow2 10M
+    cmd: |
+      qemu-img create -f raw xlab-ci-test-VD-attach.raw 10M
+      # HC3 has some problems with very small/empty disk images.
+      # Run mkfs to populate image.
+      mkfs.ext4 xlab-ci-test-VD-attach.raw
+      qemu-img convert -c -O qcow2 xlab-ci-test-VD-attach.raw xlab-ci-test-VD-attach.qcow2
 
 - name: Upload xlab-ci-test-VD-attach.qcow2
   scale_computing.hypercore.virtual_disk:


### PR DESCRIPTION
Continue #348. Some test disks were missed, were still empty.

Test: https://github.com/ScaleComputing/HyperCoreAnsibleCollection/actions/runs/12832531659/attempts/1
