### PR TITLE
Logout when module finishes

### DIFF
--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -15,6 +15,7 @@ import json
 import os
 import ssl
 from io import BufferedReader
+from types import TracebackType
 from typing import Any
 from typing import Optional
 from typing import Union
@@ -139,6 +140,33 @@ class Client:
             timeout=self.timeout,
         )
         return dict(Cookie=f"sessionID={resp.json['sessionID']}")
+
+    def _logout(self) -> None:
+        if not self._auth_header:
+            return
+        headers = {
+            "Accept": "application/json",
+            "Content-type": "application/json",
+        }
+        self._request(
+            "POST",
+            f"{self.host}/rest/v1/logout",
+            # data=json.dumps({}),
+            headers=headers,
+            timeout=self.timeout,
+        )
+        self._auth_header = None
+
+    def __enter__(self) -> Client:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TracebackType | None,
+    ) -> None:
+        self._logout()
 
     def _request(
         self,

--- a/plugins/modules/api.py
+++ b/plugins/modules/api.py
@@ -333,10 +333,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record = run(module, rest_client)
-        module.exit_json(changed=changed, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record = run(module, rest_client)
+            module.exit_json(changed=changed, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -148,10 +148,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/cluster_info.py
+++ b/plugins/modules/cluster_info.py
@@ -79,10 +79,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        record = run(rest_client)
-        module.exit_json(changed=False, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            record = run(rest_client)
+            module.exit_json(changed=False, record=record)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/cluster_name.py
+++ b/plugins/modules/cluster_name.py
@@ -110,12 +110,12 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        hcversion = HyperCoreVersion(rest_client)
-        hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            hcversion = HyperCoreVersion(rest_client)
+            hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/cluster_shutdown.py
+++ b/plugins/modules/cluster_shutdown.py
@@ -75,10 +75,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        shutdown = run(module, rest_client)
-        module.exit_json(changed=True, shutdown=shutdown)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            shutdown = run(module, rest_client)
+            module.exit_json(changed=True, shutdown=shutdown)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/dns_config.py
+++ b/plugins/modules/dns_config.py
@@ -277,10 +277,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, new_state, diff = run(module, rest_client)
-        module.exit_json(changed=changed, new_state=new_state, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, new_state, diff = run(module, rest_client)
+            module.exit_json(changed=changed, new_state=new_state, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/dns_config_info.py
+++ b/plugins/modules/dns_config_info.py
@@ -100,10 +100,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        record = run(rest_client)
-        module.exit_json(changed=False, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            record = run(rest_client)
+            module.exit_json(changed=False, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/email_alert.py
+++ b/plugins/modules/email_alert.py
@@ -278,11 +278,11 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        validate_params(module)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            validate_params(module)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/email_alert_info.py
+++ b/plugins/modules/email_alert_info.py
@@ -109,10 +109,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/iso.py
+++ b/plugins/modules/iso.py
@@ -279,10 +279,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, results=[record], diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, results=[record], diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/iso_info.py
+++ b/plugins/modules/iso_info.py
@@ -123,10 +123,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/node_info.py
+++ b/plugins/modules/node_info.py
@@ -83,10 +83,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(rest_client)
+            module.exit_json(changed=False, records=records)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/oidc_config.py
+++ b/plugins/modules/oidc_config.py
@@ -179,10 +179,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/oidc_config_info.py
+++ b/plugins/modules/oidc_config_info.py
@@ -83,10 +83,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = CachedRestClient(client=client)
-        changed, record = run(module, rest_client)
-        module.exit_json(changed=changed, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = CachedRestClient(client=client)
+            changed, record = run(module, rest_client)
+            module.exit_json(changed=changed, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/registration.py
+++ b/plugins/modules/registration.py
@@ -184,10 +184,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/registration_info.py
+++ b/plugins/modules/registration_info.py
@@ -90,10 +90,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = CachedRestClient(client)
-        record = run(module, rest_client)
-        module.exit_json(changed=False, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = CachedRestClient(client)
+            record = run(module, rest_client)
+            module.exit_json(changed=False, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/remote_cluster_info.py
+++ b/plugins/modules/remote_cluster_info.py
@@ -116,10 +116,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/smtp.py
+++ b/plugins/modules/smtp.py
@@ -327,10 +327,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/smtp_info.py
+++ b/plugins/modules/smtp_info.py
@@ -129,10 +129,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        record = run(rest_client)
-        module.exit_json(changed=False, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            record = run(rest_client)
+            module.exit_json(changed=False, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/snapshot_schedule.py
+++ b/plugins/modules/snapshot_schedule.py
@@ -249,10 +249,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/snapshot_schedule_info.py
+++ b/plugins/modules/snapshot_schedule_info.py
@@ -108,10 +108,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/support_tunnel.py
+++ b/plugins/modules/support_tunnel.py
@@ -145,9 +145,9 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        changed, record, diff = run(module, client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            changed, record, diff = run(module, client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/support_tunnel_info.py
+++ b/plugins/modules/support_tunnel_info.py
@@ -66,9 +66,9 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        record = run(client)
-        module.exit_json(record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            record = run(client)
+            module.exit_json(record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/syslog_server.py
+++ b/plugins/modules/syslog_server.py
@@ -445,10 +445,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, records, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, records=records, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, records, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, records=records, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/syslog_server_info.py
+++ b/plugins/modules/syslog_server_info.py
@@ -119,10 +119,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/task_wait.py
+++ b/plugins/modules/task_wait.py
@@ -78,10 +78,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/time_server.py
+++ b/plugins/modules/time_server.py
@@ -159,10 +159,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/time_server_info.py
+++ b/plugins/modules/time_server_info.py
@@ -93,10 +93,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        record = run(rest_client)
-        module.exit_json(changed=False, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            record = run(rest_client)
+            module.exit_json(changed=False, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/time_zone.py
+++ b/plugins/modules/time_zone.py
@@ -960,10 +960,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/time_zone_info.py
+++ b/plugins/modules/time_zone_info.py
@@ -94,10 +94,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        record = run(rest_client)
-        module.exit_json(changed=False, record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            record = run(rest_client)
+            module.exit_json(changed=False, record=record)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -283,10 +283,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = CachedRestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = CachedRestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -108,10 +108,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/version_update.py
+++ b/plugins/modules/version_update.py
@@ -168,10 +168,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/version_update_info.py
+++ b/plugins/modules/version_update_info.py
@@ -193,10 +193,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records, next_version, latest_version = run(rest_client)
-        module.exit_json(changed=False, records=records, next=next_version, latest=latest_version)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records, next_version, latest_version = run(rest_client)
+            module.exit_json(changed=False, records=records, next=next_version, latest=latest_version)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/version_update_status_info.py
+++ b/plugins/modules/version_update_status_info.py
@@ -105,10 +105,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        record = run(rest_client)
-        module.exit_json(record=record)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            record = run(rest_client)
+            module.exit_json(record=record)
 
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/virtual_disk.py
+++ b/plugins/modules/virtual_disk.py
@@ -209,12 +209,12 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        hcversion = HyperCoreVersion(rest_client)
-        hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            hcversion = HyperCoreVersion(rest_client)
+            hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/virtual_disk_attach.py
+++ b/plugins/modules/virtual_disk_attach.py
@@ -269,12 +269,12 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        hcversion = HyperCoreVersion(rest_client)
-        hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            hcversion = HyperCoreVersion(rest_client)
+            hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/virtual_disk_info.py
+++ b/plugins/modules/virtual_disk_info.py
@@ -111,12 +111,12 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = CachedRestClient(client)
-        hcversion = HyperCoreVersion(rest_client)
-        hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = CachedRestClient(client)
+            hcversion = HyperCoreVersion(rest_client)
+            hcversion.check_version(module, HYPERCORE_VERSION_REQUIREMENTS)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm.py
+++ b/plugins/modules/vm.py
@@ -722,12 +722,12 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        check_params(module, rest_client)
-        compute_params(module)
-        changed, record, diff, reboot = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            check_params(module, rest_client)
+            compute_params(module)
+            changed, record, diff, reboot = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_boot_devices.py
+++ b/plugins/modules/vm_boot_devices.py
@@ -349,10 +349,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff, reboot = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff, reboot = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
     except ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_clone.py
+++ b/plugins/modules/vm_clone.py
@@ -213,10 +213,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, msg = run(module, rest_client)
-        module.exit_json(changed=changed, msg=msg)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, msg = run(module, rest_client)
+            module.exit_json(changed=changed, msg=msg)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_disk.py
+++ b/plugins/modules/vm_disk.py
@@ -437,11 +437,11 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        compute_params(module)
-        changed, record, diff, reboot = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            compute_params(module)
+            changed, record, diff, reboot = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
     except ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_export.py
+++ b/plugins/modules/vm_export.py
@@ -153,10 +153,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, msg = run(module, rest_client)
-        module.exit_json(changed=changed, msg=msg)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, msg = run(module, rest_client)
+            module.exit_json(changed=changed, msg=msg)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_import.py
+++ b/plugins/modules/vm_import.py
@@ -222,10 +222,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, msg = run(module, rest_client)
-        module.exit_json(changed=changed, msg=msg)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, msg = run(module, rest_client)
+            module.exit_json(changed=changed, msg=msg)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_info.py
+++ b/plugins/modules/vm_info.py
@@ -179,10 +179,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = CachedRestClient(client)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = CachedRestClient(client)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_nic.py
+++ b/plugins/modules/vm_nic.py
@@ -302,15 +302,15 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, records, diff, reboot = run(module, rest_client)
-        module.exit_json(
-            changed=changed,
-            records=records,
-            diff=diff,
-            vm_rebooted=reboot,
-        )
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, records, diff, reboot = run(module, rest_client)
+            module.exit_json(
+                changed=changed,
+                records=records,
+                diff=diff,
+                vm_rebooted=reboot,
+            )
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_nic_info.py
+++ b/plugins/modules/vm_nic_info.py
@@ -115,10 +115,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, records = run(module, rest_client)
-        module.exit_json(changed=changed, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, records = run(module, rest_client)
+            module.exit_json(changed=changed, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_node_affinity.py
+++ b/plugins/modules/vm_node_affinity.py
@@ -278,10 +278,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, msg, diff = run(module, rest_client)
-        module.exit_json(changed=changed, msg=msg, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, msg, diff = run(module, rest_client)
+            module.exit_json(changed=changed, msg=msg, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_params.py
+++ b/plugins/modules/vm_params.py
@@ -205,10 +205,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, reboot, diff = run(module, rest_client)
-        module.exit_json(changed=changed, vm_rebooted=reboot, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, reboot, diff = run(module, rest_client)
+            module.exit_json(changed=changed, vm_rebooted=reboot, diff=diff)
     except ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_replication.py
+++ b/plugins/modules/vm_replication.py
@@ -205,10 +205,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client=client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client=client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_replication_info.py
+++ b/plugins/modules/vm_replication_info.py
@@ -109,10 +109,10 @@ def main():
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, records = run(module, rest_client)
-        module.exit_json(changed=changed, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, records = run(module, rest_client)
+            module.exit_json(changed=changed, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_snapshot.py
+++ b/plugins/modules/vm_snapshot.py
@@ -284,10 +284,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_snapshot_attach_disk.py
+++ b/plugins/modules/vm_snapshot_attach_disk.py
@@ -269,10 +269,10 @@ def main() -> None:
         ),
     )
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        changed, record, diff, reboot = run(module, rest_client)
-        module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            changed, record, diff, reboot = run(module, rest_client)
+            module.exit_json(changed=changed, record=record, diff=diff, vm_rebooted=reboot)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/vm_snapshot_info.py
+++ b/plugins/modules/vm_snapshot_info.py
@@ -181,10 +181,10 @@ def main() -> None:
     )
 
     try:
-        client = Client.get_client(module.params["cluster_instance"])
-        rest_client = RestClient(client)
-        records = run(module, rest_client)
-        module.exit_json(changed=False, records=records)
+        with Client.get_client(module.params["cluster_instance"]) as client:
+            rest_client = RestClient(client)
+            records = run(module, rest_client)
+            module.exit_json(changed=False, records=records)
     except errors.ScaleComputingError as e:
         module.fail_json(msg=str(e))
 


### PR DESCRIPTION
Logout from HyperCore when module finishes. Otherwise HyperCore needs to auto-close oldest connections (the least recently used one), and this sometimes selects "wrong" connection. For example, while running integration tests, the browser session might get logged out. 