### PR TITLE
370 - vm_clone produces VMs that are silently fragile to multi-disk attach

### DIFF
--- a/examples/vm_os_upgrade/05_clone_from_source.yml
+++ b/examples/vm_os_upgrade/05_clone_from_source.yml
@@ -15,7 +15,12 @@
 - ansible.builtin.assert:
     that:
       - vm_cloned is changed
-      - vm_cloned.msg == "Virtual machine - {{ source_vm_name }} - cloning complete to - {{ cloned_vm_name }}."
+      - vm_cloned.msg == expected_clone_msg
+    vars:
+      expected_clone_msg: >-
+        Virtual machine - {{ source_vm_name }} - cloning complete to -
+        {{ cloned_vm_name }} and boot order was set - you can change it with
+        vm_boot_devices module..
 
 - name: Get info about VM {{ cloned_vm_name }}
   scale_computing.hypercore.vm_info:

--- a/examples/vm_os_upgrade/05_clone_from_source.yml
+++ b/examples/vm_os_upgrade/05_clone_from_source.yml
@@ -20,7 +20,7 @@
       expected_clone_msg: >-
         Virtual machine - {{ source_vm_name }} - cloning complete to -
         {{ cloned_vm_name }} and boot order was set - you can change it with
-        vm_boot_devices module..
+        vm_boot_devices module.
 
 - name: Get info about VM {{ cloned_vm_name }}
   scale_computing.hypercore.vm_info:

--- a/plugins/module_utils/vm.py
+++ b/plugins/module_utils/vm.py
@@ -218,7 +218,7 @@ class VM(PayloadMapper):
         power_state=None,
         power_action=None,
         nics=None,  # nics represents a list of type Nic
-        disks=None,  # disks represents a list of type Nic
+        disks=None,  # disks represents a list of type Disk
         # boot_devices are stored as list of nics and/or disks internally.
         boot_devices=None,
         attach_guest_tools_iso=False,
@@ -423,6 +423,27 @@ class VM(PayloadMapper):
             payload["template"]["cloudInitData"] = cloud_init
         return payload
 
+    @staticmethod
+    def clone_add_user_data_to_cloud_init(cloud_init):
+        # Task 370 - the generated cloud-init should include a runcmd
+        # to fix the grub UUID issue at first boot
+
+        user_data = cloud_init.get("user_data")
+        if not user_data:
+            return cloud_init
+
+        cloud_init["user_data"] = (
+            user_data.rstrip()
+            + """
+
+        runcmd:
+        - sed -i 's/^GRUB_DISABLE_LINUX_UUID=true/#GRUB_DISABLE_LINUX_UUID=true/' /etc/default/grub
+        - update-grub
+        """
+        )
+
+        return cloud_init
+
     @classmethod
     def create_clone_vm_payload(
         cls,
@@ -446,6 +467,7 @@ class VM(PayloadMapper):
                     hypercore_tags.append(tag)
             data["template"]["tags"] = ",".join(hypercore_tags)
         if cloud_init:
+            cloud_init = cls.clone_add_user_data_to_cloud_init(cloud_init)
             data["template"]["cloudInitData"] = cloud_init
         if preserve_mac_address:
             data["template"]["netDevs"] = [
@@ -609,6 +631,13 @@ class VM(PayloadMapper):
         for disk in self.disk_list:
             if disk.slot == slot:
                 return disk
+
+    # primary disk is the largest Virtio disk
+    def get_primary_disk(self):
+        virtio_disks = [disk for disk in self.disk_list if disk.type == "virtio_disk"]
+        if not virtio_disks:
+            return None
+        return max(virtio_disks, key=lambda disk: disk.size)
 
     def post_vm_payload(self, rest_client, ansible_dict):
         # The rest of the keys from VM_PAYLOAD_KEYS will get set properly automatically

--- a/plugins/modules/vm_clone.py
+++ b/plugins/modules/vm_clone.py
@@ -166,10 +166,29 @@ def run(module, rest_client):
     TaskTag.wait_task(rest_client, task)
     task_status = TaskTag.get_task_status(rest_client, task)
     if task_status and task_status.get("state", "") == "COMPLETE":
-        return (
-            True,
-            f"Virtual machine - {module.params['source_vm_name']} - cloning complete to - {module.params['vm_name']}.",
-        )
+        # Get cloned VM
+        virtual_machine_cloned_obj = VM.get_or_fail(query={"name": module.params["vm_name"]}, rest_client=rest_client)[
+            0
+        ]
+        # Set boot devices after cloning Issue-370 (VM starts failing as soon as another disk is attahed if boot is not specified)
+        # By default we always set the largest Virtio disk which is the "primary disk"
+        primary_disk = virtual_machine_cloned_obj.get_primary_disk()
+        boot_items = [primary_disk.to_ansible()] if primary_disk else []
+        # previous boot order after cloning is always empty
+        previous_boot_order = []
+        changed = virtual_machine_cloned_obj.set_boot_devices(boot_items, module, rest_client, previous_boot_order)
+        if changed:
+            msg = "and boot order was set - you can change it with vm_boot_devices module"
+            return (
+                True,
+                f"Virtual machine - {module.params['source_vm_name']} - cloning complete to - {module.params['vm_name']} {msg}.",
+            )
+        else:
+            msg = "and boot order was not set - you can set it with vm_boot_devices module"
+            return (
+                True,
+                f"Virtual machine - {module.params['source_vm_name']} - cloning complete to - {module.params['vm_name']} {msg}.",
+            )
     raise errors.ScaleComputingError(
         f"There was a problem during cloning of {module.params['source_vm_name']}, cloning failed."
     )

--- a/tests/integration/targets/vm_clone/tasks/01_cleanup.yml
+++ b/tests/integration/targets/vm_clone/tasks/01_cleanup.yml
@@ -17,12 +17,14 @@
       nodeUUID: ""
       cause: INTERNAL
   register: set_to_run_task
-  when: source_running_info.records
+  when:
+    - source_running_info.records is defined
+    - source_running_info.records | length > 0
 
 - name: Wait for the VM to be set to SHUTDOWN
   scale_computing.hypercore.task_wait:
     task_tag: "{{ set_to_run_task.record }}"
-  when: set_to_run_task.record | default("")
+  when: (set_to_run_task.record | default("") | string | length) > 0
 
 - name: Delete VM XLAB-vm_clone-xyz
   scale_computing.hypercore.vm:

--- a/tests/integration/targets/vm_clone/tasks/10_clone_stopped.yml
+++ b/tests/integration/targets/vm_clone/tasks/10_clone_stopped.yml
@@ -29,11 +29,12 @@
       - cloned_info.records | length == 1
       - source_info.records.0.vcpu == cloned_info.records.0.vcpu
       - source_info.records.0.tags != cloned_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_info.records.0.boot_devices | length
       - source_info.records.0.disks | length ==  cloned_info.records.0.disks | length
       - source_info.records.0.nics | length ==  cloned_info.records.0.nics | length
       - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_info.records.0.boot_devices | length != 0
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Clone XLAB-vm_clone_CI-test into XLAB-vm_clone_CI-test-clone Idempotence
@@ -57,8 +58,9 @@
       - cloned_info.records | length == 1
       - source_info.records.0.vcpu == cloned_info.records.0.vcpu
       - source_info.records.0.tags != cloned_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_info.records.0.boot_devices | length
       - source_info.records.0.disks | length ==  cloned_info.records.0.disks | length
       - source_info.records.0.nics | length ==  cloned_info.records.0.nics | length
       - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_info.records.0.boot_devices | length != 0

--- a/tests/integration/targets/vm_clone/tasks/10_clone_stopped.yml
+++ b/tests/integration/targets/vm_clone/tasks/10_clone_stopped.yml
@@ -18,7 +18,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test - cloning complete to - XLAB-vm_clone_CI-test-clone."
+      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test - cloning complete to - XLAB-vm_clone_CI-test-clone and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Retrieve XLAB-vm_clone_CI-test-clone
   scale_computing.hypercore.vm_info:

--- a/tests/integration/targets/vm_clone/tasks/11_clone_stopped_cloudinit.yml
+++ b/tests/integration/targets/vm_clone/tasks/11_clone_stopped_cloudinit.yml
@@ -25,7 +25,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test - cloning complete to - XLAB-vm_clone_CI-test-cloud_init-clone."
+      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test - cloning complete to - XLAB-vm_clone_CI-test-cloud_init-clone and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Retrieve XLAB-vm_clone_CI-test-cloud_init-clone
   scale_computing.hypercore.vm_info:

--- a/tests/integration/targets/vm_clone/tasks/11_clone_stopped_cloudinit.yml
+++ b/tests/integration/targets/vm_clone/tasks/11_clone_stopped_cloudinit.yml
@@ -36,11 +36,12 @@
       - cloned_cloud_init_info.records | length == 1
       - source_info.records.0.vcpu == cloned_cloud_init_info.records.0.vcpu
       - source_info.records.0.tags == cloned_cloud_init_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_cloud_init_info.records.0.boot_devices | length
       - source_info.records.0.disks | length != cloned_cloud_init_info.records.0.disks | length
       - source_info.records.0.nics | length == cloned_cloud_init_info.records.0.nics | length
       - source_info.records.0.nics.0.mac !=  cloned_cloud_init_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_cloud_init_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_cloud_init_info.records.0.boot_devices | length != 0
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Clone XLAB-vm_clone_CI-test into XLAB-vm_clone_CI-test-cloud_init-clone Idempotence
@@ -70,8 +71,9 @@
       - cloned_cloud_init_info.records | length == 1
       - source_info.records.0.vcpu == cloned_cloud_init_info.records.0.vcpu
       - source_info.records.0.tags == cloned_cloud_init_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_cloud_init_info.records.0.boot_devices | length
       - source_info.records.0.disks | length != cloned_cloud_init_info.records.0.disks | length
       - source_info.records.0.nics | length == cloned_cloud_init_info.records.0.nics | length
       - source_info.records.0.nics.0.mac !=  cloned_cloud_init_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_cloud_init_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_cloud_init_info.records.0.boot_devices | length != 0

--- a/tests/integration/targets/vm_clone/tasks/12_clone_running.yml
+++ b/tests/integration/targets/vm_clone/tasks/12_clone_running.yml
@@ -26,11 +26,12 @@
       - cloned_while_running_info.records | length == 1
       - demo_server_info.records.0.vcpu == cloned_while_running_info.records.0.vcpu
       - demo_server_info.records.0.tags == cloned_while_running_info.records.0.tags
-      - demo_server_info.records.0.boot_devices | length == cloned_while_running_info.records.0.boot_devices | length
       - demo_server_info.records.0.disks | length == cloned_while_running_info.records.0.disks | length
       - demo_server_info.records.0.nics | length == cloned_while_running_info.records.0.nics | length
       - demo_server_info.records.0.nics.0.mac !=  cloned_while_running_info.records.0.nics.0.mac
       - demo_server_info.records.0.node_affinity != cloned_while_running_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_while_running_info.records.0.boot_devices | length != 0
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Clone XLAB-vm_clone-CI_test-running into XLAB-vm_clone-while-running-test-clone Idempotence
@@ -52,8 +53,9 @@
       - cloned_while_running_info.records | length == 1
       - demo_server_info.records.0.vcpu == cloned_while_running_info.records.0.vcpu
       - demo_server_info.records.0.tags == cloned_while_running_info.records.0.tags
-      - demo_server_info.records.0.boot_devices | length == cloned_while_running_info.records.0.boot_devices | length
       - demo_server_info.records.0.disks | length == cloned_while_running_info.records.0.disks | length
       - demo_server_info.records.0.nics | length == cloned_while_running_info.records.0.nics | length
       - demo_server_info.records.0.nics.0.mac !=  cloned_while_running_info.records.0.nics.0.mac
       - demo_server_info.records.0.node_affinity != cloned_while_running_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_while_running_info.records.0.boot_devices | length != 0

--- a/tests/integration/targets/vm_clone/tasks/12_clone_running.yml
+++ b/tests/integration/targets/vm_clone/tasks/12_clone_running.yml
@@ -15,7 +15,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test-running - cloning complete to - XLAB-vm_clone-while-running-test-clone."
+      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test-running - cloning complete to - XLAB-vm_clone-while-running-test-clone and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Retrieve XLAB-vm_clone-while-running-test-clone
   scale_computing.hypercore.vm_info:

--- a/tests/integration/targets/vm_clone/tasks/13_clone_stopped_preserve_mac.yml
+++ b/tests/integration/targets/vm_clone/tasks/13_clone_stopped_preserve_mac.yml
@@ -30,11 +30,12 @@
       - cloned_info.records | length == 1
       - source_info.records.0.vcpu == cloned_info.records.0.vcpu
       - source_info.records.0.tags != cloned_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_info.records.0.boot_devices | length
       - source_info.records.0.disks | length ==  cloned_info.records.0.disks | length
       - source_info.records.0.nics | length ==  cloned_info.records.0.nics | length
       - source_info.records.0.nics.0.mac ==  cloned_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_info.records.0.boot_devices | length != 0
 
 # ----------------------------------Idempotence check------------------------------------------------------------------------
 - name: Clone XLAB-vm_clone_CI-test into XLAB-vm_clone_CI-test-preserve-mac-clone Idempotence
@@ -59,8 +60,9 @@
       - cloned_info.records | length == 1
       - source_info.records.0.vcpu == cloned_info.records.0.vcpu
       - source_info.records.0.tags != cloned_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_info.records.0.boot_devices | length
       - source_info.records.0.disks | length ==  cloned_info.records.0.disks | length
       - source_info.records.0.nics | length ==  cloned_info.records.0.nics | length
       - source_info.records.0.nics.0.mac ==  cloned_info.records.0.nics.0.mac
       - source_info.records.0.node_affinity == cloned_info.records.0.node_affinity
+      # Cloned VM's boot devices should be set
+      - cloned_info.records.0.boot_devices | length != 0

--- a/tests/integration/targets/vm_clone/tasks/13_clone_stopped_preserve_mac.yml
+++ b/tests/integration/targets/vm_clone/tasks/13_clone_stopped_preserve_mac.yml
@@ -19,7 +19,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test - cloning complete to - XLAB-vm_clone_CI-test-preserve-mac-clone."
+      - output.msg == "Virtual machine - XLAB-vm_clone-CI_test - cloning complete to - XLAB-vm_clone_CI-test-preserve-mac-clone and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Retrieve XLAB-vm_clone_CI-test-preserve-mac-clone
   scale_computing.hypercore.vm_info:

--- a/tests/integration/targets/vm_clone/tasks/14_clone_from_snapshot.yml
+++ b/tests/integration/targets/vm_clone/tasks/14_clone_from_snapshot.yml
@@ -126,7 +126,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone_CI-test-clone-from-snapshot-source - cloning complete to - XLAB-vm_clone_CI-test-clone-from-snapshot-clone."
+      - output.msg == "Virtual machine - XLAB-vm_clone_CI-test-clone-from-snapshot-source - cloning complete to - XLAB-vm_clone_CI-test-clone-from-snapshot-clone and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Assert that cloning was successful
   scale_computing.hypercore.vm_info:

--- a/tests/integration/targets/vm_clone/tasks/14_clone_from_snapshot.yml
+++ b/tests/integration/targets/vm_clone/tasks/14_clone_from_snapshot.yml
@@ -140,7 +140,8 @@
       - vm_clone_info.records.0.memory == 511705088
       - vm_clone_info.records.0.nics | length == 1
       - vm_clone_info.records.0.disks | length == 1
-      - vm_clone_info.records.0.boot_devices | length == 0
+      # Boot devices should be set after cloning
+      - vm_clone_info.records.0.boot_devices | length != 0
       - vm_clone_info.records.0.vcpu == 2
       - vm_clone_info.records.0.vm_name == "XLAB-vm_clone_CI-test-clone-from-snapshot-clone"
 
@@ -153,7 +154,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone_CI-test-clone-from-snapshot-source - cloning complete to - XLAB-vm_clone_CI-test-clone-from-snapshot-clone-2."
+      - output.msg == "Virtual machine - XLAB-vm_clone_CI-test-clone-from-snapshot-source - cloning complete to - XLAB-vm_clone_CI-test-clone-from-snapshot-clone-2 and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Assert that cloning was successful and clones differ
   scale_computing.hypercore.vm_info:
@@ -167,7 +168,8 @@
       - vm_clone_info.records.0.memory == 511705088
       - vm_clone_info.records.0.nics | length == 1
       - vm_clone_info.records.0.disks | length == 2
-      - vm_clone_info.records.0.boot_devices | length == 0
+      # Boot devices should be set after cloning
+      - vm_clone_info.records.0.boot_devices | length != 0
       - vm_clone_info.records.0.vcpu == 3
       - vm_clone_info.records.0.vm_name == "XLAB-vm_clone_CI-test-clone-from-snapshot-clone-2"
 
@@ -262,7 +264,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - XLAB-vm_clone_CI-test-clone-from-snapshot-source - cloning complete to - XLAB-vm_clone_CI-test-clone-from-snapshot-clone-3."
+      - output.msg == "Virtual machine - XLAB-vm_clone_CI-test-clone-from-snapshot-source - cloning complete to - XLAB-vm_clone_CI-test-clone-from-snapshot-clone-3 and boot order was set - you can change it with vm_boot_devices module."
 
 - name: Assert that cloning was successful - same label
   scale_computing.hypercore.vm_info:
@@ -276,6 +278,7 @@
       - vm_clone_info.records.0.memory == 511705088
       - vm_clone_info.records.0.nics | length == 1
       - vm_clone_info.records.0.disks | length == 3
-      - vm_clone_info.records.0.boot_devices | length == 0
+      # Boot devices should be set after cloning
+      - vm_clone_info.records.0.boot_devices | length != 0
       - vm_clone_info.records.0.vcpu == 4
       - vm_clone_info.records.0.vm_name == "XLAB-vm_clone_CI-test-clone-from-snapshot-clone-3"

--- a/tests/integration/targets/vm_clone__replicated/tasks/10_clone_stopped.yml
+++ b/tests/integration/targets/vm_clone__replicated/tasks/10_clone_stopped.yml
@@ -9,7 +9,7 @@
 - ansible.builtin.assert:
     that:
       - output is changed
-      - output.msg == "Virtual machine - {{ vm_name_src }} - cloning complete to - {{ vm_name_dest }}."
+      - output.msg == "Virtual machine - {{ vm_name_src }} - cloning complete to - {{ vm_name_dest }} and boot order was set - you can change it with vm_boot_devices module."
 
 - name: dest-cluster Retrieve {{ vm_name_dest }}
   scale_computing.hypercore.vm_info:
@@ -21,7 +21,6 @@
       - cloned_info.records | length == 1
       - source_info.records.0.vcpu == cloned_info.records.0.vcpu
       - source_info.records.0.tags != cloned_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_info.records.0.boot_devices | length
       - source_info.records.0.disks | length ==  cloned_info.records.0.disks | length
       - source_info.records.0.nics | length ==  cloned_info.records.0.nics | length
       - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac
@@ -51,7 +50,6 @@
       - cloned_info.records | length == 1
       - source_info.records.0.vcpu == cloned_info.records.0.vcpu
       - source_info.records.0.tags != cloned_info.records.0.tags
-      - source_info.records.0.boot_devices | length == cloned_info.records.0.boot_devices | length
       - source_info.records.0.disks | length ==  cloned_info.records.0.disks | length
       - source_info.records.0.nics | length ==  cloned_info.records.0.nics | length
       - source_info.records.0.nics.0.mac !=  cloned_info.records.0.nics.0.mac

--- a/tests/unit/plugins/modules/test_vm_clone.py
+++ b/tests/unit/plugins/modules/test_vm_clone.py
@@ -149,9 +149,22 @@ class TestRun:
                 source_snapshot_uuid=None,
             )
         )
-        rest_client.get_record.side_effect = [None, None, {}, {"state": "COMPLETE"}]
+        rest_client.get_record.side_effect = [
+            None,
+            None,
+            {},
+            {"state": "COMPLETE"},
+            None,
+            None,
+            {},
+            {"state": "COMPLETE"},
+        ]
         rest_client.create_record.return_value = {"taskTag": "1234"}
-        rest_client.list_records.side_effect = [[], [self._get_empty_vm()]]
+        rest_client.update_record.return_value = {"taskTag": "1234"}
+        rest_client.list_records.side_effect = [[], [self._get_empty_vm()], [self._get_empty_vm()]]
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
+        ).return_value = None
         mocker.patch(
             "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
         ).return_value = None
@@ -161,7 +174,9 @@ class TestRun:
         results = vm_clone.run(module, rest_client)
         assert results == (
             True,
-            "Virtual machine - XLAB-test-vm - cloning complete to - XLAB-test-vm-clone.",
+            "Virtual machine - XLAB-test-vm - cloning complete to - "
+            "XLAB-test-vm-clone and boot order was not set - you can set it "
+            "with vm_boot_devices module.",
         )
 
     def test_run_when_VM_cloned_with_tag_and_cloud_init(self, rest_client, create_module, mocker):
@@ -184,9 +199,22 @@ class TestRun:
                 source_snapshot_uuid=None,
             )
         )
-        rest_client.get_record.side_effect = [None, None, {}, {"state": "COMPLETE"}]
+        rest_client.get_record.side_effect = [
+            None,
+            None,
+            {},
+            {"state": "COMPLETE"},
+            None,
+            None,
+            {},
+            {"state": "COMPLETE"},
+        ]
         rest_client.create_record.return_value = {"taskTag": "1234"}
-        rest_client.list_records.side_effect = [[], [self._get_empty_vm()]]
+        rest_client.update_record.return_value = {"taskTag": "1234"}
+        rest_client.list_records.side_effect = [[], [self._get_empty_vm()], [self._get_empty_vm()]]
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
+        ).return_value = None
         mocker.patch(
             "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
         ).return_value = None
@@ -196,7 +224,9 @@ class TestRun:
         results = vm_clone.run(module, rest_client)
         assert results == (
             True,
-            "Virtual machine - XLAB-test-vm - cloning complete to - XLAB-test-vm-clone.",
+            "Virtual machine - XLAB-test-vm - cloning complete to - "
+            "XLAB-test-vm-clone and boot order was not set - you can set it "
+            "with vm_boot_devices module.",
         )
 
     def test_run_with_preserve_mac_address(self, rest_client, create_module, mocker):
@@ -219,9 +249,22 @@ class TestRun:
                 source_snapshot_uuid=None,
             )
         )
-        rest_client.get_record.side_effect = [None, None, {}, {"state": "COMPLETE"}]
+        rest_client.get_record.side_effect = [
+            None,
+            None,
+            {},
+            {"state": "COMPLETE"},
+            None,
+            None,
+            {},
+            {"state": "COMPLETE"},
+        ]
         rest_client.create_record.return_value = {"taskTag": "1234"}
-        rest_client.list_records.side_effect = [[], [self._get_empty_vm()]]
+        rest_client.update_record.return_value = {"taskTag": "1234"}
+        rest_client.list_records.side_effect = [[], [self._get_empty_vm()], [self._get_empty_vm()]]
+        mocker.patch(
+            "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
+        ).return_value = None
         mocker.patch(
             "ansible_collections.scale_computing.hypercore.plugins.module_utils.vm.SnapshotSchedule.get_snapshot_schedule"
         ).return_value = None
@@ -231,7 +274,9 @@ class TestRun:
         results = vm_clone.run(module, rest_client)
         assert results == (
             True,
-            "Virtual machine - XLAB-test-vm - cloning complete to - XLAB-test-vm-clone.",
+            "Virtual machine - XLAB-test-vm - cloning complete to - "
+            "XLAB-test-vm-clone and boot order was not set - you can set it "
+            "with vm_boot_devices module.",
         )
 
 


### PR DESCRIPTION
Boot order is now set after cloning to avoid issues when attaching additional disk to VM afterwards. 
`Cloud init's user data` default `runcmd `is also added if `cloud init` has been passed as parameter.