### PR TITLE
test(vm_disk): cover non-default tiering_priority_factor (regression coverage for #30)

### DIFF
--- a/tests/integration/targets/vm_disk/tasks/main.yml
+++ b/tests/integration/targets/vm_disk/tasks/main.yml
@@ -349,6 +349,108 @@
     - *vminfo
     - *check_vminfo_nodisk
 
+# =========================================================================================
+# Regression coverage for #30 - a NON-DEFAULT tiering_priority_factor must be applied on the
+# FIRST pass, at disk-creation time.
+#
+# Every other tiering_priority_factor assertion in this file checks the DEFAULT (4), so none of
+# them can detect the #30 behaviour: HyperCore used to ignore tieringPriorityFactor in a disk
+# CREATE request and silently force the default, which made the module non-idempotent and needed
+# a second pass to take effect (internal Scale REST issue 5143).
+#
+# That was fixed on the HyperCore side - the collection never carried a workaround - so these
+# assertions pass on 9.7.7. They exist to catch a re-regression, in either direction.
+# The VM has no disks at this point, so this creates its own and cleans up after itself.
+# =========================================================================================
+
+    - name: "#30 - create disk with a non-default tiering_priority_factor in ONE pass"
+      scale_computing.hypercore.vm_disk:
+        vm_name: vm-integration-test-disks
+        items:
+          - disk_slot: 0
+            type: virtio_disk
+            size: "{{ '1 GB' | human_to_bytes }}"
+            tiering_priority_factor: 8
+        state: present
+      register: tiering_first_pass
+    - name: "#30 - non-default tiering must be set on the first pass, not the second"
+      ansible.builtin.assert:
+        that:
+          - tiering_first_pass is succeeded
+          - tiering_first_pass is changed
+          - tiering_first_pass.record.0.tiering_priority_factor == 8
+        fail_msg: >-
+          tiering_priority_factor was not applied when the disk was created.
+          Wanted 8, got {{ tiering_first_pass.record.0.tiering_priority_factor | default('unset') }}.
+          This is a regression of #30 - HyperCore ignoring tieringPriorityFactor on disk create.
+
+    - name: "#30 - confirm via vm_info that it persisted"
+      scale_computing.hypercore.vm_info:
+        vm_name: vm-integration-test-disks
+      register: tiering_vminfo
+    - ansible.builtin.assert:
+        that:
+          - tiering_vminfo.records.0.disks.0.tiering_priority_factor == 8
+
+    - name: "#30 - repeating the same task must be idempotent"
+      scale_computing.hypercore.vm_disk:
+        vm_name: vm-integration-test-disks
+        items:
+          - disk_slot: 0
+            type: virtio_disk
+            size: "{{ '1 GB' | human_to_bytes }}"
+            tiering_priority_factor: 8
+        state: present
+      register: tiering_second_pass
+    - ansible.builtin.assert:
+        that:
+          - tiering_second_pass is succeeded
+          - tiering_second_pass is not changed
+        fail_msg: >-
+          Second pass reported changed={{ tiering_second_pass.changed }}. If the first pass had
+          applied tiering correctly this should be a no-op - a changed=true here is the original
+          #30 symptom.
+
+    - name: "#30 - changing tiering_priority_factor on an EXISTING disk"
+      scale_computing.hypercore.vm_disk:
+        vm_name: vm-integration-test-disks
+        items:
+          - disk_slot: 0
+            type: virtio_disk
+            size: "{{ '1 GB' | human_to_bytes }}"
+            tiering_priority_factor: 3
+        state: present
+      register: tiering_change
+    - ansible.builtin.assert:
+        that:
+          - tiering_change is changed
+
+    # NOTE (observed on 9.7.7.226383): unlike the create path above, changing tiering on an
+    # EXISTING disk is NOT reflected in a GET straight away. The module returns changed=true but
+    # its own `record` still carries the OLD factor, and vm_info agrees, for a few seconds.
+    # It settles to the requested value well within 60s. So this is a read-after-write
+    # propagation lag on the change path, distinct from #30 (which was create ignoring the value
+    # outright and forcing the default). Hence the retry here rather than a bare assert - a bare
+    # assert immediately after the change WILL fail intermittently.
+    - name: "#30 - the changed value must land (allowing for read-after-write lag)"
+      scale_computing.hypercore.vm_info:
+        vm_name: vm-integration-test-disks
+      register: tiering_vminfo_changed
+      retries: 12
+      delay: 5
+      until: tiering_vminfo_changed.records.0.disks.0.tiering_priority_factor == 3
+    - ansible.builtin.assert:
+        that:
+          - tiering_vminfo_changed.records.0.disks.0.tiering_priority_factor == 3
+
+    - name: "#30 - clean up the tiering test disk"
+      scale_computing.hypercore.vm_disk:
+        vm_name: vm-integration-test-disks
+        items: [ ]
+        state: set
+        force: True
+# =========================================================================================
+
     - name: Delete the VM on which the tests were performed
       scale_computing.hypercore.vm: *vm-delete
       register: result


### PR DESCRIPTION
Adds integration coverage for a **non-default** `tiering_priority_factor`, closing the gap that let #30 go undetected for ~4 years.

## Why

Every pre-existing `tiering_priority_factor` assertion in `tests/integration/targets/vm_disk/tasks/main.yml` checks the **default** value — `== 4`, in all 8 places it appears — and nothing in the target ever *sets* a non-default value.

That means the suite could not observe #30 in either direction. The bug ("HyperCore ignores `tieringPriorityFactor` on disk create and forces the default, so it takes two passes") existed, sat for years, was fixed upstream, and `vm_disk` reported **pass** throughout.

#30 has now been verified fixed on HyperCore 9.7.7.226383 and closed. This adds the coverage so a re-regression is caught.

## What it covers

1. A non-default factor supplied at **disk-creation** time lands on the **first** pass — the exact #30 symptom.
2. It persists (confirmed via `vm_info`).
3. Repeating the identical task is **idempotent** (`changed=false`) — the original bug made it non-idempotent.
4. Changing the factor on an **existing** disk takes effect.

The VM has no disks at the point this runs, so the block creates its own disk and force-removes it afterwards — no new VM, and no interference with the existing assertions.

## One implementation note worth reviewing

The assertion in (4) uses `retries`/`until` rather than a bare assert. On 9.7.7, changing tiering on an *existing* disk is accepted but **not visible to a GET for a few seconds** — the module returns `changed=true` while its own returned `record`, and `vm_info`, still carry the old factor. It settles well within 60s.

This is not a missing wait in the collection: `ManageVMDisks._update_block_device` already calls `TaskTag.wait_task` (`plugins/module_utils/vm.py:1286`), and HyperCore reports the task COMPLETE before the new value is readable — so it looks like eventual consistency on the HyperCore side.

A bare assert immediately after the change **fails intermittently**; that is what the retry is there for, and there is a comment in the test explaining it. Flagging it explicitly in case you would rather track that lag separately.

## Verification

Ran against HyperCore **9.7.7.226383** (4-node cluster), ansible-core 2.16.19:

```
ansible-test integration --local vm_disk
testhost : ok=70  changed=15  unreachable=0  failed=0  skipped=0  rescued=0  ignored=0
```

Passes, no failures. Runtime goes from ~108s to ~149s (+41s), most of which is the settle poll in (4).

## Notes

- Test-only change; no `changelogs/fragments/` entry added, since no existing fragment covers a test-only change and this has no user-facing effect. Happy to add one if you would prefer.
- Integration tests do not run on pull requests (`integ-test.yml` is `schedule` + `workflow_dispatch` only), so this will not be exercised by PR CI — it was verified locally as above, and will be picked up by the nightly run once merged.
